### PR TITLE
feat(ui): added Health Status Badge in Navbar

### DIFF
--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -1,22 +1,23 @@
-import { Geist, Geist_Mono } from "next/font/google";
-import type { Metadata } from "next";
-import "./globals.css";
-import { QueryProvider } from "@/lib/query-provider";
-import { Navbar } from "@/components/Navbar";
+import { Geist, Geist_Mono } from 'next/font/google';
+import type { Metadata } from 'next';
+import './globals.css';
+import { QueryProvider } from '@/lib/query-provider';
+import { Navbar } from '@/components/Navbar';
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  subsets: ['latin'],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: '--font-geist-mono',
+  subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
-  title: "Soter - Transparent Aid, Directly Delivered",
-  description: "Open-source, privacy-first platform on Stellar blockchain empowering direct humanitarian aid distribution with AI verification and immutable transparency.",
+  title: 'Soter - Transparent Aid, Directly Delivered',
+  description:
+    'Open-source, privacy-first platform on Stellar blockchain empowering direct humanitarian aid distribution with AI verification and immutable transparency.',
 };
 
 export default function RootLayout({
@@ -29,8 +30,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
       >
-        <Navbar />
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          <Navbar />
+          {children}
+        </QueryProvider>
       </body>
     </html>
   );

--- a/app/frontend/src/components/HealthBadge.tsx
+++ b/app/frontend/src/components/HealthBadge.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { useHealthStatus } from '@/hooks/useHealthStatus';
+import type { HealthState } from '@/types/health';
+
+/* ─── Colours & labels ──────────────────────────────────────────────────── */
+
+interface StateConfig {
+  color: string;
+  label: string;
+  bars: number;
+}
+
+const STATE_CONFIG: Record<HealthState, StateConfig> = {
+  ok: {
+    color: 'text-green-400',
+    label: 'Healthy',
+    bars: 4,
+  },
+  degraded: {
+    color: 'text-yellow-400',
+    label: 'Degraded',
+    bars: 2,
+  },
+  down: {
+    color: 'text-red-500',
+    label: 'Down',
+    bars: 1,
+  },
+  loading: {
+    color: 'text-gray-500 animate-pulse',
+    label: 'Checking…',
+    bars: 4,
+  },
+};
+
+/* ─── Popover detail row ────────────────────────────────────────────────── */
+
+function DetailRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div className="flex justify-between gap-4 text-xs">
+      <span className="text-gray-400 shrink-0">{label}</span>
+      <span className="text-gray-200 font-mono truncate max-w-45">{value}</span>
+    </div>
+  );
+}
+
+/* ─── Main component ────────────────────────────────────────────────────── */
+
+export const HealthBadge: React.FC = () => {
+  const { state, data, error, lastChecked } = useHealthStatus();
+  const config = STATE_CONFIG[state];
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close popover when clicking outside
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const lastCheckedStr = lastChecked ? lastChecked.toLocaleTimeString() : '—';
+
+  return (
+    <div ref={containerRef} className="relative flex items-center">
+      <button
+        onClick={() => setOpen(v => !v)}
+        aria-label={`Backend status: ${config.label}`}
+        aria-expanded={open}
+        className="group relative flex items-end gap-1 p-2 rounded-md hover:bg-gray-700/50 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-600"
+        title={`Backend: ${config.label}`}
+      >
+        {[1, 2, 3, 4].map(barIndex => {
+          const heightClass =
+            barIndex === 1
+              ? 'h-1.5'
+              : barIndex === 2
+                ? 'h-2.5'
+                : barIndex === 3
+                  ? 'h-3.5'
+                  : 'h-5';
+
+          const isActive = barIndex <= config.bars;
+
+          return (
+            <div
+              key={barIndex}
+              className={`w-1.5 rounded-sm ${heightClass} ${
+                isActive ? `${config.color} bg-current` : 'bg-gray-700'
+              }`}
+            />
+          );
+        })}
+      </button>
+
+      {/* ── Detail popover ── */}
+      {open && (
+        <div
+          role="tooltip"
+          className="absolute right-0 top-full mt-2 z-50 w-64 rounded-xl border border-gray-700 bg-gray-900 shadow-2xl p-4 space-y-2.5"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className={`h-2.5 w-2.5 rounded-full bg-current ${config.color} shrink-0`}
+            />
+            <span className="font-semibold text-sm text-white">
+              Backend Health
+            </span>
+          </div>
+
+          <hr className="border-gray-700" />
+
+          {/* Details */}
+          {data ? (
+            <div className="space-y-1.5">
+              <DetailRow label="Status" value={data.status} />
+              <DetailRow label="Service" value={data.service} />
+              <DetailRow label="Version" value={data.version} />
+              <DetailRow label="Environment" value={data.environment} />
+              <DetailRow
+                label="Server time"
+                value={
+                  data.timestamp
+                    ? new Date(data.timestamp).toLocaleTimeString()
+                    : null
+                }
+              />
+            </div>
+          ) : error ? (
+            <p className="text-xs text-red-400 wrap-break-word">
+              {error.message || 'Could not reach the backend.'}
+            </p>
+          ) : (
+            <p className="text-xs text-gray-400">Fetching status…</p>
+          )}
+
+          <hr className="border-gray-700" />
+
+          <p className="text-[11px] text-gray-500">
+            Last checked: {lastCheckedStr}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app/frontend/src/components/Navbar.tsx
+++ b/app/frontend/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import React from 'react';
 import Link from 'next/link';
@@ -17,9 +17,11 @@ export const Navbar: React.FC = () => {
         <div className="flex items-center space-x-4">
           {publicKey && (
             <span className="text-sm">
-              Wallet: {publicKey.substring(0, 6)}...{publicKey.substring(publicKey.length - 6)}
+              Wallet: {publicKey.substring(0, 6)}...
+              {publicKey.substring(publicKey.length - 6)}
             </span>
           )}
+          <HealthBadge />
           <WalletConnect />
         </div>
       </div>

--- a/app/frontend/src/hooks/useHealthStatus.ts
+++ b/app/frontend/src/hooks/useHealthStatus.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type {
+  BackendHealthResponse,
+  HealthState,
+  HealthStatusResult,
+} from "@/types/health";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+/** Polling interval: 30 seconds — reasonable for a health badge */
+const POLL_INTERVAL_MS = 30_000;
+
+async function fetchHealth(): Promise<BackendHealthResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8_000); // 8 s timeout
+
+  try {
+    const response = await fetch(`${API_URL}/health`, {
+      signal: controller.signal,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Server responded with ${response.status}`);
+    }
+
+    return response.json() as Promise<BackendHealthResponse>;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function deriveState(
+  status: string | undefined,
+  isLoading: boolean,
+  isError: boolean,
+): HealthState {
+  if (isLoading) return "loading";
+  if (isError) return "down";
+  if (status === "ok") return "ok";
+  if (status) return "degraded";
+  return "down";
+}
+
+/**
+ * Hook that polls the backend /health endpoint every 30 seconds.
+ * Returns a HealthStatusResult — state, raw data, error, and last-checked time.
+ */
+export function useHealthStatus(): HealthStatusResult {
+  const { data, error, isLoading, dataUpdatedAt } = useQuery<
+    BackendHealthResponse,
+    Error
+  >({
+    queryKey: ["backend-health"],
+    queryFn: fetchHealth,
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchIntervalInBackground: true,
+    retry: 1,
+    staleTime: POLL_INTERVAL_MS,
+  });
+
+  const state = deriveState(data?.status, isLoading, !!error);
+  const lastChecked = dataUpdatedAt ? new Date(dataUpdatedAt) : null;
+
+  return {
+    state,
+    data: data ?? null,
+    error: error ?? null,
+    lastChecked,
+  };
+}

--- a/app/frontend/src/types/health.ts
+++ b/app/frontend/src/types/health.ts
@@ -1,0 +1,23 @@
+/**
+ * Shape of the backend /health response.
+ * Aligns with both the simple HealthService and the mobile HealthScreen data model.
+ */
+export interface BackendHealthResponse {
+  status: string; // 'ok' | 'error' | other
+  service?: string;
+  version?: string;
+  environment?: string;
+  timestamp?: string;
+  info?: Record<string, unknown>;
+  error?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+}
+
+export type HealthState = 'ok' | 'degraded' | 'down' | 'loading';
+
+export interface HealthStatusResult {
+  state: HealthState;
+  data: BackendHealthResponse | null;
+  error: Error | null;
+  lastChecked: Date | null;
+}


### PR DESCRIPTION
Added a live health status badge to the frontend Navbar that polls the backend health endpoint and shows a color-coded indicator (green/yellow/red) with an expandable detail popover.
. Grey Bars indicate loading 
. Red dot indicates not connected
. Orange 2-3 bars indicated a poor network
. Green 4 bars indicate connected with a good network


Close #60 