### PR TITLE
Harden CORS defaults and API security headers

### DIFF
--- a/app/backend/src/common/security/security.module.ts
+++ b/app/backend/src/common/security/security.module.ts
@@ -69,29 +69,54 @@ const isRateLimitExempt = (req: Request): boolean => {
   return RATE_LIMIT_EXEMPT_PATHS.some(pattern => pattern.test(normalizedPath));
 };
 
-// Explicit Helmet configuration: only the required headers are enabled.
-const buildHelmetOptions = (): HelmetOptions => ({
-  contentSecurityPolicy: false,
-  crossOriginEmbedderPolicy: false,
-  crossOriginOpenerPolicy: false,
-  crossOriginResourcePolicy: false,
-  originAgentCluster: false,
-  referrerPolicy: { policy: 'no-referrer' },
-  strictTransportSecurity: false,
-  xContentTypeOptions: true,
-  xDnsPrefetchControl: false,
-  xDownloadOptions: false,
-  xFrameOptions: { action: 'deny' },
-  xPermittedCrossDomainPolicies: false,
-  xPoweredBy: false,
-  xXssProtection: false,
-});
+const resolveNodeEnv = (config: ConfigService): string =>
+  (config.get<string>('NODE_ENV') ?? 'development').toLowerCase();
 
