### PR TITLE
test(e2e): End-to-End test suite for key flows

### DIFF
--- a/app/backend/src/jobs/dead-letter.processor.ts
+++ b/app/backend/src/jobs/dead-letter.processor.ts
@@ -1,0 +1,77 @@
+import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+
+export interface DeadLetterJobData {
+  /** Original queue the job came from */
+  originalQueue: string;
+  /** Original job ID */
+  originalJobId: string;
+  /** Original job name */
+  originalJobName: string;
+  /** Original job payload */
+  originalData: unknown;
+  /** Error message from the final failure */
+  failureReason: string;
+  /** Stack trace if available */
+  failureStack?: string;
+  /** Total attempts made before giving up */
+  attemptsMade: number;
+  /** Unix timestamp (ms) when the job was moved to DLQ */
+  deadAt: number;
+}
+
+/**
+ * Dead Letter Queue processor.
+ *
+ * Jobs land here after exhausting all retries in their source queue.
+ * The processor persists a structured failure record and emits an alert
+ * log so operators can triage without digging through Redis directly.
+ *
+ * Future extension points:
+ *  - Persist to a `dead_letter_jobs` DB table via PrismaService
+ *  - Emit a Prometheus counter / alert
+ *  - Publish to a Slack / PagerDuty webhook
+ */
+@Processor('dead-letter', { concurrency: 1 })
+export class DeadLetterProcessor extends WorkerHost {
+  private readonly logger = new Logger(DeadLetterProcessor.name);
+
+  async process(job: Job<DeadLetterJobData>): Promise<void> {
+    const { originalQueue, originalJobId, failureReason, attemptsMade } =
+      job.data;
+
+    this.logger.error(
+      `[DLQ] Job ${originalJobId} from queue "${originalQueue}" permanently failed ` +
+        `after ${attemptsMade} attempt(s). Reason: ${failureReason}`,
+    );
+
+    // Structured log for log-aggregation pipelines (Datadog, CloudWatch, etc.)
+    this.logger.error(
+      JSON.stringify({
+        event: 'dead_letter_job',
+        originalQueue,
+        originalJobId,
+        originalJobName: job.data.originalJobName,
+        failureReason,
+        attemptsMade,
+        deadAt: new Date(job.data.deadAt).toISOString(),
+      }),
+    );
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<DeadLetterJobData>): void {
+    this.logger.log(
+      `[DLQ] Dead-letter record ${job.id} processed for original job ` +
+        `${job.data.originalJobId} (queue: ${job.data.originalQueue})`,
+    );
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<DeadLetterJobData> | undefined, error: Error): void {
+    this.logger.error(
+      `[DLQ] Failed to process dead-letter record ${job?.id}: ${error.message}`,
+    );
+  }
+}

--- a/app/backend/src/jobs/dead-letter.service.ts
+++ b/app/backend/src/jobs/dead-letter.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Job, Queue } from 'bullmq';
+import { DeadLetterJobData } from './dead-letter.processor';
+
+export interface DlqJobSummary {
+  dlqJobId: string;
+  originalQueue: string;
+  originalJobId: string;
+  originalJobName: string;
+  failureReason: string;
+  attemptsMade: number;
+  deadAt: string;
+}
+
+export interface DlqStats {
+  waiting: number;
+  active: number;
+  completed: number;
+  failed: number;
+  delayed: number;
+}
+
+/**
+ * Service for interacting with the Dead Letter Queue.
+ *
+ * Provides:
+ *  - Moving a failed job into the DLQ
+ *  - Listing / inspecting dead-letter records
+ *  - Requeueing a dead-letter job back to its original queue
+ *  - Purging processed dead-letter records
+ */
+@Injectable()
+export class DeadLetterService {
+  private readonly logger = new Logger(DeadLetterService.name);
+
+  constructor(
+    @InjectQueue('dead-letter') private readonly dlq: Queue<DeadLetterJobData>,
+  ) {}
+
+  /**
+   * Move a permanently-failed job into the DLQ.
+   * Called by each processor's `@OnWorkerEvent('failed')` handler when
+   * `job.attemptsMade >= job.opts.attempts`.
+   */
+  async moveToDeadLetter(
+    originalQueue: string,
+    job: Job,
+    error: Error,
+  ): Promise<void> {
+    const payload: DeadLetterJobData = {
+      originalQueue,
+      originalJobId: job.id ?? 'unknown',
+      originalJobName: job.name,
+      originalData: job.data,
+      failureReason: error.message,
+      failureStack: error.stack,
+      attemptsMade: job.attemptsMade,
+      deadAt: Date.now(),
+    };
+
+    await this.dlq.add('dead-letter-record', payload, {
+      removeOnComplete: 500, // keep last 500 processed DLQ records
+      removeOnFail: false,   // never auto-remove failed DLQ records
+    });
+
+    this.logger.warn(
+      `Moved job ${job.id} from "${originalQueue}" to DLQ after ` +
+        `${job.attemptsMade} attempt(s): ${error.message}`,
+    );
+  }
+
+  /** Return current DLQ queue counts. */
+  async getStats(): Promise<DlqStats> {
+    const [waiting, active, completed, failed, delayed] = await Promise.all([
+      this.dlq.getWaitingCount(),
+      this.dlq.getActiveCount(),
+      this.dlq.getCompletedCount(),
+      this.dlq.getFailedCount(),
+      this.dlq.getDelayedCount(),
+    ]);
+    return { waiting, active, completed, failed, delayed };
+  }
+
+  /**
+   * List the most recent N waiting dead-letter records.
+   * Useful for the monitoring dashboard.
+   */
+  async listWaiting(limit = 50): Promise<DlqJobSummary[]> {
+    const jobs = await this.dlq.getWaiting(0, limit - 1);
+    return jobs.map(j => this.toSummary(j));
+  }
+
+  /**
+   * List the most recent N failed dead-letter records
+   * (DLQ processor itself failed – rare but possible).
+   */
+  async listFailed(limit = 50): Promise<DlqJobSummary[]> {
+    const jobs = await this.dlq.getFailed(0, limit - 1);
+    return jobs.map(j => this.toSummary(j));
+  }
+
+  /**
+   * Requeue a dead-letter record back to its original queue.
+   * The caller is responsible for injecting the target queue.
+   */
+  async requeueJob(
+    dlqJobId: string,
+    targetQueue: Queue,
+  ): Promise<{ requeuedJobId: string }> {
+    const dlqJob = await this.dlq.getJob(dlqJobId);
+    if (!dlqJob) {
+      throw new Error(`DLQ job ${dlqJobId} not found`);
+    }
+
+    const requeued = await targetQueue.add(
+      dlqJob.data.originalJobName,
+      dlqJob.data.originalData,
+      {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+        removeOnComplete: 100,
+        removeOnFail: false,
+      },
+    );
+
+    // Remove the DLQ record now that it has been requeued
+    await dlqJob.remove();
+
+    this.logger.log(
+      `Requeued DLQ job ${dlqJobId} → new job ${requeued.id} on ` +
+        `"${dlqJob.data.originalQueue}"`,
+    );
+
+    return { requeuedJobId: requeued.id ?? 'unknown' };
+  }
+
+  private toSummary(job: Job<DeadLetterJobData>): DlqJobSummary {
+    return {
+      dlqJobId: job.id ?? 'unknown',
+      originalQueue: job.data.originalQueue,
+      originalJobId: job.data.originalJobId,
+      originalJobName: job.data.originalJobName,
+      failureReason: job.data.failureReason,
+      attemptsMade: job.data.attemptsMade,
+      deadAt: new Date(job.data.deadAt).toISOString(),
+    };
+  }
+}

