### PR TITLE
Fix Environment Configuration UX – To Show Active Backend Endpoint

### DIFF
--- a/app/mobile/.env.example
+++ b/app/mobile/.env.example
@@ -4,5 +4,11 @@
 # For iOS Simulator, use http://localhost:3000
 EXPO_PUBLIC_API_URL=http://localhost:3000
 
+# Optional: human-readable environment name shown in the Health Screen badge and footer.
+# Accepted values (examples): dev | staging | prod
+# If omitted, the app infers the label from EXPO_PUBLIC_API_URL
+# (URLs containing "staging" → staging, "prod" → prod, otherwise → dev).
+EXPO_PUBLIC_ENV_NAME=dev
+
 # Other configuration placeholders
 EXPO_PUBLIC_NETWORK=testnet

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -5,7 +5,7 @@ Mobile application for field operations and pilots, built with Expo and TypeScri
 ## Features
 
 - **Home Screen**: Overview and quick actions.
-- **Health Screen**: Real-time system status monitoring.
+- **Health Screen**: Real-time system status monitoring with environment indicator.
 - **Navigation**: Built with React Navigation.
 - **Environment Support**: Uses `EXPO_PUBLIC_*` for configuration.
 
@@ -28,6 +28,62 @@ Mobile application for field operations and pilots, built with Expo and TypeScri
    pnpm start
    ```
 
+## Environment Variables
+
+All Expo public variables are prefixed with `EXPO_PUBLIC_` and are safe to ship in any build — they contain no secrets.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `EXPO_PUBLIC_API_URL` | Yes | `http://localhost:3000` | Full URL of the backend API. Used by the Health Screen and the API service. |
+| `EXPO_PUBLIC_ENV_NAME` | No | auto-inferred | Human-readable label shown in the Health Screen badge and footer (e.g. `dev`, `staging`, `prod`). |
+| `EXPO_PUBLIC_NETWORK` | No | `testnet` | Blockchain network identifier. |
+
+### `EXPO_PUBLIC_API_URL`
+
+```bash
+# Local development (iOS Simulator)
+EXPO_PUBLIC_API_URL=http://localhost:3000
+
+# Local development (Android Emulator)
+EXPO_PUBLIC_API_URL=http://10.0.2.2:3000
+
+# Physical device – use your machine's LAN IP
+EXPO_PUBLIC_API_URL=http://192.168.1.10:3000
+
+# Staging / production
+EXPO_PUBLIC_API_URL=https://api.staging.example.com
+```
+
+### `EXPO_PUBLIC_ENV_NAME` (optional)
+
+Sets the coloured environment badge visible in the Health Screen header and footer.
+If omitted, the label is **auto-inferred** from `EXPO_PUBLIC_API_URL`:
+
+| URL contains | Inferred label | Badge colour |
+|---|---|---|
+| `prod` | `prod` | 🔴 red |
+| `staging` | `staging` | 🟠 amber |
+| anything else | `dev` | 🔵 blue |
+
+```bash
+EXPO_PUBLIC_ENV_NAME=dev      # or staging, prod, or any custom name
+```
+
+> The badge and footer text are always visible (there are no secrets) so they are safe to leave in production builds.
+
+## Health Screen
+
+The Health Screen fetches backend health from `${EXPO_PUBLIC_API_URL}/health`.  
+If the backend is unreachable it falls back to mock data.
+
+The screen always shows a small **environment badge** (top-right of the header) and a **footer row** of the form:
+
+```
+Environment: dev · localhost:3000
+```
+
+This lets testers and field users confirm the API target without navigating to any settings page.
+
 ## Scripts
 
 - `pnpm start`: Start Expo dev server with Metro bundler
@@ -37,14 +93,10 @@ Mobile application for field operations and pilots, built with Expo and TypeScri
 - `pnpm test`: Run Jest test suite
 - `pnpm lint`: Run ESLint for code quality checks
 
-## Health Screen
-
-The Health Screen fetches the backend health status from `${EXPO_PUBLIC_API_URL}/health`. 
-If the backend is unreachable, it displays mock data to ensure the UI can still be demonstrated.
-
 ## Troubleshooting
 
 - **Connection refused**: If running on a physical device, ensure `EXPO_PUBLIC_API_URL` uses your machine's local IP address.
 - **Metro not starting**: Try clearing the cache with `expo start -c`.
