### PR TITLE
chore(backend): add Prisma seed script for demo data

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -12,6 +12,7 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",
+    "prisma:seed": "prisma db seed",
     "prisma:studio": "prisma studio",
     "start": "nest start",
     "start:dev": "nest start --watch",
@@ -112,5 +113,8 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
   }
 }

--- a/app/backend/prisma/README.md
+++ b/app/backend/prisma/README.md
@@ -31,6 +31,20 @@ pnpm --filter backend prisma:generate
 pnpm --filter backend prisma:migrate
 ```
 
+3. Seed demo data for local testing:
+
+```bash
+pnpm --filter backend prisma:seed
+```
+
+This creates:
+- 3 roles (admin, ngo, user)
+- 4 development API keys for testing different app roles
+- 2 demo campaigns (Emergency Relief Fund and Community Health Program)
+- 4 demo claims (2 per campaign with different statuses)
+
+Perfect for local testing and e2e runs without manual setup.
+
 Notes for tests
 
 - The backend includes e2e tests that exercise the verification flow and verify


### PR DESCRIPTION
## Description
Implements a Prisma seed script for demo data to accelerate local testing and e2e runs.

## What's New
- **2 demo campaigns** with realistic names and budgets
  - Emergency Relief Fund ($10,000)
  - Community Health Program ($5,000)
- **4 demo claims** across campaigns with varied statuses
  - 2 verified claims ($500 each)
  - 2 approved claims ($750 each)
- **3 roles** seeded (admin, ngo, user)
- **4 development API keys** for testing different app roles

Closes #41  

## Testing
Run migrations and seed the database:
```bash
pnpm --filter backend prisma:migrate
pnpm --filter backend prisma:seed

