### PR TITLE
feat: implement Cancel-and-Reissue Flow

### DIFF
--- a/app/backend/prisma/migrations/20260424000000_cancel_and_reissue/migration.sql
+++ b/app/backend/prisma/migrations/20260424000000_cancel_and_reissue/migration.sql
@@ -1,0 +1,35 @@
+-- Migration: cancel_and_reissue
+-- Adds cancellation fields to Claim, a BalanceLedger for locked-balance tracking,
+-- and a cancelled status to ClaimStatus.
+
+-- SQLite does not support ALTER COLUMN or ADD CONSTRAINT after the fact,
+-- so we add new nullable columns and a new table.
+
+-- 1. Add cancellation / reissue tracking columns to Claim
+ALTER TABLE "Claim" ADD COLUMN "cancelledAt"    DATETIME;
+ALTER TABLE "Claim" ADD COLUMN "cancelledBy"    TEXT;
+ALTER TABLE "Claim" ADD COLUMN "cancelReason"   TEXT;
+ALTER TABLE "Claim" ADD COLUMN "reissuedFromId" TEXT;
+
+-- 2. Index for fast reissue-chain lookups
+CREATE INDEX "Claim_reissuedFromId_idx" ON "Claim"("reissuedFromId");
+
+-- 3. BalanceLedger – one row per balance event on a campaign
+CREATE TABLE "BalanceLedger" (
+    "id"          TEXT     NOT NULL PRIMARY KEY,
+    "campaignId"  TEXT     NOT NULL,
+    "claimId"     TEXT,
+    "eventType"   TEXT     NOT NULL,   -- 'lock' | 'unlock' | 'disburse'
+    "amount"      REAL     NOT NULL,
+    "note"        TEXT,
+    "createdAt"   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BalanceLedger_campaignId_fkey"
+        FOREIGN KEY ("campaignId") REFERENCES "Campaign"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "BalanceLedger_claimId_fkey"
+        FOREIGN KEY ("claimId") REFERENCES "Claim"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE INDEX "BalanceLedger_campaignId_idx"  ON "BalanceLedger"("campaignId");
+CREATE INDEX "BalanceLedger_claimId_idx"     ON "BalanceLedger"("claimId");
+CREATE INDEX "BalanceLedger_eventType_idx"   ON "BalanceLedger"("eventType");
+CREATE INDEX "BalanceLedger_createdAt_idx"   ON "BalanceLedger"("createdAt");

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -21,6 +21,7 @@ enum ClaimStatus {
   approved
   disbursed
   archived
+  cancelled
 }
 
 model AidPackage {
@@ -29,6 +30,31 @@ model AidPackage {
   updatedAt DateTime @updatedAt
 
   status    String   @default("draft")
+}
+
+/// Tracks every balance event (lock / unlock / disburse) for a campaign.
+/// The running sum of all rows for a campaign gives the current locked balance.
+model BalanceLedger {
+  id         String   @id @default(cuid())
+  campaignId String
+  campaign   Campaign @relation(fields: [campaignId], references: [id])
+
+  claimId    String?
+  claim      Claim?   @relation(fields: [claimId], references: [id])
+
+  /// 'lock' when a claim is created/approved, 'unlock' when cancelled, 'disburse' when disbursed
+  eventType  String
+
+  /// Positive for lock/disburse, negative for unlock
+  amount     Float
+
+  note       String?
+  createdAt  DateTime @default(now())
+
+  @@index([campaignId])
+  @@index([claimId])
+  @@index([eventType])
+  @@index([createdAt])
 }
 
 enum VerificationChannel {
@@ -158,10 +184,23 @@ model Claim {
   recipientRef String
   evidenceRef  String?
 
+  /// Set when this claim is cancelled
+  cancelledAt    DateTime?
+  cancelledBy    String?
+  cancelReason   String?
+
+  /// Points to the original claim this one replaces (reissue chain)
+  reissuedFromId String?
+  reissuedFrom   Claim?    @relation("ReissueChain", fields: [reissuedFromId], references: [id])
+  reissuedTo     Claim[]   @relation("ReissueChain")
+
+  balanceLedger  BalanceLedger[]
+
   @@index([status])
   @@index([campaignId])
   @@index([createdAt])
   @@index([deletedAt])
+  @@index([reissuedFromId])
 }
 
 model AuditLog {
@@ -197,6 +236,7 @@ model Campaign {
   updatedAt   DateTime       @updatedAt
 
   claims      Claim[]
+  balanceLedger BalanceLedger[]
 
   @@index([status])
   @@index([archivedAt])

--- a/app/backend/src/campaigns/campaigns.controller.ts
+++ b/app/backend/src/campaigns/campaigns.controller.ts
@@ -32,12 +32,16 @@ import { Roles } from 'src/auth/roles.decorator';
 import { AppRole } from 'src/auth/app-role.enum';
 import { Throttle } from '@nestjs/throttler';
 import { OrgOwnershipGuard } from '../common/guards/org-ownership.guard';
+import { CancelAndReissueService } from '../claims/cancel-and-reissue.service';
 
 @ApiTags('Campaigns')
 @ApiBearerAuth('JWT-auth')
 @Controller('campaigns')
 export class CampaignsController {
-  constructor(private readonly campaigns: CampaignsService) {}
+  constructor(
+    private readonly campaigns: CampaignsService,
+    private readonly cancelAndReissueService: CancelAndReissueService,
+  ) {}
 
   @Post()
   @Roles(AppRole.admin, AppRole.ngo)
@@ -141,5 +145,44 @@ export class CampaignsController {
       ? 'Campaign already archived'
       : 'Campaign archived successfully';
     return ApiResponseDto.ok(campaign, msg);
+  }
+
+  @Get(':id/balance')
+  @Roles(AppRole.operator, AppRole.admin)
+  @ApiOperation({
+    summary: 'Get campaign balance summary',
+    description:
+      'Returns the current locked, disbursed, and available budget for a campaign. ' +
+      'Locked balance accounts for all active (non-cancelled, non-disbursed) claims. ' +
+      'Cancelled claims release their locked amount back to available.',
+  })
+  @ApiOkResponse({
+    description: 'Campaign balance retrieved successfully.',
+    schema: {
+      properties: {
+        campaignId: { type: 'string' },
+        budget: { type: 'number', description: 'Total campaign budget.' },
+        lockedAmount: {
+          type: 'number',
+          description: 'Amount locked by active claims.',
+        },
+        disbursedAmount: {
+          type: 'number',
+          description: 'Amount already disbursed.',
+        },
+        availableBudget: {
+          type: 'number',
+          description: 'Remaining available budget.',
+        },
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Campaign not found.' })
+  @ApiForbiddenResponse({
+    description: 'Access denied - operator role required.',
+  })
+  async getBalance(@Param('id') id: string) {
+    const balance = await this.cancelAndReissueService.getCampaignBalance(id);
+    return ApiResponseDto.ok(balance, 'Campaign balance fetched successfully');
   }
 }

--- a/app/backend/src/campaigns/campaigns.module.ts
+++ b/app/backend/src/campaigns/campaigns.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CampaignsController } from './campaigns.controller';
 import { CampaignsService } from './campaigns.service';
+import { ClaimsModule } from '../claims/claims.module';
 
 @Module({
+  imports: [ClaimsModule],
   controllers: [CampaignsController],
   providers: [CampaignsService],
 })

--- a/app/backend/src/claims/cancel-and-reissue.service.ts
+++ b/app/backend/src/claims/cancel-and-reissue.service.ts
@@ -1,0 +1,427 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { EncryptionService } from '../common/encryption/encryption.service';
+import { CancelClaimDto } from './dto/cancel-claim.dto';
+import { ReissueClaimDto } from './dto/reissue-claim.dto';
+import { ClaimStatus } from '@prisma/client';
+import {
+  CLAIM_EVENT,
+  ClaimCancelledEvent,
+  ClaimReissuedEvent,
+} from './claim.events';
+
+/** Statuses from which a claim may be cancelled. */
+const CANCELLABLE_STATUSES: ClaimStatus[] = [
+  ClaimStatus.requested,
+  ClaimStatus.verified,
+  ClaimStatus.approved,
+];
+
+@Injectable()
+export class CancelAndReissueService {
+  private readonly logger = new Logger(CancelAndReissueService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Cancel
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Cancel an active claim.
+   *
+   * - Marks the claim as `cancelled` and records who cancelled it and why.
+   * - Writes an `unlock` entry to BalanceLedger so the campaign budget is freed.
+   * - Emits a `claim.cancelled` audit event with the full relationship context.
+   *
+   * Disbursed or already-cancelled claims cannot be cancelled.
+   */
+  async cancel(id: string, dto: CancelClaimDto) {
+    const claim = await this.prisma.claim.findUnique({
+      where: { id },
+      include: { campaign: true },
+    });
+
+    if (!claim || claim.deletedAt) {
+      throw new NotFoundException('Claim not found');
+    }
+
+    if (claim.status === ClaimStatus.cancelled) {
+      throw new BadRequestException('Claim is already cancelled');
+    }
+
+    if (!CANCELLABLE_STATUSES.includes(claim.status)) {
+      throw new BadRequestException(
+        `Cannot cancel a claim in status "${claim.status}". ` +
+          `Only ${CANCELLABLE_STATUSES.join(', ')} claims may be cancelled.`,
+      );
+    }
+
+    const now = new Date();
+
+    const cancelled = await this.prisma.$transaction(async tx => {
+      // 1. Mark claim as cancelled
+      const updated = await tx.claim.update({
+        where: { id },
+        data: {
+          status: ClaimStatus.cancelled,
+          cancelledAt: now,
+          cancelledBy: dto.operatorId,
+          cancelReason: dto.reason ?? null,
+        },
+        include: { campaign: true },
+      });
+
+      // 2. Release the locked balance back to the campaign
+      await tx.balanceLedger.create({
+        data: {
+          campaignId: claim.campaignId,
+          claimId: id,
+          eventType: 'unlock',
+          // Negative amount: this entry reduces the total locked balance
+          amount: -claim.amount,
+          note: `Claim ${id} cancelled by ${dto.operatorId}. Reason: ${dto.reason ?? 'none'}`,
+        },
+      });
+
+      return updated;
+    });
+
+    // 3. Emit domain event via audit trail
+    const event: ClaimCancelledEvent = {
+      type: CLAIM_EVENT.CANCELLED,
+      claimId: id,
+      campaignId: claim.campaignId,
+      operatorId: dto.operatorId,
+      reason: dto.reason,
+      unlockedAmount: claim.amount,
+      timestamp: now,
+    };
+
+    await this.emitEvent(event);
+
+    this.logger.log(`Claim ${id} cancelled by ${dto.operatorId}`, {
+      claimId: id,
+      campaignId: claim.campaignId,
+      amount: claim.amount,
+    });
+
+    return {
+      ...cancelled,
+      recipientRef: this.encryptionService.decrypt(cancelled.recipientRef),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reissue
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Cancel an existing claim and atomically create a replacement.
+   *
+   * - The original claim must be in a cancellable status.
+   * - The new claim inherits the original's campaign, recipient, and amount
+   *   unless overrides are provided in the DTO.
+   * - `reissuedFromId` on the new claim links it back to the original,
+   *   preserving the full audit chain.
+   * - A single DB transaction ensures the old claim is cancelled and the new
+   *   one is created together — no double-counting of locked balances.
+   * - Emits both `claim.cancelled` and `claim.reissued` audit events.
+   */
+  async reissue(originalId: string, dto: ReissueClaimDto) {
+    const original = await this.prisma.claim.findUnique({
+      where: { id: originalId },
+      include: { campaign: true },
+    });
+
+    if (!original || original.deletedAt) {
+      throw new NotFoundException('Original claim not found');
+    }
+
+    if (original.status === ClaimStatus.cancelled) {
+      throw new BadRequestException('Original claim is already cancelled');
+    }
+
+    if (!CANCELLABLE_STATUSES.includes(original.status)) {
+      throw new BadRequestException(
+        `Cannot reissue from a claim in status "${original.status}". ` +
+          `Only ${CANCELLABLE_STATUSES.join(', ')} claims may be reissued.`,
+      );
+    }
+
+    const newAmount = dto.amount ?? original.amount;
+    const newRecipientRef = dto.recipientRef
+      ? this.encryptionService.encrypt(dto.recipientRef)
+      : original.recipientRef; // already encrypted
+
+    const now = new Date();
+
+    const { cancelledClaim, newClaim } = await this.prisma.$transaction(
+      async tx => {
+        // 1. Cancel the original claim
+        const cancelledClaim = await tx.claim.update({
+          where: { id: originalId },
+          data: {
+            status: ClaimStatus.cancelled,
+            cancelledAt: now,
+            cancelledBy: dto.operatorId,
+            cancelReason: dto.reason ?? `Reissued as new claim`,
+          },
+        });
+
+        // 2. Unlock the original amount from the campaign budget
+        await tx.balanceLedger.create({
+          data: {
+            campaignId: original.campaignId,
+            claimId: originalId,
+            eventType: 'unlock',
+            amount: -original.amount,
+            note: `Claim ${originalId} cancelled for reissue by ${dto.operatorId}`,
+          },
+        });
+
+        // 3. Create the replacement claim, linked to the original
+        const newClaim = await tx.claim.create({
+          data: {
+            campaignId: original.campaignId,
+            amount: newAmount,
+            recipientRef: newRecipientRef,
+            evidenceRef: original.evidenceRef,
+            status: ClaimStatus.requested,
+            reissuedFromId: originalId,
+          },
+          include: { campaign: true },
+        });
+
+        // 4. Lock the new amount against the campaign budget
+        await tx.balanceLedger.create({
+          data: {
+            campaignId: original.campaignId,
+            claimId: newClaim.id,
+            eventType: 'lock',
+            amount: newAmount,
+            note: `Replacement claim ${newClaim.id} issued by ${dto.operatorId} (replaces ${originalId})`,
+          },
+        });
+
+        return { cancelledClaim, newClaim };
+      },
+    );
+
+    // 5. Emit domain events via audit trail
+    const cancelEvent: ClaimCancelledEvent = {
+      type: CLAIM_EVENT.CANCELLED,
+      claimId: originalId,
+      campaignId: original.campaignId,
+      operatorId: dto.operatorId,
+      reason: dto.reason ?? `Reissued as ${newClaim.id}`,
+      unlockedAmount: original.amount,
+      timestamp: now,
+    };
+
+    const reissueEvent: ClaimReissuedEvent = {
+      type: CLAIM_EVENT.REISSUED,
+      newClaimId: newClaim.id,
+      originalClaimId: originalId,
+      campaignId: original.campaignId,
+      operatorId: dto.operatorId,
+      amount: newAmount,
+      reason: dto.reason,
+      timestamp: now,
+    };
+
+    // Emit both events; fire-and-forget is intentional — audit failures
+    // must not roll back the already-committed transaction.
+    await Promise.all([
+      this.emitEvent(cancelEvent),
+      this.emitEvent(reissueEvent),
+    ]);
+
+    this.logger.log(
+      `Claim ${originalId} cancelled and reissued as ${newClaim.id} by ${dto.operatorId}`,
+      {
+        originalId,
+        newClaimId: newClaim.id,
+        campaignId: original.campaignId,
+        originalAmount: original.amount,
+        newAmount,
+      },
+    );
+
+    return {
+      original: {
+        ...cancelledClaim,
+        recipientRef: this.encryptionService.decrypt(
+          cancelledClaim.recipientRef,
+        ),
+      },
+      replacement: {
+        ...newClaim,
+        recipientRef: this.encryptionService.decrypt(newClaim.recipientRef),
+      },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reissue history
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Walk the reissue chain for a given claim ID and return every claim in the
+   * lineage, ordered from oldest to newest.
+   *
+   * Works in both directions: pass any claim in the chain and the full history
+   * is returned.
+   */
+  async getReissueHistory(id: string) {
+    const claim = await this.prisma.claim.findUnique({ where: { id } });
+    if (!claim || claim.deletedAt) {
+      throw new NotFoundException('Claim not found');
+    }
+
+    // Walk backwards to find the root of the chain
+    const root = await this.findChainRoot(id);
+
+    // Walk forwards from root to collect all descendants
+    const chain = await this.collectChain(root);
+
+    return chain.map(c => ({
+      ...c,
+      recipientRef: this.encryptionService.decrypt(c.recipientRef),
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Locked balance summary
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Return the current locked balance for a campaign by summing all
+   * BalanceLedger entries.
+   *
+   * - `lockedAmount`  = sum of all 'lock' entries minus sum of all 'unlock' entries
+   * - `disbursedAmount` = sum of all 'disburse' entries
+   * - `availableBudget` = campaign.budget - lockedAmount - disbursedAmount
+   */
+  async getCampaignBalance(campaignId: string) {
+    const campaign = await this.prisma.campaign.findUnique({
+      where: { id: campaignId },
+    });
+    if (!campaign || campaign.deletedAt) {
+      throw new NotFoundException('Campaign not found');
+    }
+
+    const ledger = await this.prisma.balanceLedger.findMany({
+      where: { campaignId },
+    });
+
+    let lockedAmount = 0;
+    let disbursedAmount = 0;
+
+    for (const entry of ledger) {
+      if (entry.eventType === 'lock' || entry.eventType === 'unlock') {
+        lockedAmount += entry.amount; // unlock entries have negative amounts
+      } else if (entry.eventType === 'disburse') {
+        disbursedAmount += entry.amount;
+      }
+    }
+
+    const availableBudget = campaign.budget - lockedAmount - disbursedAmount;
+
+    return {
+      campaignId,
+      budget: campaign.budget,
+      lockedAmount,
+      disbursedAmount,
+      availableBudget,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async findChainRoot(id: string): Promise<string> {
+    let current = await this.prisma.claim.findUnique({
+      where: { id },
+      select: { id: true, reissuedFromId: true },
+    });
+
+    while (current?.reissuedFromId) {
+      current = await this.prisma.claim.findUnique({
+        where: { id: current.reissuedFromId },
+        select: { id: true, reissuedFromId: true },
+      });
+    }
+
+    return current?.id ?? id;
+  }
+
+  private async collectChain(rootId: string) {
+    const results: Awaited<ReturnType<typeof this.prisma.claim.findUnique>>[] =
+      [];
+
+    const root = await this.prisma.claim.findUnique({
+      where: { id: rootId },
+      include: { campaign: true },
+    });
+    if (!root) return [];
+
+    results.push(root);
+
+    // BFS over reissuedTo children
+    const queue = [rootId];
+    while (queue.length > 0) {
+      const parentId = queue.shift()!;
+      const children = await this.prisma.claim.findMany({
+        where: { reissuedFromId: parentId },
+        include: { campaign: true },
+        orderBy: { createdAt: 'asc' },
+      });
+      for (const child of children) {
+        results.push(child);
+        queue.push(child.id);
+      }
+    }
+
+    return results.filter(Boolean) as NonNullable<(typeof results)[number]>[];
+  }
+
+  /**
+   * Persist a domain event to the AuditLog.
+   * The metadata field carries the full typed event payload so downstream
+   * consumers (reporting, compliance) can reconstruct the relationship graph.
+   */
+  private async emitEvent(
+    event: ClaimCancelledEvent | ClaimReissuedEvent,
+  ): Promise<void> {
+    try {
+      const entityId =
+        event.type === CLAIM_EVENT.REISSUED ? event.newClaimId : event.claimId;
+
+      await this.auditService.record({
+        actorId: event.operatorId,
+        entity: 'claim',
+        entityId,
+        action: event.type,
+        metadata: event as unknown as Record<string, unknown>,
+      });
+    } catch (err) {
+      // Audit failures are logged but must not surface to the caller
+      this.logger.error(
+        `Failed to emit event ${event.type}: ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+    }
+  }
+}

--- a/app/backend/src/claims/claim.events.ts
+++ b/app/backend/src/claims/claim.events.ts
@@ -1,0 +1,39 @@
+/**
+ * Typed domain events for the cancel-and-reissue flow.
+ *
+ * These are emitted via ClaimEventsService and recorded in the AuditLog so
+ * every state change is traceable without an external message broker.
+ */
+
+export const CLAIM_EVENT = {
+  CANCELLED: 'claim.cancelled',
+  REISSUED: 'claim.reissued',
+} as const;
+
+export type ClaimEventType = (typeof CLAIM_EVENT)[keyof typeof CLAIM_EVENT];
+
+export interface ClaimCancelledEvent {
+  type: typeof CLAIM_EVENT.CANCELLED;
+  claimId: string;
+  campaignId: string;
+  operatorId: string;
+  reason?: string;
+  /** Amount that was unlocked from the campaign budget */
+  unlockedAmount: number;
+  timestamp: Date;
+}
+
+export interface ClaimReissuedEvent {
+  type: typeof CLAIM_EVENT.REISSUED;
+  /** The newly created replacement claim */
+  newClaimId: string;
+  /** The original claim that was cancelled */
+  originalClaimId: string;
+  campaignId: string;
+  operatorId: string;
+  amount: number;
+  reason?: string;
+  timestamp: Date;
+}
+
+export type ClaimEvent = ClaimCancelledEvent | ClaimReissuedEvent;

--- a/app/backend/src/claims/claims.controller.ts
+++ b/app/backend/src/claims/claims.controller.ts
@@ -19,12 +19,15 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { ClaimsService } from './claims.service';
+import { CancelAndReissueService } from './cancel-and-reissue.service';
 import { CreateClaimDto } from './dto/create-claim.dto';
 import {
   ClaimReceiptDto,
   ClaimShareResponseDto,
   SendReceiptShareDto,
 } from './dto/claim-receipt.dto';
+import { CancelClaimDto } from './dto/cancel-claim.dto';
+import { ReissueClaimDto } from './dto/reissue-claim.dto';
 import { Roles } from 'src/auth/roles.decorator';
 import { AppRole } from 'src/auth/app-role.enum';
 import { InternalNotesService } from 'src/common/services/internal-notes.service';
@@ -37,6 +40,7 @@ import { InternalNoteResponseDto } from 'src/common/dto/internal-note-response.d
 export class ClaimsController {
   constructor(
     private readonly claimsService: ClaimsService,
+    private readonly cancelAndReissueService: CancelAndReissueService,
     private readonly internalNotesService: InternalNotesService,
   ) {}
 
@@ -271,5 +275,88 @@ export class ClaimsController {
   })
   getNotes(@Param('id') id: string) {
     return this.internalNotesService.findNotesByEntity('claim', id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cancel-and-Reissue
+  // ---------------------------------------------------------------------------
+
+  @Post(':id/cancel')
+  @Roles(AppRole.operator, AppRole.admin)
+  @ApiOperation({
+    summary: 'Cancel a claim',
+    description:
+      'Cancels an active claim (requested / verified / approved). ' +
+      'Releases the locked budget back to the campaign and records a full audit trail. ' +
+      'Disbursed claims cannot be cancelled.',
+  })
+  @ApiOkResponse({ description: 'Claim cancelled successfully.' })
+  @ApiBadRequestResponse({
+    description: 'Claim is already cancelled or in a non-cancellable status.',
+  })
+  @ApiForbiddenResponse({
+    description: 'Access denied - operator role required.',
+  })
+  @ApiNotFoundResponse({ description: 'Claim not found.' })
+  cancel(@Param('id') id: string, @Body() dto: CancelClaimDto) {
+    return this.cancelAndReissueService.cancel(id, dto);
+  }
+
+  @Post(':id/reissue')
+  @Roles(AppRole.operator, AppRole.admin)
+  @ApiOperation({
+    summary: 'Cancel and reissue a claim',
+    description:
+      'Atomically cancels the original claim and creates a replacement. ' +
+      'The replacement is linked to the original via `reissuedFromId`, ' +
+      'preserving the full audit chain. Locked balances are transferred to ' +
+      'the new claim — no double-counting occurs. ' +
+      'Returns both the cancelled original and the new replacement.',
+  })
+  @ApiCreatedResponse({
+    description: 'Original claim cancelled and replacement created.',
+    schema: {
+      properties: {
+        original: {
+          type: 'object',
+          description: 'The cancelled original claim.',
+        },
+        replacement: {
+          type: 'object',
+          description: 'The newly created replacement claim.',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Original claim is not in a cancellable status.',
+  })
+  @ApiForbiddenResponse({
+    description: 'Access denied - operator role required.',
+  })
+  @ApiNotFoundResponse({ description: 'Original claim not found.' })
+  reissue(@Param('id') id: string, @Body() dto: ReissueClaimDto) {
+    return this.cancelAndReissueService.reissue(id, dto);
+  }
+
+  @Get(':id/reissue-history')
+  @Roles(AppRole.operator, AppRole.admin)
+  @ApiOperation({
+    summary: 'Get reissue chain for a claim',
+    description:
+      'Returns the full lineage of a claim — the original and every ' +
+      'replacement — ordered from oldest to newest. Pass any claim ID in ' +
+      'the chain to retrieve the complete history.',
+  })
+  @ApiOkResponse({
+    description: 'Reissue chain retrieved successfully.',
+    schema: { type: 'array', items: { type: 'object' } },
+  })
+  @ApiForbiddenResponse({
+    description: 'Access denied - operator role required.',
+  })
+  @ApiNotFoundResponse({ description: 'Claim not found.' })
+  getReissueHistory(@Param('id') id: string) {
+    return this.cancelAndReissueService.getReissueHistory(id);
   }
 }

--- a/app/backend/src/claims/claims.module.ts
+++ b/app/backend/src/claims/claims.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ClaimsService } from './claims.service';
 import { ClaimsController } from './claims.controller';
+import { CancelAndReissueService } from './cancel-and-reissue.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { OnchainModule } from '../onchain/onchain.module';
 import { MetricsModule } from '../observability/metrics/metrics.module';
@@ -18,6 +19,7 @@ import { EncryptionModule } from '../common/encryption/encryption.module';
     EncryptionModule,
   ],
   controllers: [ClaimsController],
-  providers: [ClaimsService],
+  providers: [ClaimsService, CancelAndReissueService],
+  exports: [CancelAndReissueService],
 })
 export class ClaimsModule {}

--- a/app/backend/src/claims/dto/cancel-claim.dto.ts
+++ b/app/backend/src/claims/dto/cancel-claim.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
+
+export class CancelClaimDto {
+  @ApiProperty({
+    description: 'ID of the operator performing the cancellation.',
+    example: 'operator-uuid',
+  })
+  @IsString()
+  @IsNotEmpty()
+  operatorId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable reason for cancellation.',
+    example: 'Recipient relocated; package no longer applicable.',
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/app/backend/src/claims/dto/claim-receipt.dto.ts
+++ b/app/backend/src/claims/dto/claim-receipt.dto.ts
@@ -15,10 +15,23 @@ export class ClaimReceiptDto {
 
   @ApiProperty({
     description: 'Current status of the claim',
-    enum: ['requested', 'verified', 'approved', 'disbursed', 'archived'],
+    enum: [
+      'requested',
+      'verified',
+      'approved',
+      'disbursed',
+      'archived',
+      'cancelled',
+    ],
     example: 'disbursed',
   })
-  status: 'requested' | 'verified' | 'approved' | 'disbursed' | 'archived';
+  status:
+    | 'requested'
+    | 'verified'
+    | 'approved'
+    | 'disbursed'
+    | 'archived'
+    | 'cancelled';
 
   @ApiProperty({
     description: 'Token amount for the claim',

--- a/app/backend/src/claims/dto/reissue-claim.dto.ts
+++ b/app/backend/src/claims/dto/reissue-claim.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsNumber,
+  Min,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ReissueClaimDto {
+  @ApiProperty({
+    description: 'ID of the operator performing the reissue.',
+    example: 'operator-uuid',
+  })
+  @IsString()
+  @IsNotEmpty()
+  operatorId!: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Override amount for the replacement package. ' +
+      'Defaults to the original amount when omitted.',
+    example: 750,
+    minimum: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  amount?: number;
+
+  @ApiPropertyOptional({
+    description: 'Override recipient reference for the replacement package.',
+    example: 'recipient-ref-new',
+  })
+  @IsOptional()
+  @IsString()
+  recipientRef?: string;
+
+  @ApiPropertyOptional({
+    description: 'Human-readable reason for the reissue.',
+    example: 'Corrected amount after field verification.',
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}


### PR DESCRIPTION
Adds the ability for operators to cancel an active claim and issue a replacement, without losing the audit trail or double-counting locked campaign budget.

What changed

Database (Prisma schema + migration)

Added cancelled to the ClaimStatus enum
Extended Claim with cancelledAt, cancelledBy, cancelReason, and reissuedFromId — the last field creates a self-referential relation that links every replacement back to its original, forming a traversable reissue chain
Added a new BalanceLedger model that records every lock, unlock, and disburse event against a campaign; the running sum of all entries gives the current locked balance without mutating any existing column


closes #309 