### PR TITLE
feat: add API key management settings page with lifecycle actions

### DIFF
--- a/app/backend/src/controllers/api_keys_controller.js
+++ b/app/backend/src/controllers/api_keys_controller.js
@@ -1,0 +1,24 @@
+// app/backend/src/controllers/api_keys_controller.js
+const express = require('express');
+const router = express.Router();
+const service = require('../services/api_keys_service');
+
+router.get('/api/admin/keys', async (req, res) => {
+  res.json(await service.listKeys());
+});
+
+router.post('/api/admin/keys', async (req, res) => {
+  res.json(await service.createKey(req.user.id));
+});
+
+router.post('/api/admin/keys/:id/rotate', async (req, res) => {
+  await service.rotateKey(req.params.id);
+  res.json({ success: true });
+});
+
+router.post('/api/admin/keys/:id/revoke', async (req, res) => {
+  await service.revokeKey(req.params.id);
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/app/backend/src/services/api_keys_service.js
+++ b/app/backend/src/services/api_keys_service.js
@@ -1,0 +1,38 @@
+// app/backend/src/services/api_keys_service.js
+const db = require('../db');
+const crypto = require('crypto');
+
+function maskKey(key) {
+  return key.slice(0, 6) + '****' + key.slice(-4);
+}
+
+async function listKeys() {
+  const res = await db.query('SELECT * FROM api_keys');
+  return res.rows.map(k => ({
+    id: k.id,
+    masked: maskKey(k.key),
+    creator: k.creator,
+    createdAt: k.created_at,
+    lastUsed: k.last_used,
+  }));
+}
+
+async function createKey(creatorId) {
+  const rawKey = crypto.randomBytes(32).toString('hex');
+  await db.query(
+    'INSERT INTO api_keys (id, key, creator, created_at) VALUES (gen_random_uuid(), $1, $2, NOW())',
+    [rawKey, creatorId]
+  );
+  return { masked: maskKey(rawKey) };
+}
+
+async function rotateKey(id) {
+  const newKey = crypto.randomBytes(32).toString('hex');
+  await db.query('UPDATE api_keys SET key=$1, created_at=NOW() WHERE id=$2', [newKey, id]);
+}
+
+async function revokeKey(id) {
+  await db.query('DELETE FROM api_keys WHERE id=$1', [id]);
+}
+
+module.exports = { listKeys, createKey, rotateKey, revokeKey };

--- a/app/backend/test/api_keys_tests.js
+++ b/app/backend/test/api_keys_tests.js
@@ -1,0 +1,23 @@
+// app/backend/tests/api_keys_tests.js
+const service = require('../src/services/api_keys_service');
+
+describe('API Key Service', () => {
+  it('creates a new key', async () => {
+    const key = await service.createKey('admin1');
+    expect(key.masked).toMatch(/^\w{6}\*{4}\w{4}$/);
+  });
+
+  it('rotates a key', async () => {
+    const keys = await service.listKeys();
+    await service.rotateKey(keys[0].id);
+    const updated = await service.listKeys();
+    expect(updated[0].createdAt).not.toBe(keys[0].createdAt);
+  });
+
+  it('revokes a key', async () => {
+    const keys = await service.listKeys();
+    await service.revokeKey(keys[0].id);
+    const updated = await service.listKeys();
+    expect(updated.find(k => k.id === keys[0].id)).toBeUndefined();
+  });
+});

--- a/app/frontend/src/pages/settings/ApiKeysPage.js
+++ b/app/frontend/src/pages/settings/ApiKeysPage.js
@@ -1,0 +1,65 @@
+// app/frontend/src/pages/settings/ApiKeysPage.js
+import React, { useState, useEffect } from 'react';
+import { getKeys, rotateKey, revokeKey, createKey } from '../../services/apiKeyService';
+
+function ApiKeysPage() {
+  const [keys, setKeys] = useState([]);
+
+  useEffect(() => {
+    getKeys().then(setKeys);
+  }, []);
+
+  const handleRotate = async (id) => {
+    if (window.confirm('Are you sure you want to rotate this key?')) {
+      await rotateKey(id);
+      setKeys(await getKeys());
+    }
+  };
+
+  const handleRevoke = async (id) => {
+    if (window.confirm('Are you sure you want to revoke this key?')) {
+      await revokeKey(id);
+      setKeys(await getKeys());
+    }
+  };
+
+  const handleCreate = async () => {
+    const newKey = await createKey();
+    alert(`New key created: ${newKey.masked}`);
+    setKeys(await getKeys());
+  };
+
+  return (
+    <div>
+      <h2>API Key Management</h2>
+      <button onClick={handleCreate}>Create New Key</button>
+      <table>
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Creator</th>
+            <th>Created</th>
+            <th>Last Used</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {keys.map(k => (
+            <tr key={k.id}>
+              <td>{k.masked}</td>
+              <td>{k.creator}</td>
+              <td>{k.createdAt}</td>
+              <td>{k.lastUsed}</td>
+              <td>
+                <button onClick={() => handleRotate(k.id)}>Rotate</button>
+                <button onClick={() => handleRevoke(k.id)}>Revoke</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ApiKeysPage;

--- a/app/frontend/src/services/apiKeyService.js
+++ b/app/frontend/src/services/apiKeyService.js
@@ -1,0 +1,20 @@
+// app/frontend/src/services/apiKeyService.js
+import axios from 'axios';
+
+export async function getKeys() {
+  const res = await axios.get('/api/admin/keys');
+  return res.data;
+}
+
+export async function rotateKey(id) {
+  await axios.post(`/api/admin/keys/${id}/rotate`);
+}
+
+export async function revokeKey(id) {
+  await axios.post(`/api/admin/keys/${id}/revoke`);
+}
+
+export async function createKey() {
+  const res = await axios.post('/api/admin/keys');
+  return res.data;
+}


### PR DESCRIPTION
# Pull Request: API Key Management Settings Page

## Overview
This PR implements issue **#268 API Key Management Settings Page**.  
It adds an admin UI and backend logic for secure API key lifecycle management.

---

## Changes Introduced
- Frontend page `ApiKeysPage.js` with table view and lifecycle actions.
- Frontend service `apiKeyService.js` for API calls.
- Backend controller `api_keys_controller.js` for routes.
- Backend service `api_keys_service.js` for business logic.
- Unit tests in `api_keys_tests.js`.

---

## Acceptance Criteria ✅
- [x] Admin UI for API key lifecycle actions
- [x] Masked previews, creator, creation date, last-used timestamps
- [x] Confirmation before revoke/rotate
- [x] Backend logic implemented
- [x] Unit tests included
- [x] All work scoped to app/frontend and app/backend

---

## How to Test
1. Navigate to Settings → API Keys in admin UI.
2. Create a new key → masked preview shown.
3. Rotate a key → confirmation required, creation date updated.
4. Revoke a key → confirmation required, key removed.
5. Run tests: `npm test app/backend/tests/api_keys_tests.js`.

---

## Contribution Notes
- All work scoped strictly to frontend/backend.
- No files outside these folders were modified.
- Branch: `feat/api-key-management`

---

## Next Steps
- Add pagination and search for large key sets.
- Add audit logging for key lifecycle actions.
- Integrate role-based access control for admin-only visibility.

---

## Checklist Before Merge
- [ ] Code reviewed
- [ ] Tests passed locally
- [ ] Security validated
- [ ] UI verified
Closes #268 