### PR TITLE
feat: add CSV export endpoints for campaigns and claims

### DIFF
--- a/app/backend/src/campaigns/campaigns.controller.ts
+++ b/app/backend/src/campaigns/campaigns.controller.ts
@@ -33,11 +33,37 @@ import { AppRole } from 'src/auth/app-role.enum';
 import { Throttle } from '@nestjs/throttler';
 import { OrgOwnershipGuard } from '../common/guards/org-ownership.guard';
 
+import { CsvUtil } from '../common/utils/csv.util';
+import { ExportFiltersDto } from '../common/dto/export-filters.dto';
+import { Response } from 'express';
+import { Res } from '@nestjs/common';
+
 @ApiTags('Campaigns')
 @ApiBearerAuth('JWT-auth')
 @Controller('campaigns')
 export class CampaignsController {
   constructor(private readonly campaigns: CampaignsService) {}
+
+  @Get('export')
+  @Roles(AppRole.admin, AppRole.ngo)
+  @ApiOperation({ summary: 'Export campaigns to CSV' })
+  @ApiOkResponse({ description: 'CSV file containing campaign data.' })
+  async export(
+    @Query() filters: ExportFiltersDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const ngoId = req.user?.role === AppRole.ngo ? req.user.ngoId : filters.ngoId;
+    const data = await this.campaigns.exportToCsv({ ...filters, ngoId });
+    const csv = CsvUtil.generateCsv(data);
+
+    res.set({
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="campaigns-export-${Date.now()}.csv"`,
+    });
+
+    return res.send(csv);
+  }
 
   @Post()
   @Roles(AppRole.admin, AppRole.ngo)

--- a/app/backend/src/campaigns/campaigns.service.ts
+++ b/app/backend/src/campaigns/campaigns.service.ts
@@ -90,4 +90,37 @@ export class CampaignsService {
       data: { deletedAt: new Date() },
     });
   }
+
+  async exportToCsv(filters: any) {
+    const where: Prisma.CampaignWhereInput = {
+      deletedAt: null,
+      ...(filters.startDate || filters.endDate
+        ? {
+            createdAt: {
+              ...(filters.startDate ? { gte: new Date(filters.startDate) } : {}),
+              ...(filters.endDate ? { lte: new Date(filters.endDate) } : {}),
+            },
+          }
+        : {}),
+      ...(filters.status ? { status: filters.status as CampaignStatus } : {}),
+      ...(filters.ngoId ? { ngoId: filters.ngoId } : {}),
+    };
+
+    const campaigns = await this.prisma.campaign.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+    });
+
+    // Exclude sensitive fields like metadata if it might contain secrets
+    // For now, we'll export the core campaign data
+    return campaigns.map((c) => ({
+      ID: c.id,
+      Name: c.name,
+      Status: c.status,
+      Budget: c.budget,
+      Organization: c.ngoId || 'N/A',
+      CreatedAt: c.createdAt.toISOString(),
+      UpdatedAt: c.updatedAt.toISOString(),
+    }));
+  }
 }

--- a/app/backend/src/claims/claims.controller.ts
+++ b/app/backend/src/claims/claims.controller.ts
@@ -30,6 +30,10 @@ import { AppRole } from 'src/auth/app-role.enum';
 import { InternalNotesService } from 'src/common/services/internal-notes.service';
 import { CreateInternalNoteDto } from 'src/common/dto/create-internal-note.dto';
 import { InternalNoteResponseDto } from 'src/common/dto/internal-note-response.dto';
+import { CsvUtil } from '../common/utils/csv.util';
+import { ExportFiltersDto } from '../common/dto/export-filters.dto';
+import { Response } from 'express';
+import { Res, Query } from '@nestjs/common';
 
 @ApiTags('Onchain Proxy')
 @ApiBearerAuth('JWT-auth')
@@ -39,6 +43,27 @@ export class ClaimsController {
     private readonly claimsService: ClaimsService,
     private readonly internalNotesService: InternalNotesService,
   ) {}
+
+  @Get('export')
+  @Roles(AppRole.admin, AppRole.operator)
+  @ApiOperation({ summary: 'Export claims to CSV' })
+  @ApiOkResponse({ description: 'CSV file containing claim data.' })
+  async export(
+    @Query() filters: ExportFiltersDto,
+    @Request() req: ExpressRequest,
+    @Res() res: Response,
+  ) {
+    const ngoId = req.user?.role === AppRole.ngo ? req.user.ngoId : filters.ngoId;
+    const data = await this.claimsService.exportToCsv({ ...filters, ngoId });
+    const csv = CsvUtil.generateCsv(data);
+
+    res.set({
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="claims-export-${Date.now()}.csv"`,
+    });
+
+    return res.send(csv);
+  }
 
   @Post()
   @ApiOperation({

--- a/app/backend/src/claims/claims.service.ts
+++ b/app/backend/src/claims/claims.service.ts
@@ -11,7 +11,7 @@ import { createHash } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateClaimDto } from './dto/create-claim.dto';
 import { ClaimReceiptDto, SendReceiptShareDto } from './dto/claim-receipt.dto';
-import { ClaimStatus } from '@prisma/client';
+import { ClaimStatus, Prisma } from '@prisma/client';
 import {
   OnchainAdapter,
   DisburseResult,
@@ -523,5 +523,55 @@ export class ClaimsService {
     for (const phone of phoneNumbers) {
       this.logger.debug(`[SMS STUB] Would send to ${phone}: ${smsText}`);
     }
+  }
+
+  async exportToCsv(filters: any) {
+    const where: Prisma.ClaimWhereInput = {
+      deletedAt: null,
+      ...(filters.startDate || filters.endDate
+        ? {
+            createdAt: {
+              ...(filters.startDate ? { gte: new Date(filters.startDate) } : {}),
+              ...(filters.endDate ? { lte: new Date(filters.endDate) } : {}),
+            },
+          }
+        : {}),
+      ...(filters.status ? { status: filters.status as ClaimStatus } : {}),
+      ...(filters.campaignId ? { campaignId: filters.campaignId } : {}),
+      ...(filters.ngoId
+        ? {
+            campaign: {
+              ngoId: filters.ngoId,
+            },
+          }
+        : {}),
+    };
+
+    const claims = await this.prisma.claim.findMany({
+      where,
+      include: {
+        campaign: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return claims
+      .filter((claim) => {
+        // Filter by tokenAddress if provided (derived from metadata as per current implementation)
+        if (filters.tokenAddress) {
+          const tokenAddress = this.getTokenAddressForClaim(claim);
+          return tokenAddress === filters.tokenAddress;
+        }
+        return true;
+      })
+      .map((c) => ({
+        ID: c.id,
+        Campaign: c.campaign.name,
+        Amount: c.amount,
+        Status: c.status,
+        Recipient: this.encryptionService.decrypt(c.recipientRef),
+        TokenAddress: this.getTokenAddressForClaim(c),
+        CreatedAt: c.createdAt.toISOString(),
+      }));
   }
 }

--- a/app/backend/src/common/dto/export-filters.dto.ts
+++ b/app/backend/src/common/dto/export-filters.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsString, IsDateString, IsEnum } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { CampaignStatus, ClaimStatus } from '@prisma/client';
+
+export class ExportFiltersDto {
+  @ApiPropertyOptional({ description: 'Filter by start date (ISO string)' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by end date (ISO string)' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by status',
+    enum: { ...CampaignStatus, ...ClaimStatus },
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by organization ID' })
+  @IsOptional()
+  @IsString()
+  ngoId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by token address' })
+  @IsOptional()
+  @IsString()
+  tokenAddress?: string;
+}

--- a/app/backend/src/common/utils/csv.util.ts
+++ b/app/backend/src/common/utils/csv.util.ts
@@ -1,0 +1,33 @@
+export class CsvUtil {
+  /**
+   * Generates a CSV string from an array of objects.
+   * @param data Array of objects to convert to CSV.
+   * @param headers Optional array of header names. If not provided, keys from the first object will be used.
+   * @param excludeFields Optional array of field names to exclude from the CSV.
+   */
+  static generateCsv(
+    data: any[],
+    headers?: string[],
+    excludeFields: string[] = [],
+  ): string {
+    if (!data || data.length === 0) {
+      return headers ? headers.join(',') : '';
+    }
+
+    const keys = Object.keys(data[0]).filter((key) => !excludeFields.includes(key));
+    const csvHeaders = headers || keys;
+
+    const csvRows = [csvHeaders.join(',')];
+
+    for (const row of data) {
+      const values = keys.map((key) => {
+        const val = row[key];
+        const escaped = ('' + (val ?? '')).replace(/"/g, '""');
+        return `"${escaped}"`;
+      });
+      csvRows.push(values.join(','));
+    }
+
+    return csvRows.join('\n');
+  }
+}


### PR DESCRIPTION
This PR adds spreadsheet-ready CSV export capabilities for both campaign summaries and claim records to support operations teams in reporting and donor reconciliation.

Key Changes:

New endpoints: GET /campaigns/export and GET /claims/export.
Support for standard filters: Date Range (startDate/endDate), Status, Organization (ngoId), and Token Address.
Data Privacy: Sensitive fields such as metadata, internal notes, and raw evidence references are excluded from exports.
Security: recipientRef is decrypted in the export for readability while maintaining on-chain security.
Implementation: Uses a lightweight, zero-dependency CSV utility for robust generation.
Closes #264