-export const createHelmetMiddleware = () => helmet(buildHelmetOptions());
+// Explicit Helmet configuration: only required API security headers are enabled.
+const buildHelmetOptions = (config: ConfigService): HelmetOptions => {
+  const nodeEnv = resolveNodeEnv(config);
+  const strictTransportSecurity =
+    nodeEnv === 'production'
+      ? {
+          maxAge: 15_552_000,
+          includeSubDomains: true,
+          preload: true,
+        }
+      : false;
+
+  return {
+    contentSecurityPolicy: false,
+    crossOriginEmbedderPolicy: false,
+    crossOriginOpenerPolicy: false,
+    crossOriginResourcePolicy: false,
+    originAgentCluster: false,
+    permissionsPolicy: {
+      features: {
+        camera: [],
+        geolocation: [],
+        microphone: [],
+      },
+    },
+    referrerPolicy: { policy: 'no-referrer' },
+    strictTransportSecurity,
+    xContentTypeOptions: true,
+    xDnsPrefetchControl: false,
+    xDownloadOptions: false,
+    xFrameOptions: { action: 'deny' },
+    xPermittedCrossDomainPolicies: false,
+    xPoweredBy: false,
+    xXssProtection: false,
+  };
+};
+
+export const createHelmetMiddleware = (config: ConfigService) =>
+  helmet(buildHelmetOptions(config));
 
 const resolveAllowedOrigins = (config: ConfigService): string[] => {
-  const rawOrigins = config.get<string>('CORS_ORIGINS');
-  const nodeEnv = config.get<string>('NODE_ENV');
+  const nodeEnv = resolveNodeEnv(config);
+  const envSpecificKey = `CORS_ORIGINS_${nodeEnv.toUpperCase()}`;
+  const rawOrigins =
+    config.get<string>(envSpecificKey) ?? config.get<string>('CORS_ORIGINS');
   if (rawOrigins === undefined) {
     if (nodeEnv === 'development' || nodeEnv === 'test') {
       return DEFAULT_ALLOWED_ORIGINS;

--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -44,7 +44,7 @@ async function bootstrap() {
   const configService = app.get(ConfigService);
 
   // Security middleware (order matters)
-  app.use(createHelmetMiddleware());
+  app.use(createHelmetMiddleware(configService));
   app.use(createCorsOriginValidator(configService));
   app.enableCors(buildCorsOptions(configService));
   app.use(createRateLimiter(configService));

--- a/app/backend/test/security.e2e-spec.ts
+++ b/app/backend/test/security.e2e-spec.ts
@@ -38,7 +38,7 @@ const createTestApp = async ({ enableDocs }: TestAppOptions) => {
   });
 
   const configService = app.get(ConfigService);
-  app.use(createHelmetMiddleware());
+  app.use(createHelmetMiddleware(configService));
   app.use(createCorsOriginValidator(configService));
   app.enableCors(buildCorsOptions(configService));
   app.use(createRateLimiter(configService));
@@ -63,6 +63,9 @@ describe('Security (e2e)', () => {
     API_RATE_LIMIT: process.env.API_RATE_LIMIT,
     THROTTLE_TTL: process.env.THROTTLE_TTL,
     CORS_ORIGINS: process.env.CORS_ORIGINS,
+    CORS_ORIGINS_DEVELOPMENT: process.env.CORS_ORIGINS_DEVELOPMENT,
+    CORS_ORIGINS_TEST: process.env.CORS_ORIGINS_TEST,
+    CORS_ORIGINS_PRODUCTION: process.env.CORS_ORIGINS_PRODUCTION,
     CORS_ALLOW_CREDENTIALS: process.env.CORS_ALLOW_CREDENTIALS,
   };
 
@@ -81,6 +84,12 @@ describe('Security (e2e)', () => {
     setEnvValue('API_RATE_LIMIT', originalEnv.API_RATE_LIMIT);
     setEnvValue('THROTTLE_TTL', originalEnv.THROTTLE_TTL);
     setEnvValue('CORS_ORIGINS', originalEnv.CORS_ORIGINS);
+    setEnvValue(
+      'CORS_ORIGINS_DEVELOPMENT',
+      originalEnv.CORS_ORIGINS_DEVELOPMENT,
+    );
+    setEnvValue('CORS_ORIGINS_TEST', originalEnv.CORS_ORIGINS_TEST);
+    setEnvValue('CORS_ORIGINS_PRODUCTION', originalEnv.CORS_ORIGINS_PRODUCTION);
     setEnvValue('CORS_ALLOW_CREDENTIALS', originalEnv.CORS_ALLOW_CREDENTIALS);
   });
 
@@ -117,6 +126,52 @@ describe('Security (e2e)', () => {
 
       expect(response.status).toBe(403);
       expect(response.text).toBe('Not allowed by CORS');
+    });
+
+    it('should use environment-specific CORS allowlist when configured', async () => {
+      process.env.CORS_ORIGINS = 'https://fallback.example.com';
+      process.env.CORS_ORIGINS_TEST = 'http://localhost:3000';
+      const scopedApp = await createTestApp({ enableDocs: false });
+      const server = scopedApp.getHttpServer();
+
+      const allowed = await request(server)
+        .get('/api/v1/health')
+        .set('Origin', 'http://localhost:3000');
+      expect(allowed.status).toBe(200);
+      expect(allowed.headers['access-control-allow-origin']).toBe(
+        'http://localhost:3000',
+      );
+
+      const blocked = await request(server)
+        .get('/api/v1/health')
+        .set('Origin', 'https://fallback.example.com');
+      expect(blocked.status).toBe(403);
+
+      await scopedApp.close();
+      process.env.CORS_ORIGINS = 'http://localhost:3000';
+      delete process.env.CORS_ORIGINS_TEST;
+    });
+
+    it('should deny browser origins by default in production without an allowlist', () => {
+      const config = {
+        get: (key: string) => (key === 'NODE_ENV' ? 'production' : undefined),
+      } as unknown as ConfigService;
+
+      const validator = createCorsOriginValidator(config);
+      const req = {
+        headers: { origin: 'https://frontend.pulsefy.com' },
+      } as any;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn(),
+      } as any;
+      const next = jest.fn();
+
+      validator(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.send).toHaveBeenCalledWith('Not allowed by CORS');
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('should handle preflight requests for allowed origins', async () => {


### PR DESCRIPTION
## Summary
- add explicit environment-based CORS allowlist resolution (`CORS_ORIGINS_<ENV>` with `CORS_ORIGINS` fallback)
- keep deployed defaults locked down by denying browser origins when no allowlist is configured (production-safe default)
- make helmet middleware config-aware and enforce recommended API security headers, including production-only HSTS
- extend security e2e coverage for env-specific CORS behavior and production default deny behavior

## Test plan
- [x] `npm run lint:check -- src/common/security/security.module.ts test/security.e2e-spec.ts src/main.ts`
- [x] `npm run test:e2e -- security.e2e-spec.ts -t "environment-specific CORS allowlist|deny browser origins by default in production"`
- [ ] optional: run full `npm run test:e2e -- security.e2e-spec.ts` (contains unrelated pre-existing rate-limit test failures)  

Closes #251 
