### PR TITLE
feat(mobile): offline caching, network indicator and auto-sync for ai…

### DIFF
--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -17,6 +17,8 @@
     "@react-navigation/native": "^7.1.8",
     "@react-navigation/native-stack": "^7.1.1",
     "@react-navigation/routers": "^7.5.3",
+    "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-community/netinfo": "^11.4.1",
     "expo": "~54.0.31",
     "expo-asset": "^12.0.12",
     "expo-constants": "~18.0.13",

--- a/app/mobile/src/components/OfflineBanner.tsx
+++ b/app/mobile/src/components/OfflineBanner.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  visible: boolean;
+  cachedAt?: string | null;
+}
+
+/**
+ * Displays a banner when the device is offline.
+ * Optionally shows when the data was last cached.
+ */
+export const OfflineBanner: React.FC<Props> = ({ visible, cachedAt }) => {
+  if (!visible) return null;
+
+  return (
+    <View style={styles.banner}>
+      <Text style={styles.icon}>📡</Text>
+      <View>
+        <Text style={styles.title}>Offline</Text>
+        {cachedAt && (
+          <Text style={styles.subtitle}>Showing cached data from {cachedAt}</Text>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FEF3C7',
+    borderBottomWidth: 1,
+    borderBottomColor: '#F59E0B',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 10,
+  },
+  icon: {
+    fontSize: 18,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#92400E',
+  },
+  subtitle: {
+    fontSize: 12,
+    color: '#B45309',
+    marginTop: 2,
+  },
+});

--- a/app/mobile/src/hooks/useNetworkStatus.ts
+++ b/app/mobile/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
+
+export interface NetworkStatus {
+  isConnected: boolean;
+  isInternetReachable: boolean | null;
+}
+
+/**
+ * Monitors network connectivity using @react-native-community/netinfo.
+ * Returns live connection state and fires `onReconnect` when connectivity is restored.
+ */
+export const useNetworkStatus = (onReconnect?: () => void): NetworkStatus => {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isConnected: true,
+    isInternetReachable: true,
+  });
+
+  useEffect(() => {
+    let wasOffline = false;
+
+    const unsubscribe = NetInfo.addEventListener((state: NetInfoState) => {
+      const connected = state.isConnected ?? false;
+      const reachable = state.isInternetReachable ?? null;
+
+      setStatus({ isConnected: connected, isInternetReachable: reachable });
+
+      // Fire sync callback when coming back online
+      if (wasOffline && connected && onReconnect) {
+        onReconnect();
+      }
+
+      wasOffline = !connected;
+    });
+
+    return () => unsubscribe();
+  }, [onReconnect]);
+
+  return status;
+};

--- a/app/mobile/src/screens/AidOverviewScreen.tsx
+++ b/app/mobile/src/screens/AidOverviewScreen.tsx
@@ -1,30 +1,242 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  RefreshControl,
+  TouchableOpacity,
+  ActivityIndicator,
+  SafeAreaView,
+} from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+import { AidItem, fetchAidList, getMockAidList } from '../services/aidApi';
+import { cacheAidList, loadCachedAidList, getCacheTimestamp } from '../services/aidCache';
+import { useNetworkStatus } from '../hooks/useNetworkStatus';
+import { OfflineBanner } from '../components/OfflineBanner';
 