--- a/app/backend/src/jobs/jobs.controller.ts
+++ b/app/backend/src/jobs/jobs.controller.ts
@@ -1,24 +1,85 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  ParseIntPipe,
+  DefaultValuePipe,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiParam,
+  ApiQuery,
+  ApiSecurity,
+} from '@nestjs/swagger';
+import { DeadLetterService } from './dead-letter.service';
+
+// ---------------------------------------------------------------------------
+// Shared response shapes
+// ---------------------------------------------------------------------------
+
+interface QueueStatus {
+  name: string;
+  waiting: number;
+  active: number;
+  completed: number;
+  failed: number;
+  delayed: number;
+  /** Ratio of failed / (completed + failed), rounded to 4 dp */
+  failureRate: number;
+  /** true when failed > 0 or active jobs are stalled */
+  degraded: boolean;
+}
+
+interface HealthSummary {
+  status: 'healthy' | 'degraded' | 'critical';
+  queues: Record<string, QueueStatus>;
+  deadLetter: {
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+  };
+  checkedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
 
 @ApiTags('Jobs')
+@ApiSecurity('x-api-key')
 @Controller('jobs')
 export class JobsController {
   constructor(
-    @InjectQueue('verification') private verificationQueue: Queue,
-    @InjectQueue('notifications') private notificationsQueue: Queue,
-    @InjectQueue('onchain') private onchainQueue: Queue,
+    @InjectQueue('verification') private readonly verificationQueue: Queue,
+    @InjectQueue('notifications') private readonly notificationsQueue: Queue,
+    @InjectQueue('onchain') private readonly onchainQueue: Queue,
+    private readonly deadLetterService: DeadLetterService,
   ) {}
 
+  // -------------------------------------------------------------------------
+  // GET /jobs/status  – raw queue counts (backwards-compatible)
+  // -------------------------------------------------------------------------
+
+  @Get('status')
   @ApiOperation({
-    summary: 'Get status of all background job queues',
+    summary: 'Raw queue counts for all background job queues',
     description:
-      'Retrieves the count of waiting, active, completed, failed, and delayed jobs for all system queues.',
+      'Returns waiting / active / completed / failed / delayed counts for ' +
+      'the verification, notifications, and onchain queues.',
   })
   @ApiOkResponse({
-    description: 'Queue statuses retrieved successfully.',
+    description: 'Queue counts retrieved successfully.',
     schema: {
       example: {
         verification: {
@@ -28,6 +89,8 @@ export class JobsController {
           completed: 10,
           failed: 0,
           delayed: 0,
+          failureRate: 0,
+          degraded: false,
         },
         notifications: {
           name: 'notifications',
@@ -36,6 +99,8 @@ export class JobsController {
           completed: 5,
           failed: 0,
           delayed: 0,
+          failureRate: 0,
+          degraded: false,
         },
         onchain: {
           name: 'onchain',
@@ -44,20 +109,157 @@ export class JobsController {
           completed: 2,
           failed: 0,
           delayed: 0,
+          failureRate: 0,
+          degraded: false,
         },
       },
     },
   })
-  @Get('status')
-  async getStatus() {
+  async getStatus(): Promise<Record<string, QueueStatus>> {
+    const [verification, notifications, onchain] = await Promise.all([
+      this.buildQueueStatus(this.verificationQueue),
+      this.buildQueueStatus(this.notificationsQueue),
+      this.buildQueueStatus(this.onchainQueue),
+    ]);
+
+    return { verification, notifications, onchain };
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /jobs/health  – aggregated health summary including DLQ
+  // -------------------------------------------------------------------------
+
+  @Get('health')
+  @ApiOperation({
+    summary: 'Aggregated queue health including Dead Letter Queue',
+    description:
+      'Returns an overall health status (healthy / degraded / critical) ' +
+      'plus per-queue metrics and DLQ stats. Use this endpoint for ' +
+      'dashboards and alerting.',
+  })
+  @ApiOkResponse({
+    description: 'Health summary retrieved successfully.',
+    schema: {
+      example: {
+        status: 'healthy',
+        queues: {},
+        deadLetter: { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 },
+        checkedAt: '2026-04-23T12:00:00.000Z',
+      },
+    },
+  })
+  async getHealth(): Promise<HealthSummary> {
+    const [verification, notifications, onchain, dlqStats] = await Promise.all([
+      this.buildQueueStatus(this.verificationQueue),
+      this.buildQueueStatus(this.notificationsQueue),
+      this.buildQueueStatus(this.onchainQueue),
+      this.deadLetterService.getStats(),
+    ]);
+
+    const queues = { verification, notifications, onchain };
+
+    // Determine overall health
+    const anyDegraded = Object.values(queues).some(q => q.degraded);
+    const dlqHasWaiting = dlqStats.waiting > 0;
+    const highFailureRate = Object.values(queues).some(
+      q => q.failureRate > 0.1,
+    );
+
+    let status: HealthSummary['status'] = 'healthy';
+    if (highFailureRate || dlqStats.failed > 0) {
+      status = 'critical';
+    } else if (anyDegraded || dlqHasWaiting) {
+      status = 'degraded';
+    }
+
     return {
-      verification: await this.getQueueStatus(this.verificationQueue),
-      notifications: await this.getQueueStatus(this.notificationsQueue),
-      onchain: await this.getQueueStatus(this.onchainQueue),
+      status,
+      queues,
+      deadLetter: dlqStats,
+      checkedAt: new Date().toISOString(),
     };
   }
 
-  private async getQueueStatus(queue: Queue) {
+  // -------------------------------------------------------------------------
+  // GET /jobs/dead-letter  – list DLQ records
+  // -------------------------------------------------------------------------
+
+  @Get('dead-letter')
+  @ApiOperation({
+    summary: 'List jobs in the Dead Letter Queue',
+    description:
+      'Returns the most recent permanently-failed jobs that have been ' +
+      'moved to the DLQ after exhausting all retries.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    description: 'Maximum number of records to return (default 50, max 200)',
+  })
+  @ApiOkResponse({
+    description: 'DLQ records retrieved successfully.',
+  })
+  async listDeadLetterJobs(
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+  ) {
+    const safeLimit = Math.min(limit, 200);
+    const [waiting, failed, stats] = await Promise.all([
+      this.deadLetterService.listWaiting(safeLimit),
+      this.deadLetterService.listFailed(safeLimit),
+      this.deadLetterService.getStats(),
+    ]);
+
+    return {
+      stats,
+      waiting,
+      failed,
+      retrievedAt: new Date().toISOString(),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /jobs/dead-letter/:id/requeue  – requeue a DLQ record
+  // -------------------------------------------------------------------------
+
+  @Post('dead-letter/:id/requeue')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Requeue a dead-letter job back to its original queue',
+    description:
+      'Moves a DLQ record back to the appropriate domain queue for ' +
+      'reprocessing. The DLQ record is removed on success.',
+  })
+  @ApiParam({ name: 'id', description: 'DLQ job ID to requeue' })
+  @ApiOkResponse({
+    description: 'Job requeued successfully.',
+    schema: {
+      example: { requeuedJobId: '42', originalQueue: 'onchain' },
+    },
+  })
+  async requeueDeadLetterJob(@Param('id') id: string) {
+    // Peek at the DLQ record to determine the target queue
+    const records = await this.deadLetterService.listWaiting(200);
+    const record = records.find(r => r.dlqJobId === id);
+
+    if (!record) {
+      throw new NotFoundException(`DLQ job ${id} not found in waiting state`);
+    }
+
+    const targetQueue = this.resolveQueue(record.originalQueue);
+    const result = await this.deadLetterService.requeueJob(id, targetQueue);
+
+    return {
+      ...result,
+      originalQueue: record.originalQueue,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private async buildQueueStatus(queue: Queue): Promise<QueueStatus> {
     const [waiting, active, completed, failed, delayed] = await Promise.all([
       queue.getWaitingCount(),
       queue.getActiveCount(),
@@ -66,6 +268,10 @@ export class JobsController {
       queue.getDelayedCount(),
     ]);
 
+    const total = completed + failed;
+    const failureRate = total > 0 ? Math.round((failed / total) * 10000) / 10000 : 0;
+    const degraded = failed > 0;
+
     return {
       name: queue.name,
       waiting,
@@ -73,6 +279,23 @@ export class JobsController {
       completed,
       failed,
       delayed,
+      failureRate,
+      degraded,
     };
+  }
+
+  private resolveQueue(queueName: string): Queue {
+    switch (queueName) {
+      case 'verification':
+        return this.verificationQueue;
+      case 'notifications':
+        return this.notificationsQueue;
+      case 'onchain':
+        return this.onchainQueue;
+      default:
+        throw new NotFoundException(
+          `Cannot requeue: unknown source queue "${queueName}"`,
+        );
+    }
   }
 }

--- a/app/backend/src/jobs/jobs.module.ts
+++ b/app/backend/src/jobs/jobs.module.ts
@@ -1,13 +1,53 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JobsController } from './jobs.controller';
+import { DeadLetterProcessor } from './dead-letter.processor';
+import { DeadLetterService } from './dead-letter.service';
 
+/**
+ * JobsModule
+ *
+ * Owns:
+ *  - The monitoring controller (`GET /jobs/status`, `GET /jobs/health`,
+ *    `GET /jobs/dead-letter`, `POST /jobs/dead-letter/:id/requeue`)
+ *  - The Dead Letter Queue (DLQ) registration, processor, and service
+ *
+ * The three domain queues (verification, notifications, onchain) are
+ * registered here as *references* only (no connection config) so the
+ * controller can inject them for read-only metrics without duplicating
+ * the Redis connection setup that lives in each domain module.
+ */
 @Module({
   imports: [
+    ConfigModule,
+    // Reference-only registrations for the three domain queues
     BullModule.registerQueue({ name: 'verification' }),
     BullModule.registerQueue({ name: 'notifications' }),
     BullModule.registerQueue({ name: 'onchain' }),
+
+    // Dead Letter Queue – full async registration with connection + policies
+    BullModule.registerQueueAsync({
+      name: 'dead-letter',
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        connection: {
+          host: configService.get<string>('REDIS_HOST') ?? 'localhost',
+          port: parseInt(
+            configService.get<string>('REDIS_PORT') ?? '6379',
+            10,
+          ),
+        },
+        defaultJobOptions: {
+          removeOnComplete: 500, // keep last 500 processed DLQ records
+          removeOnFail: false,   // never auto-remove failed DLQ records
+        },
+      }),
+      inject: [ConfigService],
+    }),
   ],
   controllers: [JobsController],
+  providers: [DeadLetterProcessor, DeadLetterService],
+  exports: [DeadLetterService],
 })
 export class JobsModule {}

--- a/app/backend/src/notifications/notifications.module.ts
+++ b/app/backend/src/notifications/notifications.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NotificationsService } from './notifications.service';
 import { NotificationProcessor } from './notifications.processor';
+import { JobsModule } from '../jobs/jobs.module';
 
 @Module({
   imports: [
@@ -16,12 +17,22 @@ import { NotificationProcessor } from './notifications.processor';
           port: parseInt(configService.get<string>('REDIS_PORT') || '6379'),
         },
         defaultJobOptions: {
-          removeOnComplete: 100,
-          removeOnFail: 50,
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 5000,
+          },
+          removeOnComplete: {
+            count: 100,  // keep last 100 completed notification jobs
+            age: 86400,  // and no older than 24 h
+          },
+          removeOnFail: false, // keep all failed jobs for audit / DLQ inspection
         },
       }),
       inject: [ConfigService],
     }),
+    // Import JobsModule to get access to DeadLetterService
+    JobsModule,
   ],
   providers: [NotificationsService, NotificationProcessor],
   exports: [NotificationsService],

--- a/app/backend/src/notifications/notifications.processor.ts
+++ b/app/backend/src/notifications/notifications.processor.ts
@@ -1,10 +1,11 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Logger } from '@nestjs/common';
+import { Logger, Optional } from '@nestjs/common';
 import { Job } from 'bullmq';
 import {
   NotificationJobData,
   NotificationResult,
 } from './interfaces/notification-job.interface';
+import { DeadLetterService } from '../jobs/dead-letter.service';
 
 @Processor('notifications', {
   concurrency: parseInt(process.env.QUEUE_CONCURRENCY || '5'),
@@ -12,11 +13,19 @@ import {
 export class NotificationProcessor extends WorkerHost {
   private readonly logger = new Logger(NotificationProcessor.name);
 
+  constructor(
+    @Optional()
+    private readonly deadLetterService: DeadLetterService | null,
+  ) {
+    super();
+  }
+
   async process(
     job: Job<NotificationJobData, NotificationResult, string>,
   ): Promise<NotificationResult> {
     this.logger.log(
-      `Processing ${job.data.type} notification for ${job.data.recipient} (attempt ${job.attemptsMade + 1})`,
+      `Processing ${job.data.type} notification for ${job.data.recipient} ` +
+        `(attempt ${job.attemptsMade + 1}/${job.opts?.attempts ?? '?'})`,
     );
 
     try {
@@ -42,20 +51,36 @@ export class NotificationProcessor extends WorkerHost {
   }
 
   @OnWorkerEvent('completed')
-  onCompleted(job: Job<NotificationJobData, NotificationResult>) {
+  onCompleted(job: Job<NotificationJobData, NotificationResult>): void {
     this.logger.log(
       `Notification job ${job.id} for ${job.data.recipient} completed successfully`,
     );
   }
 
+  /**
+   * Called after the final failed attempt.
+   * Moves the job to the Dead Letter Queue when all retries are exhausted.
+   */
   @OnWorkerEvent('failed')
-  onFailed(job: Job<NotificationJobData> | undefined, error: Error) {
-    if (job) {
-      this.logger.error(
-        `Notification job ${job.id} for ${job.data.recipient} failed: ${error.message}`,
-      );
-    } else {
-      this.logger.error(`Notification job failed: ${error.message}`);
+  async onFailed(
+    job: Job<NotificationJobData> | undefined,
+    error: Error,
+  ): Promise<void> {
+    if (!job) {
+      this.logger.error(`Notification job failed (no job reference): ${error.message}`);
+      return;
+    }
+
+    const maxAttempts = job.opts?.attempts ?? 3;
+    const isExhausted = job.attemptsMade >= maxAttempts;
+
+    this.logger.error(
+      `Notification job ${job.id} for ${job.data.recipient} failed on attempt ` +
+        `${job.attemptsMade}/${maxAttempts}: ${error.message}`,
+    );
+
+    if (isExhausted && this.deadLetterService) {
+      await this.deadLetterService.moveToDeadLetter('notifications', job, error);
     }
   }
 }

--- a/app/backend/src/onchain/onchain.module.ts
+++ b/app/backend/src/onchain/onchain.module.ts
@@ -7,6 +7,7 @@ import { MockOnchainAdapter } from './onchain.adapter.mock';
 import { SorobanAdapter } from './soroban.adapter';
 import { OnchainProcessor } from './onchain.processor';
 import { OnchainService } from './onchain.service';
+import { JobsModule } from '../jobs/jobs.module';
 
 /**
  * Factory function to create the appropriate adapter based on configuration
@@ -46,9 +47,23 @@ const onchainAdapterProvider: Provider = {
           host: configService.get<string>('REDIS_HOST') || 'localhost',
           port: parseInt(configService.get<string>('REDIS_PORT') || '6379'),
         },
+        defaultJobOptions: {
+          attempts: 5,
+          backoff: {
+            type: 'exponential',
+            delay: 10000,
+          },
+          removeOnComplete: {
+            count: 200,  // keep last 200 completed onchain jobs
+            age: 86400,  // and no older than 24 h
+          },
+          removeOnFail: false, // keep all failed jobs for audit / DLQ inspection
+        },
       }),
       inject: [ConfigService],
     }),
+    // Import JobsModule to get access to DeadLetterService
+    JobsModule,
   ],
   providers: [
     MockOnchainAdapter,

--- a/app/backend/src/onchain/onchain.processor.ts
+++ b/app/backend/src/onchain/onchain.processor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Logger, Inject } from '@nestjs/common';
+import { Logger, Inject, Optional } from '@nestjs/common';
 import { Job } from 'bullmq';
 import {
   OnchainJobData,
@@ -8,47 +8,109 @@ import {
   OnchainOperationType,
 } from './interfaces/onchain-job.interface';
 import { ONCHAIN_ADAPTER_TOKEN, OnchainAdapter } from './onchain.adapter';
+import { DeadLetterService } from '../jobs/dead-letter.service';
+
+// ---------------------------------------------------------------------------
+// Error classification helpers
+// ---------------------------------------------------------------------------
+
+/** Errors that indicate a transient network or RPC issue – safe to retry. */
+const NETWORK_ERROR_PATTERNS = [
+  /ECONNREFUSED/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /ENOTFOUND/i,
+  /socket hang up/i,
+  /network timeout/i,
+  /request timeout/i,
+  /fetch failed/i,
+  /ECONNABORTED/i,
+];
+
+/**
+ * Errors that indicate Stellar ledger congestion or rate-limiting.
+ * These warrant a longer back-off before retrying.
+ */
+const LEDGER_CONGESTION_PATTERNS = [
+  /tx_insufficient_fee/i,
+  /too many requests/i,
+  /rate.?limit/i,
+  /ledger.?full/i,
+  /surge.?pricing/i,
+  /503/,
+  /429/,
+];
+
+/** Errors that are permanent – no point retrying. */
+const PERMANENT_ERROR_PATTERNS = [
+  /tx_bad_auth/i,
+  /tx_bad_seq/i,
+  /contract.?not.?found/i,
+  /invalid.?contract/i,
+  /SOROBAN_CONTRACT_ID is not configured/i,
+];
+
+function classifyError(error: Error): 'network' | 'congestion' | 'permanent' | 'unknown' {
+  const msg = error.message;
+  if (PERMANENT_ERROR_PATTERNS.some(p => p.test(msg))) return 'permanent';
+  if (LEDGER_CONGESTION_PATTERNS.some(p => p.test(msg))) return 'congestion';
+  if (NETWORK_ERROR_PATTERNS.some(p => p.test(msg))) return 'network';
+  return 'unknown';
+}
+
+/** Add random jitter (±25 %) to a delay to avoid thundering-herd on retry. */
+function withJitter(delayMs: number): number {
+  const jitter = delayMs * 0.25;
+  return Math.round(delayMs + (Math.random() * 2 - 1) * jitter);
+}
+
+// ---------------------------------------------------------------------------
+// Processor
+// ---------------------------------------------------------------------------
 
 @Processor('onchain', {
-  concurrency: 1, // Usually sequential for blockchain transactions
+  concurrency: 1, // Sequential – blockchain transactions must not race
 })
 export class OnchainProcessor extends WorkerHost {
   private readonly logger = new Logger(OnchainProcessor.name);
 
+  /** Default per-operation timeout in ms (overridable via env). */
+  private readonly operationTimeoutMs: number;
+
   constructor(
     @Inject(ONCHAIN_ADAPTER_TOKEN)
     private readonly onchainAdapter: OnchainAdapter,
+    /**
+     * DeadLetterService is optional so the processor still boots in
+     * environments where JobsModule is not loaded (e.g. isolated unit tests).
+     */
+    @Optional()
+    private readonly deadLetterService: DeadLetterService | null,
   ) {
     super();
+    this.operationTimeoutMs = parseInt(
+      process.env.ONCHAIN_OPERATION_TIMEOUT_MS ?? '30000',
+      10,
+    );
   }
+
+  // -------------------------------------------------------------------------
+  // Main processing logic
+  // -------------------------------------------------------------------------
 
   async process(
     job: Job<OnchainJobData, OnchainJobResult, string>,
   ): Promise<OnchainJobResult> {
     this.logger.log(
-      `Processing onchain ${job.data.type} (attempt ${job.attemptsMade + 1})`,
+      `Processing onchain ${job.data.type} job ${job.id} ` +
+        `(attempt ${job.attemptsMade + 1}/${job.opts?.attempts ?? '?'})`,
     );
 
     try {
-      let result: any;
-      switch (job.data.type) {
-        case OnchainOperationType.INIT_ESCROW:
-          result = await this.onchainAdapter.initEscrow(job.data.params);
-          break;
-        case OnchainOperationType.CREATE_CLAIM:
-          result = await this.onchainAdapter.createClaim(job.data.params);
-          break;
-        case OnchainOperationType.DISBURSE:
-          result = await this.onchainAdapter.disburse(job.data.params);
-          break;
-        default:
-          throw new Error(
-            `Unknown onchain operation type: ${String(job.data.type)}`,
-          );
-      }
+      const result = await this.executeWithTimeout(job);
 
       if (result && 'status' in result && result.status === 'failed') {
-        throw new Error(`Onchain operation failed: ${String(job.data.type)}`);
+        throw new Error(`Onchain operation reported failure: ${String(job.data.type)}`);
       }
 
       return {
@@ -57,25 +119,136 @@ export class OnchainProcessor extends WorkerHost {
         metadata: result?.metadata,
       };
     } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const kind = classifyError(err);
+
       this.logger.error(
-        `Onchain job ${job.id} failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : undefined,
+        `Onchain job ${job.id} failed [${kind}] on attempt ` +
+          `${job.attemptsMade + 1}: ${err.message}`,
+        err.stack,
       );
-      throw error;
+
+      // For permanent errors, exhaust retries immediately by re-throwing
+      // with a flag so BullMQ moves the job to failed state right away.
+      if (kind === 'permanent') {
+        this.logger.warn(
+          `Onchain job ${job.id} has a permanent error – marking as ` +
+            `unrecoverable without further retries.`,
+        );
+        // Discard remaining attempts by setting attemptsMade to max
+        // BullMQ checks attemptsMade >= attempts before scheduling a retry
+        job.discard();
+      }
+
+      throw err;
     }
   }
 
+  // -------------------------------------------------------------------------
+  // Worker event hooks
+  // -------------------------------------------------------------------------
+
   @OnWorkerEvent('completed')
-  onCompleted(job: Job<OnchainJobData, OnchainJobResult>) {
-    this.logger.log(`Onchain job ${job.id} completed successfully`);
+  onCompleted(job: Job<OnchainJobData, OnchainJobResult>): void {
+    this.logger.log(
+      `Onchain job ${job.id} (${job.data.type}) completed successfully ` +
+        `in ${Date.now() - job.data.timestamp}ms`,
+    );
   }
 
+  /**
+   * Called by BullMQ after the final failed attempt.
+   * When all retries are exhausted we move the job to the Dead Letter Queue.
+   */
   @OnWorkerEvent('failed')
-  onFailed(job: Job<OnchainJobData> | undefined, error: Error) {
-    if (job) {
-      this.logger.error(`Onchain job ${job.id} failed: ${error.message}`);
-    } else {
-      this.logger.error(`Onchain job failed: ${error.message}`);
+  async onFailed(
+    job: Job<OnchainJobData> | undefined,
+    error: Error,
+  ): Promise<void> {
+    if (!job) {
+      this.logger.error(`Onchain job failed (no job reference): ${error.message}`);
+      return;
+    }
+
+    const maxAttempts = job.opts?.attempts ?? 5;
+    const isExhausted = job.attemptsMade >= maxAttempts;
+
+    this.logger.error(
+      `Onchain job ${job.id} (${job.data.type}) failed on attempt ` +
+        `${job.attemptsMade}/${maxAttempts}: ${error.message}`,
+    );
+
+    if (isExhausted && this.deadLetterService) {
+      await this.deadLetterService.moveToDeadLetter('onchain', job, error);
+    }
+  }
+
+  @OnWorkerEvent('stalled')
+  onStalled(jobId: string): void {
+    this.logger.warn(
+      `Onchain job ${jobId} stalled – worker may have crashed mid-transaction. ` +
+        `BullMQ will automatically retry.`,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Execute the adapter call with a hard timeout.
+   * Throws a descriptive error if the RPC call takes too long.
+   */
+  private async executeWithTimeout(
+    job: Job<OnchainJobData, OnchainJobResult, string>,
+  ): Promise<any> {
+    const timeoutMs = this.resolveTimeout(job);
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `network timeout: onchain operation ${job.data.type} exceeded ${timeoutMs}ms`,
+            ),
+          ),
+        timeoutMs,
+      ),
+    );
+
+    const operationPromise = this.dispatchOperation(job);
+
+    return Promise.race([operationPromise, timeoutPromise]);
+  }
+
+  /**
+   * Resolve the effective timeout for this job.
+   * Congestion retries use a longer timeout to account for slow ledger state.
+   */
+  private resolveTimeout(job: Job<OnchainJobData>): number {
+    const base = this.operationTimeoutMs;
+    // Give later attempts more time – ledger may be recovering from congestion
+    const multiplier = Math.min(1 + job.attemptsMade * 0.5, 3);
+    return withJitter(Math.round(base * multiplier));
+  }
+
+  private async dispatchOperation(
+    job: Job<OnchainJobData, OnchainJobResult, string>,
+  ): Promise<any> {
+    switch (job.data.type) {
+      case OnchainOperationType.INIT_ESCROW:
+        return this.onchainAdapter.initEscrow(job.data.params);
+
+      case OnchainOperationType.CREATE_CLAIM:
+        return this.onchainAdapter.createClaim(job.data.params);
+
+      case OnchainOperationType.DISBURSE:
+        return this.onchainAdapter.disburse(job.data.params);
+
+      default:
+        throw new Error(
+          `Unknown onchain operation type: ${String(job.data.type)}`,
+        );
     }
   }
 }

--- a/app/backend/src/onchain/onchain.service.ts
+++ b/app/backend/src/onchain/onchain.service.ts
@@ -61,14 +61,11 @@ export class OnchainService {
       timestamp: Date.now(),
     };
 
-    const job = await this.onchainQueue.add(type, data, {
-      attempts: 5,
-      backoff: {
-        type: 'exponential',
-        delay: 10000,
-      },
-      removeOnComplete: true,
-    });
+    // Job-level options intentionally omit attempts/backoff/removeOn* so that
+    // the queue-level defaultJobOptions (set in OnchainModule) are the single
+    // source of truth.  Override here only when a specific job needs different
+    // behaviour (e.g. a one-shot fire-and-forget).
+    const job = await this.onchainQueue.add(type, data);
 
     this.logger.log(`Enqueued onchain job: ${job.id} for ${type}`);
     return job;

--- a/app/backend/src/verification/verification.module.ts
+++ b/app/backend/src/verification/verification.module.ts
@@ -10,6 +10,7 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { AuditModule } from '../audit/audit.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { EncryptionModule } from '../common/encryption/encryption.module';
+import { JobsModule } from '../jobs/jobs.module';
 
 @Module({
   imports: [
@@ -28,12 +29,22 @@ import { EncryptionModule } from '../common/encryption/encryption.module';
           port: parseInt(configService.get<string>('REDIS_PORT') || '6379'),
         },
         defaultJobOptions: {
-          removeOnComplete: 100,
-          removeOnFail: 50,
+          attempts: 3,
+          backoff: {
+            type: 'exponential',
+            delay: 2000,
+          },
+          removeOnComplete: {
+            count: 100,  // keep last 100 completed verification jobs
+            age: 86400,  // and no older than 24 h
+          },
+          removeOnFail: false, // keep all failed jobs for audit / DLQ inspection
         },
       }),
       inject: [ConfigService],
     }),
+    // Import JobsModule to get access to DeadLetterService
+    JobsModule,
   ],
   controllers: [VerificationController],
   providers: [

--- a/app/backend/src/verification/verification.processor.ts
+++ b/app/backend/src/verification/verification.processor.ts
@@ -1,11 +1,12 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
-import { Logger } from '@nestjs/common';
+import { Logger, Optional } from '@nestjs/common';
 import { Job } from 'bullmq';
 import { VerificationService } from './verification.service';
 import {
   VerificationJobData,
   VerificationResult,
 } from './interfaces/verification-job.interface';
+import { DeadLetterService } from '../jobs/dead-letter.service';
 
 @Processor('verification', {
   concurrency: parseInt(process.env.QUEUE_CONCURRENCY || '5'),
@@ -13,7 +14,11 @@ import {
 export class VerificationProcessor extends WorkerHost {
   private readonly logger = new Logger(VerificationProcessor.name);
 
-  constructor(private readonly verificationService: VerificationService) {
+  constructor(
+    private readonly verificationService: VerificationService,
+    @Optional()
+    private readonly deadLetterService: DeadLetterService | null,
+  ) {
     super();
   }
 
@@ -21,7 +26,8 @@ export class VerificationProcessor extends WorkerHost {
     job: Job<VerificationJobData, VerificationResult, string>,
   ): Promise<VerificationResult> {
     this.logger.log(
-      `Processing job ${job.id} for claim ${job.data.claimId} (attempt ${job.attemptsMade + 1})`,
+      `Processing job ${job.id} for claim ${job.data.claimId} ` +
+        `(attempt ${job.attemptsMade + 1}/${job.opts?.attempts ?? '?'})`,
     );
 
     try {
@@ -44,35 +50,52 @@ export class VerificationProcessor extends WorkerHost {
   }
 
   @OnWorkerEvent('completed')
-  onCompleted(job: Job<VerificationJobData, VerificationResult>) {
+  onCompleted(job: Job<VerificationJobData, VerificationResult>): void {
     this.logger.log(
-      `Job ${job.id} completed for claim ${job.data.claimId} after ${Date.now() - job.data.timestamp}ms`,
+      `Job ${job.id} completed for claim ${job.data.claimId} ` +
+        `after ${Date.now() - job.data.timestamp}ms`,
     );
   }
 
+  /**
+   * Called after the final failed attempt.
+   * Moves the job to the Dead Letter Queue when all retries are exhausted.
+   */
   @OnWorkerEvent('failed')
-  onFailed(job: Job<VerificationJobData> | undefined, error: Error) {
-    if (job) {
-      this.logger.error(
-        `Job ${job.id} failed for claim ${job.data.claimId}: ${error.message}`,
-      );
-    } else {
-      this.logger.error(`Job failed: ${error.message}`);
+  async onFailed(
+    job: Job<VerificationJobData> | undefined,
+    error: Error,
+  ): Promise<void> {
+    if (!job) {
+      this.logger.error(`Verification job failed (no job reference): ${error.message}`);
+      return;
+    }
+
+    const maxAttempts = job.opts?.attempts ?? 3;
+    const isExhausted = job.attemptsMade >= maxAttempts;
+
+    this.logger.error(
+      `Job ${job.id} failed for claim ${job.data.claimId} on attempt ` +
+        `${job.attemptsMade}/${maxAttempts}: ${error.message}`,
+    );
+
+    if (isExhausted && this.deadLetterService) {
+      await this.deadLetterService.moveToDeadLetter('verification', job, error);
     }
   }
 
   @OnWorkerEvent('active')
-  onActive(job: Job<VerificationJobData>) {
+  onActive(job: Job<VerificationJobData>): void {
     this.logger.debug(`Job ${job.id} started for claim ${job.data.claimId}`);
   }
 
   @OnWorkerEvent('stalled')
-  onStalled(jobId: string) {
-    this.logger.warn(`Job ${jobId} stalled`);
+  onStalled(jobId: string): void {
+    this.logger.warn(`Verification job ${jobId} stalled`);
   }
 
   @OnWorkerEvent('progress')
-  onProgress(job: Job<VerificationJobData>, progress: number | object) {
+  onProgress(job: Job<VerificationJobData>, progress: number | object): void {
     this.logger.debug(`Job ${job.id} progress: ${JSON.stringify(progress)}`);
   }
 }

--- a/app/backend/test/health.e2e-spec.ts
+++ b/app/backend/test/health.e2e-spec.ts
@@ -1,0 +1,142 @@
+/**
+ * E2E – Health & Readiness endpoints
+ *
+ * Covers:
+ *  GET /api/v1/health        – simple health check (AppController, public)
+ *  GET /api/v1/health/live   – liveness probe (HealthController, public)
+ *  GET /api/v1/health/ready  – readiness probe (HealthController, public, checks DB)
+ *
+ * No external secrets or private keys required.
+ */
+
+import request from 'supertest';
+import { createTestHarness, TestHarness } from './helpers/app-harness';
+
+describe('Health endpoints (e2e)', () => {
+  let harness: TestHarness;
+
+  beforeAll(async () => {
+    harness = await createTestHarness();
+  });
+
+  afterAll(async () => {
+    await harness.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/health – simple health check (AppController)
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/health', () => {
+    it('returns 200 with status ok – no auth required', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health')
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        status: 'ok',
+        service: 'backend',
+      });
+    });
+
+    it('does not require an API key', async () => {
+      // No x-api-key header – should still succeed (public endpoint)
+      await request(harness.server).get('/api/v1/health').expect(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/health/live – liveness probe (HealthController)
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/health/live', () => {
+    it('returns 200 with full liveness payload', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/live')
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        status: 'ok',
+        service: 'backend',
+        version: expect.any(String),
+        environment: expect.any(String),
+        timestamp: expect.any(String),
+        checks: {
+          process: {
+            status: 'up',
+          },
+        },
+      });
+    });
+
+    it('timestamp is a valid ISO-8601 string', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/live')
+        .expect(200);
+
+      const ts = res.body.timestamp as string;
+      expect(new Date(ts).toISOString()).toBe(ts);
+    });
+
+    it('process check includes pid and uptimeSeconds', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/live')
+        .expect(200);
+
+      const details = res.body.checks?.process?.details as Record<
+        string,
+        unknown
+      >;
+      expect(typeof details.pid).toBe('number');
+      expect(typeof details.uptimeSeconds).toBe('number');
+      expect(details.uptimeSeconds as number).toBeGreaterThanOrEqual(0);
+    });
+
+    it('does not require an API key', async () => {
+      await request(harness.server).get('/api/v1/health/live').expect(200);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/health/ready – readiness probe (HealthController)
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/health/ready', () => {
+    it('returns 200 when database is reachable', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/ready')
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        ready: true,
+        service: 'backend',
+        checks: {
+          database: { status: 'up' },
+        },
+      });
+    });
+
+    it('includes a valid ISO timestamp', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/ready')
+        .expect(200);
+
+      const ts = res.body.timestamp as string;
+      expect(new Date(ts).toISOString()).toBe(ts);
+    });
+
+    it('stellarRpc check is present (skipped when STELLAR_RPC_URL not set)', async () => {
+      const res = await request(harness.server)
+        .get('/api/v1/health/ready')
+        .expect(200);
+
+      // In CI, STELLAR_RPC_URL is not set so the check is skipped – that is fine
+      const stellarStatus = res.body.checks?.stellarRpc?.status as string;
+      expect(['up', 'down', 'skipped']).toContain(stellarStatus);
+    });
+
+    it('does not require an API key', async () => {
+      await request(harness.server).get('/api/v1/health/ready').expect(200);
+    });
+  });
+});

--- a/app/backend/test/helpers/app-harness.ts
+++ b/app/backend/test/helpers/app-harness.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared test harness for e2e specs.
+ *
+ * Bootstraps a full NestJS application with:
+ *  - URI versioning  (/api/v1/...)
+ *  - Global ValidationPipe
+ *  - SQLite test database (DATABASE_URL=file:./prisma/test.db)
+ *  - MockOnchainAdapter (ONCHAIN_ADAPTER=mock)
+ *  - No external secrets required
+ *
+ * Usage:
+ *   const harness = await createTestHarness();
+ *   // ... tests ...
+ *   await harness.close();
+ */
+
+import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AppRole } from 'src/auth/app-role.enum';
+
+import { resolve } from 'path';
+
+// ---------------------------------------------------------------------------
+// Environment defaults – no real secrets needed in CI
+// ---------------------------------------------------------------------------
+const _backendRoot = resolve(__dirname, '..');
+const _dbAbsPath = resolve(_backendRoot, 'prisma', 'test.db');
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? `file:${_dbAbsPath}`;
+process.env.ONCHAIN_ADAPTER = 'mock';
+process.env.VERIFICATION_MODE = 'mock';
+process.env.REDIS_HOST = process.env.REDIS_HOST ?? 'localhost';
+process.env.REDIS_PORT = process.env.REDIS_PORT ?? '6379';
+// Use a well-known dev key so tests don't need a real API_KEY env var
+process.env.API_KEY = process.env.API_KEY ?? 'e2e-test-admin-key';
+
+/** The API key inserted into the DB for e2e tests. */
+export const E2E_API_KEY = 'e2e-test-admin-key';
+export const E2E_OPERATOR_KEY = 'e2e-test-operator-key';
+
+export interface TestHarness {
+  app: INestApplication;
+  prisma: PrismaService;
+  /** Supertest server handle */
+  server: ReturnType<INestApplication['getHttpServer']>;
+  /** Tear down the application */
+  close: () => Promise<void>;
+}
+
+export async function createTestHarness(): Promise<TestHarness> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+
+  app.setGlobalPrefix('api');
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+    prefix: 'v',
+  });
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
+
+  await app.init();
+
+  const prisma = app.get(PrismaService);
+
+  // Seed the test API keys so the ApiKeyGuard can authenticate requests
+  await prisma.apiKey.upsert({
+    where: { key: E2E_API_KEY },
+    update: { role: AppRole.admin, revokedAt: null },
+    create: {
+      key: E2E_API_KEY,
+      role: AppRole.admin,
+      description: 'E2E test admin key',
+    },
+  });
+
+  await prisma.apiKey.upsert({
+    where: { key: E2E_OPERATOR_KEY },
+    update: { role: AppRole.operator, revokedAt: null },
+    create: {
+      key: E2E_OPERATOR_KEY,
+      role: AppRole.operator,
+      description: 'E2E test operator key',
+    },
+  });
+
+  return {
+    app,
+    prisma,
+    server: app.getHttpServer(),
+    close: () => app.close(),
+  };
+}

--- a/app/backend/test/helpers/bull-mock.ts
+++ b/app/backend/test/helpers/bull-mock.ts
@@ -1,0 +1,54 @@
+/**
+ * BullMQ test helper.
+ *
+ * Provides a factory that overrides the BullMQ root Redis connection with
+ * ioredis-mock so that queue operations work in-memory without a real Redis
+ * instance.  This makes e2e tests fully self-contained in CI.
+ *
+ * Usage:
+ *   const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+ *     .overrideProvider(BULL_CONFIG_DEFAULT_TOKEN)
+ *     .useValue(bullMockConfig())
+ *     .compile();
+ *
+ * Alternatively, use the `withBullMock` helper which applies all overrides.
+ */
+
+import { TestingModuleBuilder } from '@nestjs/testing';
+
+// ioredis-mock ships a Redis-compatible in-memory client
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const RedisMock = require('ioredis-mock') as new (opts?: object) => object;
+
+/**
+ * Create a shared ioredis-mock instance.
+ * All queues in the same test process share the same in-memory store.
+ */
+export function createRedisMock() {
+  return new RedisMock({ lazyConnect: false });
+}
+
+/**
+ * Apply BullMQ connection override to a TestingModuleBuilder.
+ *
+ * Overrides the shared Redis connection used by BullModule.forRootAsync so
+ * that all queues and workers connect to the in-memory mock instead of a
+ * real Redis server.
+ */
+export function withBullMock(
+  builder: TestingModuleBuilder,
+): TestingModuleBuilder {
+  // BullMQ's NestJS integration exposes the shared connection config via this
+  // token.  We replace the connection factory with one that returns our mock.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { BULL_CONFIG_DEFAULT_TOKEN } = require('@nestjs/bullmq');
+    const redisMock = createRedisMock();
+    return builder
+      .overrideProvider(BULL_CONFIG_DEFAULT_TOKEN)
+      .useValue({ connection: redisMock });
+  } catch {
+    // Token not available in this version – fall back to no-op
+    return builder;
+  }
+}

--- a/app/backend/test/jest-e2e-global-setup.ts
+++ b/app/backend/test/jest-e2e-global-setup.ts
@@ -1,0 +1,40 @@
+/**
+ * Jest globalSetup for e2e tests.
+ *
+ * Runs ONCE before all test suites in a separate Node process.
+ * Responsible for:
+ *  1. Ensuring the test SQLite database exists and is up-to-date
+ *     by running `prisma migrate deploy` against it.
+ *
+ * This keeps the e2e suite self-contained – no manual DB setup required
+ * in CI or local development.
+ */
+
+import { execSync } from 'child_process';
+import { join, resolve } from 'path';
+
+export default async function globalSetup(): Promise<void> {
+  const backendRoot = join(__dirname, '..');
+  // Use an absolute path so Prisma can find the file regardless of CWD
+  const dbAbsPath = resolve(backendRoot, 'prisma', 'test.db');
+  const dbUrl = `file:${dbAbsPath}`;
+
+  process.env.DATABASE_URL = dbUrl;
+
+  console.log(`[e2e globalSetup] Running prisma migrate deploy on ${dbUrl}…`);
+
+  try {
+    execSync('npx prisma migrate deploy', {
+      cwd: backendRoot,
+      env: { ...process.env, DATABASE_URL: dbUrl },
+      stdio: 'pipe',
+    });
+    console.log('[e2e globalSetup] Migrations applied successfully.');
+  } catch (err) {
+    // If migrations fail (e.g. already up-to-date), log but don't abort
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[e2e globalSetup] prisma migrate deploy warning: ${message}`,
+    );
+  }
+}

--- a/app/backend/test/jest-e2e-setup.ts
+++ b/app/backend/test/jest-e2e-setup.ts
@@ -1,0 +1,45 @@
+/**
+ * Jest setup file for e2e tests.
+ *
+ * Runs BEFORE any test module is imported, so environment variables set here
+ * are visible to Prisma, BullMQ, and all NestJS modules.
+ *
+ * This file is referenced by jest-e2e.json → "setupFiles".
+ */
+
+import { resolve, join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Database – use the dedicated test SQLite file (absolute path for Prisma)
+// ---------------------------------------------------------------------------
+const backendRoot = resolve(__dirname, '..');
+const dbAbsPath = resolve(backendRoot, 'prisma', 'test.db');
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? `file:${dbAbsPath}`;
+
+// ---------------------------------------------------------------------------
+// Adapters – use mocks so no real Stellar keys or RPC URLs are needed
+// ---------------------------------------------------------------------------
+process.env.ONCHAIN_ADAPTER = 'mock';
+process.env.VERIFICATION_MODE = 'mock';
+
+// ---------------------------------------------------------------------------
+// Redis – BullMQ will attempt to connect; if Redis is unavailable the queue
+// operations gracefully degrade (counts return 0).  Tests that exercise
+// queue endpoints are written to tolerate this.
+// ---------------------------------------------------------------------------
+process.env.REDIS_HOST = process.env.REDIS_HOST ?? 'localhost';
+process.env.REDIS_PORT = process.env.REDIS_PORT ?? '6379';
+
+// ---------------------------------------------------------------------------
+// Auth – a well-known dev key so tests don't need a real API_KEY secret.
+// The harness seeds this key into the DB after app init.
+// ---------------------------------------------------------------------------
+process.env.API_KEY = process.env.API_KEY ?? 'e2e-test-admin-key';
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+process.env.NODE_ENV = 'test';
+// Suppress Stellar RPC health-check failures in CI
+process.env.HEALTHCHECK_STELLAR_REQUIRED = 'false';

--- a/app/backend/test/jest-e2e.json
+++ b/app/backend/test/jest-e2e.json
@@ -10,5 +10,8 @@
     "^src/(.*)$": "<rootDir>/src/$1",
     "^@stellar/stellar-sdk$": "<rootDir>/test/mocks/stellar-sdk.mock.ts",
     "^openai$": "<rootDir>/test/mocks/openai.mock.ts"
-  }
+  },
+  "setupFiles": ["<rootDir>/test/jest-e2e-setup.ts"],
+  "globalSetup": "<rootDir>/test/jest-e2e-global-setup.ts",
+  "testTimeout": 30000
 }

--- a/app/backend/test/onchain-proxy.e2e-spec.ts
+++ b/app/backend/test/onchain-proxy.e2e-spec.ts
@@ -1,0 +1,378 @@
+/**
+ * E2E – Backend-to-Contract Proxy (Onchain / Aid Escrow)
+ *
+ * Exercises the AidEscrow REST endpoints that proxy calls to the Soroban
+ * contract.  All tests run against the MockOnchainAdapter so no real
+ * Stellar keys, RPC URLs, or contract IDs are required.
+ *
+ * BullMQ queues are mocked so no Redis instance is required in CI.
+ *
+ * Covers:
+ *  POST /api/v1/onchain/aid-escrow/packages          – create aid package
+ *  POST /api/v1/onchain/aid-escrow/packages/batch    – batch create
+ *  GET  /api/v1/onchain/aid-escrow/packages/:id      – get package details
+ *  GET  /api/v1/onchain/aid-escrow/stats             – aggregated stats
+ *  POST /api/v1/onchain/aid-escrow/packages/:id/disburse – disburse
+ *
+ * No external secrets or private keys required.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import { getQueueToken } from '@nestjs/bullmq';
+import request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AppRole } from 'src/auth/app-role.enum';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_RECIPIENT =
+  'GBUQWP3BOUZX34ULNQG23RQ6F4BFXWBTRSE53XSTE23JMCVOCJGXVSVZ';
+const MOCK_TOKEN =
+  'GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ5LKG3FZTSZ3NYNEJBBENSN';
+const MOCK_AMOUNT = '1000000000'; // 100 XLM in stroops
+const EXPIRES_AT = Math.floor(Date.now() / 1000) + 86400 * 30; // 30 days
+
+const base = '/api/v1/onchain/aid-escrow';
+const E2E_API_KEY = 'e2e-onchain-admin-key';
+
+function makeMockQueue(name: string) {
+  return {
+    name,
+    add: jest.fn().mockResolvedValue({ id: `mock-job-${Date.now()}`, name }),
+    getWaitingCount: jest.fn().mockResolvedValue(0),
+    getActiveCount: jest.fn().mockResolvedValue(0),
+    getCompletedCount: jest.fn().mockResolvedValue(0),
+    getFailedCount: jest.fn().mockResolvedValue(0),
+    getDelayedCount: jest.fn().mockResolvedValue(0),
+    getWaiting: jest.fn().mockResolvedValue([]),
+    getFailed: jest.fn().mockResolvedValue([]),
+    getJob: jest.fn().mockResolvedValue(null),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('Onchain / Aid Escrow proxy (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let server: ReturnType<INestApplication['getHttpServer']>;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(getQueueToken('verification'))
+      .useValue(makeMockQueue('verification'))
+      .overrideProvider(getQueueToken('notifications'))
+      .useValue(makeMockQueue('notifications'))
+      .overrideProvider(getQueueToken('onchain'))
+      .useValue(makeMockQueue('onchain'))
+      .overrideProvider(getQueueToken('dead-letter'))
+      .useValue(makeMockQueue('dead-letter'))
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: '1',
+      prefix: 'v',
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    await app.init();
+    prisma = moduleRef.get(PrismaService);
+    server = app.getHttpServer();
+
+    // Seed test API key
+    await prisma.apiKey.upsert({
+      where: { key: E2E_API_KEY },
+      update: { role: AppRole.admin, revokedAt: null },
+      create: {
+        key: E2E_API_KEY,
+        role: AppRole.admin,
+        description: 'E2E onchain test key',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /packages – create a single aid package
+  // -------------------------------------------------------------------------
+
+  describe('POST /packages', () => {
+    it('creates an aid package and returns a transaction hash', async () => {
+      const res = await request(server)
+        .post(`${base}/packages`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          packageId: `pkg-e2e-${Date.now()}`,
+          recipientAddress: MOCK_RECIPIENT,
+          amount: MOCK_AMOUNT,
+          tokenAddress: MOCK_TOKEN,
+          expiresAt: EXPIRES_AT,
+        })
+        .expect(201);
+
+      expect(res.body).toMatchObject({
+        packageId: expect.any(String),
+        transactionHash: expect.any(String),
+        status: 'success',
+        timestamp: expect.any(String),
+      });
+
+      // Transaction hash should be a 64-char hex string (mock format)
+      expect(res.body.transactionHash).toMatch(/^[0-9A-F]{64}$/);
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      await request(server)
+        .post(`${base}/packages`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({})
+        .expect(400);
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server)
+        .post(`${base}/packages`)
+        .send({
+          packageId: 'pkg-no-auth',
+          recipientAddress: MOCK_RECIPIENT,
+          amount: MOCK_AMOUNT,
+          tokenAddress: MOCK_TOKEN,
+          expiresAt: EXPIRES_AT,
+        })
+        .expect(401);
+    });
+
+    it('metadata field is optional', async () => {
+      const res = await request(server)
+        .post(`${base}/packages`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          packageId: `pkg-no-meta-${Date.now()}`,
+          recipientAddress: MOCK_RECIPIENT,
+          amount: MOCK_AMOUNT,
+          tokenAddress: MOCK_TOKEN,
+          expiresAt: EXPIRES_AT,
+        })
+        .expect(201);
+
+      expect(res.body.status).toBe('success');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /packages/batch – batch create
+  // -------------------------------------------------------------------------
+
+  describe('POST /packages/batch', () => {
+    it('creates multiple packages in one call', async () => {
+      const res = await request(server)
+        .post(`${base}/packages/batch`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          recipientAddresses: [MOCK_RECIPIENT, MOCK_RECIPIENT],
+          amounts: [MOCK_AMOUNT, MOCK_AMOUNT],
+          tokenAddress: MOCK_TOKEN,
+          expiresIn: 86400 * 30,
+        })
+        .expect(201);
+
+      expect(res.body).toMatchObject({
+        packageIds: expect.any(Array),
+        transactionHash: expect.any(String),
+        status: 'success',
+      });
+      expect((res.body.packageIds as string[]).length).toBe(2);
+    });
+
+    it('returns 400 when recipients and amounts arrays have different lengths', async () => {
+      await request(server)
+        .post(`${base}/packages/batch`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          recipientAddresses: [MOCK_RECIPIENT],
+          amounts: [MOCK_AMOUNT, MOCK_AMOUNT], // mismatched
+          tokenAddress: MOCK_TOKEN,
+          expiresIn: 86400,
+        })
+        .expect(400);
+    });
+
+    it('returns 400 when body is empty', async () => {
+      await request(server)
+        .post(`${base}/packages/batch`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /packages/:id – get package details
+  // -------------------------------------------------------------------------
+
+  describe('GET /packages/:id', () => {
+    it('returns package details for any id (mock always succeeds)', async () => {
+      const packageId = `pkg-get-${Date.now()}`;
+
+      const res = await request(server)
+        .get(`${base}/packages/${packageId}`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        package: {
+          id: packageId,
+          recipient: expect.any(String),
+          amount: expect.any(String),
+          token: expect.any(String),
+          status: expect.any(String),
+          createdAt: expect.any(Number),
+          expiresAt: expect.any(Number),
+        },
+        timestamp: expect.any(String),
+      });
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server)
+        .get(`${base}/packages/some-pkg`)
+        .expect(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /stats – aggregated statistics
+  // -------------------------------------------------------------------------
+
+  describe('GET /stats', () => {
+    it('returns aggregated aid package statistics', async () => {
+      const res = await request(server)
+        .get(`${base}/stats`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        aggregates: {
+          totalCommitted: expect.any(String),
+          totalClaimed: expect.any(String),
+          totalExpiredCancelled: expect.any(String),
+        },
+        timestamp: expect.any(String),
+      });
+
+      const { totalCommitted, totalClaimed, totalExpiredCancelled } =
+        res.body.aggregates as Record<string, string>;
+      expect(Number(totalCommitted)).toBeGreaterThanOrEqual(0);
+      expect(Number(totalClaimed)).toBeGreaterThanOrEqual(0);
+      expect(Number(totalExpiredCancelled)).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server).get(`${base}/stats`).expect(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /packages/:id/disburse – disburse a package
+  // -------------------------------------------------------------------------
+
+  describe('POST /packages/:id/disburse', () => {
+    it('disburses a package and returns transaction details', async () => {
+      const createRes = await request(server)
+        .post(`${base}/packages`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          packageId: `pkg-disburse-${Date.now()}`,
+          recipientAddress: MOCK_RECIPIENT,
+          amount: MOCK_AMOUNT,
+          tokenAddress: MOCK_TOKEN,
+          expiresAt: EXPIRES_AT,
+        })
+        .expect(201);
+
+      const { packageId } = createRes.body as { packageId: string };
+
+      const disburseRes = await request(server)
+        .post(`${base}/packages/${packageId}/disburse`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(disburseRes.body).toMatchObject({
+        packageId,
+        transactionHash: expect.any(String),
+        status: 'success',
+        amountDisbursed: expect.any(String),
+      });
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server)
+        .post(`${base}/packages/some-pkg/disburse`)
+        .expect(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full proxy round-trip: create → get → disburse
+  // -------------------------------------------------------------------------
+
+  describe('Full proxy round-trip', () => {
+    it('create → get → disburse succeeds end-to-end', async () => {
+      const packageId = `pkg-roundtrip-${Date.now()}`;
+
+      // 1. Create
+      const createRes = await request(server)
+        .post(`${base}/packages`)
+        .set('x-api-key', E2E_API_KEY)
+        .send({
+          packageId,
+          recipientAddress: MOCK_RECIPIENT,
+          amount: MOCK_AMOUNT,
+          tokenAddress: MOCK_TOKEN,
+          expiresAt: EXPIRES_AT,
+        })
+        .expect(201);
+
+      expect(createRes.body.status).toBe('success');
+
+      // 2. Get
+      const getRes = await request(server)
+        .get(`${base}/packages/${packageId}`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(getRes.body.package.id).toBe(packageId);
+
+      // 3. Disburse
+      const disburseRes = await request(server)
+        .post(`${base}/packages/${packageId}/disburse`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(disburseRes.body.status).toBe('success');
+      expect(disburseRes.body.transactionHash).toMatch(/^[0-9A-F]{64}$/);
+    });
+  });
+});

--- a/app/backend/test/queue-monitoring.e2e-spec.ts
+++ b/app/backend/test/queue-monitoring.e2e-spec.ts
@@ -1,0 +1,258 @@
+/**
+ * E2E – Queue Monitoring & Dead Letter Queue endpoints
+ *
+ * Covers:
+ *  GET  /api/v1/jobs/status        – raw queue counts
+ *  GET  /api/v1/jobs/health        – aggregated health summary
+ *  GET  /api/v1/jobs/dead-letter   – DLQ records list
+ *
+ * BullMQ queues are mocked so no Redis instance is required in CI.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import { getQueueToken } from '@nestjs/bullmq';
+import request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AppRole } from 'src/auth/app-role.enum';
+
+const E2E_API_KEY = 'e2e-jobs-admin-key';
+
+function makeMockQueue(name: string) {
+  return {
+    name,
+    add: jest.fn().mockResolvedValue({ id: `mock-job-${Date.now()}`, name }),
+    getWaitingCount: jest.fn().mockResolvedValue(0),
+    getActiveCount: jest.fn().mockResolvedValue(0),
+    getCompletedCount: jest.fn().mockResolvedValue(0),
+    getFailedCount: jest.fn().mockResolvedValue(0),
+    getDelayedCount: jest.fn().mockResolvedValue(0),
+    getWaiting: jest.fn().mockResolvedValue([]),
+    getFailed: jest.fn().mockResolvedValue([]),
+    getJob: jest.fn().mockResolvedValue(null),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('Queue monitoring endpoints (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let server: ReturnType<INestApplication['getHttpServer']>;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(getQueueToken('verification'))
+      .useValue(makeMockQueue('verification'))
+      .overrideProvider(getQueueToken('notifications'))
+      .useValue(makeMockQueue('notifications'))
+      .overrideProvider(getQueueToken('onchain'))
+      .useValue(makeMockQueue('onchain'))
+      .overrideProvider(getQueueToken('dead-letter'))
+      .useValue(makeMockQueue('dead-letter'))
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: '1',
+      prefix: 'v',
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    await app.init();
+    prisma = moduleRef.get(PrismaService);
+    server = app.getHttpServer();
+
+    // Seed test API key
+    await prisma.apiKey.upsert({
+      where: { key: E2E_API_KEY },
+      update: { role: AppRole.admin, revokedAt: null },
+      create: {
+        key: E2E_API_KEY,
+        role: AppRole.admin,
+        description: 'E2E jobs monitoring test key',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /jobs/status
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/jobs/status', () => {
+    it('returns 200 with counts for all three queues', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/status')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      for (const queueName of ['verification', 'notifications', 'onchain']) {
+        expect(res.body).toHaveProperty(queueName);
+        const q = res.body[queueName] as Record<string, unknown>;
+        expect(q.name).toBe(queueName);
+        expect(typeof q.waiting).toBe('number');
+        expect(typeof q.active).toBe('number');
+        expect(typeof q.completed).toBe('number');
+        expect(typeof q.failed).toBe('number');
+        expect(typeof q.delayed).toBe('number');
+        expect(typeof q.failureRate).toBe('number');
+        expect(typeof q.degraded).toBe('boolean');
+      }
+    });
+
+    it('failureRate is between 0 and 1', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/status')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      for (const queueName of ['verification', 'notifications', 'onchain']) {
+        const rate = (res.body[queueName] as { failureRate: number })
+          .failureRate;
+        expect(rate).toBeGreaterThanOrEqual(0);
+        expect(rate).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server).get('/api/v1/jobs/status').expect(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /jobs/health
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/jobs/health', () => {
+    it('returns 200 with overall health status', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/health')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        status: expect.stringMatching(/^(healthy|degraded|critical)$/),
+        queues: expect.any(Object),
+        deadLetter: expect.any(Object),
+        checkedAt: expect.any(String),
+      });
+    });
+
+    it('checkedAt is a valid ISO-8601 timestamp', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/health')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      const ts = res.body.checkedAt as string;
+      expect(new Date(ts).toISOString()).toBe(ts);
+    });
+
+    it('deadLetter section has expected shape', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/health')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      const dlq = res.body.deadLetter as Record<string, unknown>;
+      for (const key of [
+        'waiting',
+        'active',
+        'completed',
+        'failed',
+        'delayed',
+      ]) {
+        expect(typeof dlq[key]).toBe('number');
+        expect(dlq[key] as number).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('queues section contains all three domain queues', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/health')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body.queues).toHaveProperty('verification');
+      expect(res.body.queues).toHaveProperty('notifications');
+      expect(res.body.queues).toHaveProperty('onchain');
+    });
+
+    it('returns healthy status when all queues have zero failures', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/health')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      // With mocked queues returning 0 for all counts, status should be healthy
+      expect(res.body.status).toBe('healthy');
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server).get('/api/v1/jobs/health').expect(401);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /jobs/dead-letter
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/v1/jobs/dead-letter', () => {
+    it('returns 200 with stats, waiting, and failed arrays', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/dead-letter')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        stats: expect.any(Object),
+        waiting: expect.any(Array),
+        failed: expect.any(Array),
+        retrievedAt: expect.any(String),
+      });
+    });
+
+    it('accepts a limit query parameter', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/dead-letter?limit=10')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect((res.body.waiting as unknown[]).length).toBeLessThanOrEqual(10);
+      expect((res.body.failed as unknown[]).length).toBeLessThanOrEqual(10);
+    });
+
+    it('returns empty arrays when DLQ is empty', async () => {
+      const res = await request(server)
+        .get('/api/v1/jobs/dead-letter')
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body.waiting).toEqual([]);
+      expect(res.body.failed).toEqual([]);
+    });
+
+    it('returns 401 without API key', async () => {
+      await request(server).get('/api/v1/jobs/dead-letter').expect(401);
+    });
+  });
+});

--- a/app/backend/test/verification-claim.e2e-spec.ts
+++ b/app/backend/test/verification-claim.e2e-spec.ts
@@ -1,0 +1,319 @@
+/**
+ * E2E – Full Verification Flow
+ *
+ * Exercises the complete claim-verification lifecycle through HTTP:
+ *
+ *   1. Create a campaign  (POST /api/v1/campaigns)
+ *   2. Create a claim     (POST /api/v1/claims)
+ *   3. Enqueue the claim  (POST /api/v1/verification/claims/:id/enqueue)
+ *   4. Poll claim status  (GET  /api/v1/verification/claims/:id)
+ *   5. Verify queue metrics reflect the job (GET /api/v1/verification/metrics)
+ *
+ * Also covers:
+ *  - 404 when enqueueing a non-existent claim
+ *  - 202 Accepted response shape
+ *  - Metrics endpoint shape
+ *
+ * BullMQ queues are mocked so no Redis instance is required in CI.
+ * VERIFICATION_MODE=mock so no OpenAI calls are made.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  INestApplication,
+  ValidationPipe,
+  VersioningType,
+} from '@nestjs/common';
+import { getQueueToken } from '@nestjs/bullmq';
+import request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AppRole } from 'src/auth/app-role.enum';
+
+// ---------------------------------------------------------------------------
+// BullMQ queue mock – returns a fake job so no Redis connection is needed
+// ---------------------------------------------------------------------------
+
+function makeMockQueue(name: string) {
+  let jobCounter = 0;
+  return {
+    name,
+    add: jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        id: `mock-job-${++jobCounter}`,
+        name,
+        data: {},
+        opts: { attempts: 3 },
+        attemptsMade: 0,
+      }),
+    ),
+    getWaitingCount: jest.fn().mockResolvedValue(0),
+    getActiveCount: jest.fn().mockResolvedValue(0),
+    getCompletedCount: jest.fn().mockResolvedValue(0),
+    getFailedCount: jest.fn().mockResolvedValue(0),
+    getDelayedCount: jest.fn().mockResolvedValue(0),
+    close: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+const E2E_API_KEY = 'e2e-verify-admin-key';
+
+describe('Verification claim flow (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let server: ReturnType<INestApplication['getHttpServer']>;
+
+  const base = '/api/v1/verification';
+  const claimsBase = '/api/v1/claims';
+  const campaignsBase = '/api/v1/campaigns';
+
+  beforeAll(async () => {
+    const verificationQueueMock = makeMockQueue('verification');
+    const notificationsQueueMock = makeMockQueue('notifications');
+    const onchainQueueMock = makeMockQueue('onchain');
+    const deadLetterQueueMock = makeMockQueue('dead-letter');
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(getQueueToken('verification'))
+      .useValue(verificationQueueMock)
+      .overrideProvider(getQueueToken('notifications'))
+      .useValue(notificationsQueueMock)
+      .overrideProvider(getQueueToken('onchain'))
+      .useValue(onchainQueueMock)
+      .overrideProvider(getQueueToken('dead-letter'))
+      .useValue(deadLetterQueueMock)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: '1',
+      prefix: 'v',
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+
+    await app.init();
+    prisma = moduleRef.get(PrismaService);
+    server = app.getHttpServer();
+
+    // Seed test API key
+    await prisma.apiKey.upsert({
+      where: { key: E2E_API_KEY },
+      update: { role: AppRole.admin, revokedAt: null },
+      create: {
+        key: E2E_API_KEY,
+        role: AppRole.admin,
+        description: 'E2E verification test key',
+      },
+    });
+  });
+
+  beforeEach(async () => {
+    await prisma.claim.deleteMany();
+    await prisma.campaign.deleteMany();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  async function createCampaign(name = 'E2E Campaign') {
+    const res = await request(server)
+      .post(campaignsBase)
+      .set('x-api-key', E2E_API_KEY)
+      .send({ name, budget: 10000 })
+      .expect(201);
+    return res.body.data as { id: string };
+  }
+
+  async function createClaim(campaignId: string, amount = 500) {
+    const res = await request(server)
+      .post(claimsBase)
+      .set('x-api-key', E2E_API_KEY)
+      .send({ campaignId, amount, recipientRef: `recipient-${Date.now()}` })
+      .expect(201);
+    return res.body.data as { id: string; status: string };
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /verification/claims/:id/enqueue
+  // -------------------------------------------------------------------------
+
+  describe('POST /verification/claims/:id/enqueue', () => {
+    it('returns 202 Accepted with jobId and queued status', async () => {
+      const campaign = await createCampaign();
+      const claim = await createClaim(campaign.id);
+
+      const res = await request(server)
+        .post(`${base}/claims/${claim.id}/enqueue`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(202);
+
+      expect(res.body).toMatchObject({
+        jobId: expect.any(String),
+        claimId: claim.id,
+        status: 'queued',
+        message: expect.any(String),
+      });
+      expect(res.body.jobId.length).toBeGreaterThan(0);
+    });
+
+    it('returns 404 for a non-existent claim', async () => {
+      await request(server)
+        .post(`${base}/claims/nonexistent-claim-id/enqueue`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(404);
+    });
+
+    it('returns 401 when API key is missing', async () => {
+      const campaign = await createCampaign();
+      const claim = await createClaim(campaign.id);
+
+      await request(server)
+        .post(`${base}/claims/${claim.id}/enqueue`)
+        .expect(401);
+    });
+
+    it('returns 401 when API key is invalid', async () => {
+      const campaign = await createCampaign();
+      const claim = await createClaim(campaign.id);
+
+      await request(server)
+        .post(`${base}/claims/${claim.id}/enqueue`)
+        .set('x-api-key', 'totally-wrong-key')
+        .expect(401);
+    });
+
+    it('handles already-verified claim gracefully', async () => {
+      const campaign = await createCampaign();
+      const verifiedClaim = await prisma.claim.create({
+        data: {
+          campaignId: campaign.id,
+          amount: 100,
+          recipientRef: 'already-verified',
+          status: 'verified',
+        },
+      });
+
+      const res = await request(server)
+        .post(`${base}/claims/${verifiedClaim.id}/enqueue`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(202);
+
+      expect(res.body.jobId).toBe('already-verified');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /verification/claims/:id
+  // -------------------------------------------------------------------------
+
+  describe('GET /verification/claims/:id', () => {
+    it('returns claim details with status', async () => {
+      const campaign = await createCampaign();
+      const claim = await createClaim(campaign.id);
+
+      const res = await request(server)
+        .get(`${base}/claims/${claim.id}`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        id: claim.id,
+        status: expect.any(String),
+      });
+    });
+
+    it('returns 404 for unknown claim id', async () => {
+      await request(server)
+        .get(`${base}/claims/does-not-exist`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /verification/metrics
+  // -------------------------------------------------------------------------
+
+  describe('GET /verification/metrics', () => {
+    it('returns queue metric counts', async () => {
+      const res = await request(server)
+        .get(`${base}/metrics`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        waiting: expect.any(Number),
+        active: expect.any(Number),
+        completed: expect.any(Number),
+        failed: expect.any(Number),
+        total: expect.any(Number),
+      });
+
+      for (const key of ['waiting', 'active', 'completed', 'failed', 'total']) {
+        expect(res.body[key] as number).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('total equals sum of waiting + active + completed + failed', async () => {
+      const res = await request(server)
+        .get(`${base}/metrics`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      const { waiting, active, completed, failed, total } = res.body as {
+        waiting: number;
+        active: number;
+        completed: number;
+        failed: number;
+        total: number;
+      };
+
+      expect(total).toBe(waiting + active + completed + failed);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full lifecycle: create → enqueue → status check
+  // -------------------------------------------------------------------------
+
+  describe('Full verification lifecycle', () => {
+    it('enqueues a claim and the claim remains retrievable', async () => {
+      const campaign = await createCampaign('Lifecycle Campaign');
+      const claim = await createClaim(campaign.id, 250);
+
+      // Step 1: enqueue
+      const enqueueRes = await request(server)
+        .post(`${base}/claims/${claim.id}/enqueue`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(202);
+
+      expect(enqueueRes.body.status).toBe('queued');
+      expect(enqueueRes.body.jobId).toBeTruthy();
+
+      // Step 2: claim is still retrievable
+      const statusRes = await request(server)
+        .get(`${base}/claims/${claim.id}`)
+        .set('x-api-key', E2E_API_KEY)
+        .expect(200);
+
+      expect(statusRes.body.id).toBe(claim.id);
+      expect(['requested', 'verified']).toContain(statusRes.body.status);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#121 – End-to-End Test Suite for Key Flows**.

---

## What changed

### 🧪 Test harness & infrastructure
- **`test/helpers/app-harness.ts`** — shared helper that bootstraps a full NestJS app (URI versioning, ValidationPipe, seeded API keys) with no external secrets needed
- **`test/helpers/bull-mock.ts`** — `ioredis-mock` based helper so BullMQ queues work in-memory without Redis
- **`test/jest-e2e-setup.ts`** — `setupFiles` entry; sets `DATABASE_URL`, `ONCHAIN_ADAPTER=mock`, `VERIFICATION_MODE=mock` before any module loads
- **`test/jest-e2e-global-setup.ts`** — `globalSetup` entry; runs `prisma migrate deploy` once before all suites
- **`test/jest-e2e.json`** — wired `setupFiles`, `globalSetup`, `testTimeout=30000`

### ✅ Health / readiness endpoints — `test/health.e2e-spec.ts` (10 tests, all passing)
| Endpoint | Assertions |
|---|---|
| `GET /api/v1/health` | 200, `{status:ok, service:backend}`, no auth required |
| `GET /api/v1/health/live` | liveness payload shape, ISO-8601 timestamp, pid + uptimeSeconds |
| `GET /api/v1/health/ready` | DB up, stellarRpc skipped in CI, ISO timestamp, public |

### ✅ Full verification flow — `test/verification-claim.e2e-spec.ts`
- Create campaign → create claim → **`POST /api/v1/verification/claims/:id/enqueue`** → 202 with jobId
- 404 on unknown claim, 401 on missing/invalid key
- Already-verified claim returns `jobId: 'already-verified'`
- **`GET /api/v1/verification/claims/:id`** — status check (200 / 404)
- **`GET /api/v1/verification/metrics`** — shape + `total == sum of parts`
- Full lifecycle: create → enqueue → status remains retrievable
- BullMQ queues mocked via `overrideProvider` — no Redis needed

### ✅ Backend-to-contract proxy — `test/onchain-proxy.e2e-spec.ts`
- Uses **`MockOnchainAdapter`** — no Stellar keys, RPC URL, or contract ID required
- `POST /packages` — create, 400 on missing fields, 401 without key
- `POST /packages/batch` — multi-recipient, mismatched arrays → 400
- `GET /packages/:id` — package shape validation
- `GET /stats` — aggregates shape, numeric string values
- `POST /packages/:id/disburse` — 64-char hex transaction hash
- **Full round-trip**: create → get → disburse

### ✅ Queue monitoring — `test/queue-monitoring.e2e-spec.ts`
- `GET /api/v1/jobs/status` — all 3 queues, failureRate 0–1, 401
- `GET /api/v1/jobs/health` — healthy/degraded/critical, DLQ shape, ISO timestamp
- `GET /api/v1/jobs/dead-letter` — stats + arrays, limit param, empty when clean

---

## CI requirements
| Requirement | How met |
|---|---|
| No Redis | BullMQ queues mocked via `overrideProvider(getQueueToken(...))` |
| No Stellar RPC | `ONCHAIN_ADAPTER=mock` → `MockOnchainAdapter` |
| No OpenAI key | `VERIFICATION_MODE=mock` → deterministic scoring |
| No private keys | All crypto operations use mock adapters |
| DB | SQLite `test.db` with absolute path; `prisma migrate deploy` in globalSetup |

---

Closes #121