+- **Wrong environment shown**: Verify `.env` contains the correct `EXPO_PUBLIC_ENV_NAME` or `EXPO_PUBLIC_API_URL`, then restart Metro (`expo start -c`).
 
 For detailed development setup, testing procedures, and comprehensive troubleshooting, see [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/app/mobile/src/__tests__/HealthScreen.test.tsx
+++ b/app/mobile/src/__tests__/HealthScreen.test.tsx
@@ -48,7 +48,7 @@ describe('HealthScreen', () => {
     render(<HealthScreen />);
 
     await waitFor(() => {
-      expect(screen.getByText('🔧 MOCK DATA')).toBeTruthy();
+      expect(screen.getByText('🔧 MOCK')).toBeTruthy();
       expect(screen.getByText('📊 Using simulated data')).toBeTruthy();
       expect(screen.getByText('Backend unreachable - showing mock data')).toBeTruthy();
       expect(screen.getByText('⚠️ This is simulated data - backend connection failed')).toBeTruthy();
@@ -88,5 +88,91 @@ describe('HealthScreen', () => {
       expect(screen.getByText('🔄 Retry Connection')).toBeTruthy();
     });
   });
-});
 
+  // ── Environment indicator tests ─────────────────────────────────────────
+
+  it('shows environment badge in the header', async () => {
+    mockFetchHealthStatus.mockResolvedValueOnce({
+      status: 'ok', service: 'backend', version: '1.0.0',
+      environment: 'development', timestamp: new Date().toISOString(),
+    });
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      // The env badge element is always rendered
+      expect(screen.getByTestId('env-badge')).toBeTruthy();
+    });
+  });
+
+  it('displays EXPO_PUBLIC_ENV_NAME label when variable is set', async () => {
+    process.env.EXPO_PUBLIC_ENV_NAME = 'staging';
+    mockFetchHealthStatus.mockResolvedValueOnce({
+      status: 'ok', service: 'backend', version: '1.0.0',
+      environment: 'staging', timestamp: new Date().toISOString(),
+    });
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      // Badge shows uppercased label
+      expect(screen.getByText('STAGING')).toBeTruthy();
+      // Footer shows lowercase label
+      expect(screen.getByTestId('footer-env-name')).toBeTruthy();
+    });
+
+    delete process.env.EXPO_PUBLIC_ENV_NAME;
+  });
+
+  it('falls back to "prod" when EXPO_PUBLIC_API_URL contains "prod"', async () => {
+    delete process.env.EXPO_PUBLIC_ENV_NAME;
+    process.env.EXPO_PUBLIC_API_URL = 'https://api.prod.example.com';
+    mockFetchHealthStatus.mockResolvedValueOnce({
+      status: 'ok', service: 'backend', version: '1.0.0',
+      environment: 'production', timestamp: new Date().toISOString(),
+    });
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('PROD')).toBeTruthy();
+    });
+
+    delete process.env.EXPO_PUBLIC_API_URL;
+  });
+
+  it('defaults to "dev" label when no env variables are set', async () => {
+    delete process.env.EXPO_PUBLIC_ENV_NAME;
+    delete process.env.EXPO_PUBLIC_API_URL;
+    mockFetchHealthStatus.mockResolvedValueOnce({
+      status: 'ok', service: 'backend', version: '1.0.0',
+      environment: 'development', timestamp: new Date().toISOString(),
+    });
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('DEV')).toBeTruthy();
+    });
+  });
+
+  it('renders the footer env row with env label and api url', async () => {
+    process.env.EXPO_PUBLIC_ENV_NAME = 'dev';
+    process.env.EXPO_PUBLIC_API_URL = 'http://localhost:3000';
+    mockFetchHealthStatus.mockResolvedValueOnce({
+      status: 'ok', service: 'backend', version: '1.0.0',
+      environment: 'development', timestamp: new Date().toISOString(),
+    });
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('footer-env-row')).toBeTruthy();
+      expect(screen.getByTestId('footer-env-name')).toBeTruthy();
+      expect(screen.getByTestId('footer-api-url')).toBeTruthy();
+    });
+
+    delete process.env.EXPO_PUBLIC_ENV_NAME;
+    delete process.env.EXPO_PUBLIC_API_URL;
+  });
+});


### PR DESCRIPTION
close #68 

Added a non-intrusive environment badge and footer row to the Health Screen so testers and field users can instantly see which backend the mobile app targets.

All done — 11/11 tests pass. Here's what was delivered:

HealthScreen.tsx — Coloured env badge in the header (🔵 DEV / 🟠 STAGING / 🔴 PROD) + compact footer row showing Environment: dev · localhost:3000
HealthScreen.test.tsx — 5 new tests covering explicit env name, URL-inferred env, default fallback, badge presence, and footer row
.env.example — Documented the new EXPO_PUBLIC_ENV_NAME variable
README.md — Full environment variables section with table, examples, and auto-inference docs

**Test Screenshot**:
<img width="695" height="411" alt="test" src="https://github.com/user-attachments/assets/c6933dbf-cd74-4882-b09a-37e241c75d9f" />


close #68