-export const AidOverviewScreen = () => {
-    return (
-        <View style={styles.container}>
-            <Text style={styles.title}>Aid Overview</Text>
-            <Text style={styles.subtitle}>Coming Soon in a future wave</Text>
+type Props = NativeStackScreenProps<RootStackParamList, 'AidOverview'>;
+
+const STATUS_COLORS: Record<AidItem['status'], string> = {
+  active: '#16A34A',
+  pending: '#D97706',
+  closed: '#6B7280',
+};
+
+export const AidOverviewScreen: React.FC<Props> = ({ navigation }) => {
+  const [aidList, setAidList] = useState<AidItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [isCached, setIsCached] = useState(false);
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const loadData = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const fresh = await fetchAidList();
+      setAidList(fresh);
+      setIsCached(false);
+      await cacheAidList(fresh);
+      setCachedAt(null);
+    } catch {
+      // Network failed — try cache, then fall back to mock
+      const cached = await loadCachedAidList();
+      if (cached && cached.length > 0) {
+        setAidList(cached);
+        setIsCached(true);
+        const ts = await getCacheTimestamp();
+        setCachedAt(ts);
+      } else {
+        setAidList(getMockAidList());
+        setIsCached(true);
+        setCachedAt(null);
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  // Sync when connectivity is restored
+  const handleReconnect = useCallback(async () => {
+    if (!isCached) return;
+    setSyncing(true);
+    await loadData(false);
+    setSyncing(false);
+  }, [isCached, loadData]);
+
+  const { isConnected } = useNetworkStatus(handleReconnect);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const renderItem = ({ item }: { item: AidItem }) => (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => navigation.navigate('AidDetails', { aidId: item.id })}
+      accessibilityRole="button"
+      accessibilityLabel={`View details for ${item.title}`}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle}>{item.title}</Text>
+        <View style={[styles.badge, { backgroundColor: STATUS_COLORS[item.status] }]}>
+          <Text style={styles.badgeText}>{item.status.toUpperCase()}</Text>
         </View>
+      </View>
+      <Text style={styles.cardDescription} numberOfLines={2}>
+        {item.description}
+      </Text>
+      <Text style={styles.cardLocation}>📍 {item.location}</Text>
+    </TouchableOpacity>
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.centered}>
+        <ActivityIndicator size="large" color="#0F172A" />
+        <Text style={styles.loadingText}>Loading aid operations...</Text>
+      </SafeAreaView>
     );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <OfflineBanner visible={!isConnected} cachedAt={cachedAt} />
+
+      {syncing && (
+        <View style={styles.syncBanner}>
+          <ActivityIndicator size="small" color="#1D4ED8" />
+          <Text style={styles.syncText}>Syncing latest data...</Text>
+        </View>
+      )}
+
+      <FlatList
+        data={aidList}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => loadData(true)}
+            tintColor="#0F172A"
+          />
+        }
+        ListHeaderComponent={
+          isCached && isConnected ? (
+            <View style={styles.staleNotice}>
+              <Text style={styles.staleText}>
+                ⚠️ Showing cached data. Pull to refresh.
+              </Text>
+            </View>
+          ) : null
+        }
+        ListEmptyComponent={
+          <View style={styles.centered}>
+            <Text style={styles.emptyText}>No aid operations found.</Text>
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#F8FAFC',
-    },
-    title: {
-        fontSize: 24,
-        fontWeight: '700',
-        color: '#0F172A',
-    },
-    subtitle: {
-        fontSize: 16,
-        color: '#64748B',
-        marginTop: 8,
-    },
+  container: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#64748B',
+  },
+  list: {
+    padding: 16,
+    gap: 12,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#0F172A',
+    flex: 1,
+    marginRight: 8,
+  },
+  badge: {
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  badgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  cardDescription: {
+    fontSize: 14,
+    color: '#475569',
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+  cardLocation: {
+    fontSize: 12,
+    color: '#94A3B8',
+  },
+  syncBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#EFF6FF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#BFDBFE',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  syncText: {
+    fontSize: 13,
+    color: '#1D4ED8',
+  },
+  staleNotice: {
+    backgroundColor: '#FFF7ED',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 8,
+  },
+  staleText: {
+    fontSize: 13,
+    color: '#C2410C',
+    textAlign: 'center',
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#94A3B8',
+  },
 });

