### PR TITLE
docs(aid_escrow): add README and Rust doc comments for public functions

### DIFF
--- a/app/onchain/contracts/aid_escrow/README.md
+++ b/app/onchain/contracts/aid_escrow/README.md
@@ -1,0 +1,146 @@
+# Aid Escrow Contract
+
+Soroban smart contract for managing aid-package escrow on Stellar.
+
+## What It Does
+
+This contract allows an admin (and optionally designated distributors) to create
+locked aid packages for recipients. Each package holds a specific amount of a
+token until the recipient claims it, an admin disburses it, or the package
+expires and is refunded.
+
+## Public Functions
+
+### Admin & Config
+
+| Function | Auth | Description |
+|---|---|---|
+| `init(env, admin)` | None (once) | Initializes the contract with an admin address and default config. |
+| `get_admin(env)` | — | Returns the current admin address. |
+| `get_version(env)` | — | Returns the current contract version. |
+| `migrate(env, new_version)` | Admin | Performs version-specific migrations. |
+| `add_distributor(env, addr)` | Admin | Grants distributor privileges to an address. |
+| `remove_distributor(env, addr)` | Admin | Revokes distributor privileges. |
+| `set_config(env, config)` | Admin | Updates contract configuration (min amount, max expiry, allowed tokens). |
+| `get_config(env)` | — | Returns the current config. |
+| `pause(env)` | Admin | Pauses the contract (blocks package creation and claims). |
+| `unpause(env)` | Admin | Unpauses the contract. |
+| `is_paused(env)` | — | Returns true if the contract is paused. |
+
+### Funding
+
+| Function | Auth | Description |
+|---|---|---|
+| `fund(env, token, from, amount)` | Funder | Transfers tokens into the contract balance. This increases the available pool from which packages are locked. |
+
+### Package Management
+
+| Function | Auth | Description |
+|---|---|---|
+| `create_package(env, operator, id, recipient, amount, token, expires_at)` | Admin / Distributor | Creates a single aid package with a specific ID. Locks funds from the available pool. |
+| `batch_create_packages(env, operator, recipients, amounts, token, expires_in)` | Admin / Distributor | Creates multiple packages in one transaction using auto-incrementing IDs. |
+| `claim(env, id)` | Recipient | Recipient claims the package. Transfers tokens to recipient and marks package as claimed. |
+| `disburse(env, id)` | Admin | Admin manually disburses a package to its recipient. |
+| `revoke(env, id)` | Admin | Admin revokes a package, returning funds to the surplus pool. |
+| `refund(env, id)` | Admin | Refunds an expired or cancelled package to the admin. |
+| `cancel_package(env, package_id)` | Admin | Cancels a package (transitions to Cancelled status). |
+| `extend_expiration(env, package_id, additional_time)` | Admin / Distributor | Extends the expiration time of an active package. |
+
+### Queries
+
+| Function | Auth | Description |
+|---|---|---|
+| `get_package(env, id)` | — | Returns full package details. |
+| `view_package_status(env, id)` | — | Returns only the status (cheaper for polling). |
+| `get_aggregates(env, token)` | — | Returns aggregate stats: total committed, claimed, expired/cancelled for a token. |
+| `withdraw_surplus(env, token, to, amount)` | Admin | Withdraws surplus (unlocked) tokens from the contract. |
+
+## Package Lifecycle
+
+```
+Created --> Claimed          (recipient claims)
+Created --> Expired          (past expiry, recipient tries to claim)
+Created --> Cancelled        (admin cancels)
+Created --> Claimed (admin)  (admin disburses)
+Expired --> Refunded         (admin refunds)
+Cancelled --> Refunded       (admin refunds)
+```
+
+## Error Enum
+
+| Code | Error | When It Happens |
+|---|---|---|
+| 1 | `NotInitialized` | Contract not initialized yet. |
+| 2 | `AlreadyInitialized` | `init` called twice. |
+| 3 | `NotAuthorized` | Caller lacks required role. |
+| 4 | `InvalidAmount` | Amount is zero, negative, or below `min_amount`. |
+| 5 | `PackageNotFound` | Package ID does not exist. |
+| 6 | `PackageNotActive` | Package is not in `Created` status. |
+| 7 | `PackageExpired` | Package past expiry. |
+| 8 | `PackageNotExpired` | Refund attempted before expiry. |
+| 9 | `InsufficientFunds` | Not enough unlocked balance to lock for package. |
+| 10 | `PackageIdExists` | Duplicate ID in `create_package`. |
+| 11 | `InvalidState` | Generic state violation (e.g. paused, bad config). |
+| 12 | `MismatchedArrays` | `recipients` and `amounts` lengths differ in batch create. |
+| 13 | `InsufficientSurplus` | `withdraw_surplus` amount exceeds available surplus. |
+| 14 | `ContractPaused` | Operation blocked because contract is paused. |
+
+## Data Structures
+
+### `Package`
+
+```rust
+pub struct Package {
+    pub id: u64,
+    pub recipient: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub status: PackageStatus,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub metadata: Map<Symbol, String>,
+}
+```
+
+### `Config`
+
+```rust
+pub struct Config {
+    pub min_amount: i128,          // minimum amount per package
+    pub max_expires_in: u64,       // max seconds from creation to expiry (0 = no limit)
+    pub allowed_tokens: Vec<Address>, // empty = any token allowed
+}
+```
+
+### `Aggregates`
+
+```rust
+pub struct Aggregates {
+    pub total_committed: i128,
+    pub total_claimed: i128,
+    pub total_expired_cancelled: i128,
+}
+```
+
+## Events
+
+All state-changing operations emit events with stable topics for indexer consumption:
+
+- `EscrowFunded` — pool funded
+- `PackageCreated` — package created
+- `PackageClaimed` — recipient claimed
+- `PackageDisbursed` — admin disbursed
+- `PackageRevoked` — admin revoked
+- `PackageRefunded` — admin refunded
+- `BatchCreatedEvent` — batch creation
+
+## Testing
+
+Run the test suite:
+
+```bash
+cd app/onchain/contracts/aid_escrow
+cargo test
+```
+
+See the `tests/` directory for integration, batch, event, versioning, and surplus tests.

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -178,6 +178,13 @@ pub struct AidEscrow;
 impl AidEscrow {
     // --- Admin & Config ---
 
+    /// Initializes the contract.
+    ///
+    /// # Arguments
+    /// * `admin` — The address that will own the contract (can pause, config, disburse, etc.).
+    ///
+    /// # Errors
+    /// Returns `Error::AlreadyInitialized` if called more than once.
     pub fn init(env: Env, admin: Address) -> Result<(), Error> {
         if env.storage().instance().has(&KEY_ADMIN) {
             return Err(Error::AlreadyInitialized);
@@ -193,6 +200,10 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Returns the admin address stored at initialization.
+    ///
+    /// # Errors
+    /// Returns `Error::NotInitialized` if the contract has not been initialized.
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         env.storage()
             .instance()
@@ -200,10 +211,19 @@ impl AidEscrow {
             .ok_or(Error::NotInitialized)
     }
 
+    /// Returns the current contract version.
+    /// Defaults to `0` if the contract has never been initialized.
     pub fn get_version(env: Env) -> u32 {
         env.storage().instance().get(&KEY_VERSION).unwrap_or(0)
     }
 
+    /// Admin-only. Bumps the contract version and runs any required migration logic.
+    ///
+    /// # Arguments
+    /// * `new_version` — Target version number.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn migrate(env: Env, new_version: u32) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -224,6 +244,11 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Admin-only. Grants distributor privileges to `addr`.
+    /// Distributors can create packages but cannot pause, config, or disburse.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn add_distributor(env: Env, addr: Address) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -241,6 +266,10 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Admin-only. Revokes distributor privileges from `addr`.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn remove_distributor(env: Env, addr: Address) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -258,6 +287,14 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Admin-only. Updates the global contract configuration.
+    ///
+    /// # Arguments
+    /// * `config` — New config values (`min_amount`, `max_expires_in`, `allowed_tokens`).
+    ///
+    /// # Errors
+    /// Returns `Error::InvalidAmount` if `config.min_amount` is zero or negative.
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn set_config(env: Env, config: Config) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -270,6 +307,12 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Admin-only. Pauses the contract.
+    /// While paused, package creation and claims are blocked.
+    /// Emits a `ContractPausedEvent`.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn pause(env: Env) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -278,6 +321,11 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Admin-only. Unpauses the contract, resuming normal operation.
+    /// Emits a `ContractUnpausedEvent`.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
     pub fn unpause(env: Env) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
@@ -286,10 +334,14 @@ impl AidEscrow {
         Ok(())
     }
 
+    /// Returns `true` if the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage().instance().get(&KEY_PAUSED).unwrap_or(false)
     }
 
+    /// Returns the current contract configuration.
+    /// Falls back to defaults (`min_amount: 1`, `max_expires_in: 0`, empty token list)
+    /// if no config has been explicitly set.
     pub fn get_config(env: Env) -> Config {
         env.storage().instance().get(&KEY_CONFIG).unwrap_or(Config {
             min_amount: 1,
@@ -924,6 +976,10 @@ impl AidEscrow {
         }
     }
 
+    /// Retrieves the full details of a package by its ID.
+    ///
+    /// # Errors
+    /// Returns `Error::PackageNotFound` if no package exists with the given `id`.
     pub fn get_package(env: Env, id: u64) -> Result<Package, Error> {
         let key = (symbol_short!("pkg"), id);
         env.storage()


### PR DESCRIPTION
Closes #74

This PR documents the public interface of the aid_escrow contract for contributors and integrators.

New file: README.md
- Table of all public functions with auth requirements and descriptions
- Package lifecycle state diagram
- Error enum reference table (code, name, meaning)
- Data structure definitions (Package, Config, Aggregates)
- Event listing for indexer developers
- Quick testing instructions

Updated: src/lib.rs
- Added Rust doc comments to all previously undocumented public functions:
  init, get_admin, get_version, migrate, add_distributor, remove_distributor,
  set_config, pause, unpause, is_paused, get_config, get_package
- Each doc includes purpose, arguments, and error semantics.