--- a/app/mobile/src/services/aidApi.ts
+++ b/app/mobile/src/services/aidApi.ts
@@ -1,0 +1,51 @@
+import { Platform } from 'react-native';
+
+const API_URL =
+  process.env.EXPO_PUBLIC_API_URL ||
+  (Platform.OS === 'android' ? 'http://10.0.2.2:3000' : 'http://localhost:3000');
+
+export interface AidItem {
+  id: string;
+  title: string;
+  description: string;
+  status: 'active' | 'pending' | 'closed';
+  location: string;
+  createdAt: string;
+}
+
+/** Fetch aid overview list from the backend */
+export const fetchAidList = async (): Promise<AidItem[]> => {
+  const response = await fetch(`${API_URL}/aid`);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.json();
+};
+
+/** Fallback mock data used when the backend is unreachable */
+export const getMockAidList = (): AidItem[] => [
+  {
+    id: '1',
+    title: 'Emergency Food Supply',
+    description: 'Distribution of emergency food packages to affected families.',
+    status: 'active',
+    location: 'Sector A, Zone 3',
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: '2',
+    title: 'Medical Aid Convoy',
+    description: 'Mobile medical units providing first aid and triage.',
+    status: 'active',
+    location: 'Northern District',
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: '3',
+    title: 'Shelter Allocation',
+    description: 'Temporary shelter setup for displaced residents.',
+    status: 'pending',
+    location: 'Central Camp',
+    createdAt: new Date().toISOString(),
+  },
+];

--- a/app/mobile/src/services/aidCache.ts
+++ b/app/mobile/src/services/aidCache.ts
@@ -1,0 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AidItem } from './aidApi';
+
+const CACHE_KEY = '@soter/aid_overview';
+const CACHE_TIMESTAMP_KEY = '@soter/aid_overview_timestamp';
+
+/** Persist aid list to AsyncStorage */
+export const cacheAidList = async (data: AidItem[]): Promise<void> => {
+  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
+};
+
+/** Load cached aid list from AsyncStorage */
+export const loadCachedAidList = async (): Promise<AidItem[] | null> => {
+  const raw = await AsyncStorage.getItem(CACHE_KEY);
+  if (!raw) return null;
+  return JSON.parse(raw) as AidItem[];
+};
+
+/** Returns the ISO timestamp of the last successful cache write, or null */
+export const getCacheTimestamp = async (): Promise<string | null> => {
+  const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
+  if (!ts) return null;
+  return new Date(parseInt(ts, 10)).toLocaleString();
+};
+
+/** Clear the cached aid list */
+export const clearAidCache = async (): Promise<void> => {
+  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
+};

--- a/app/mobile/src/types/netinfo.d.ts
+++ b/app/mobile/src/types/netinfo.d.ts
@@ -1,0 +1,34 @@
+// Type shim for @react-native-community/netinfo
+// Remove this file once the package is fully installed via:
+//   npx expo install @react-native-community/netinfo @react-native-async-storage/async-storage
+
+declare module '@react-native-community/netinfo' {
+  export interface NetInfoState {
+    type: string;
+    isConnected: boolean | null;
+    isInternetReachable: boolean | null;
+    details: unknown;
+  }
+
+  type NetInfoChangeHandler = (state: NetInfoState) => void;
+
+  interface NetInfoStatic {
+    addEventListener(listener: NetInfoChangeHandler): () => void;
+    fetch(): Promise<NetInfoState>;
+  }
+
+  const NetInfo: NetInfoStatic;
+  export default NetInfo;
+}
+
+declare module '@react-native-async-storage/async-storage' {
+  interface AsyncStorageStatic {
+    getItem(key: string): Promise<string | null>;
+    setItem(key: string, value: string): Promise<void>;
+    removeItem(key: string): Promise<void>;
+    multiRemove(keys: string[]): Promise<void>;
+  }
+
+  const AsyncStorage: AsyncStorageStatic;
+  export default AsyncStorage;
+}


### PR DESCRIPTION
overview

- Add @react-native-community/netinfo and @react-native-async-storage/async-storage to package.json
- Add useNetworkStatus hook to monitor connectivity and fire onReconnect callback
- Add aidApi service with fetchAidList() and getMockAidList() fallback
- Add aidCache service to persist/load aid list via AsyncStorage
- Add OfflineBanner component shown when device is offline with last-cached timestamp
- Rewrite AidOverviewScreen with full offline-first flow:
  - Loads from network, caches on success
  - Falls back to AsyncStorage cache, then mock data when offline
  - Shows offline banner and stale-data notice when serving cached content
  - Auto-syncs when connectivity is restored via useNetworkStatus
  - Pull-to-refresh supported
- Add src/types/netinfo.d.ts type shims (remove after full npm install completes)

Closed #186