### PR TITLE
feat/partial claim support and campaign level escrow grouping

### DIFF
--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -30,6 +30,16 @@ model AidPackage {
   updatedAt DateTime @updatedAt
 
   status    String   @default("draft")
+
+  campaignId    String?
+  campaign      Campaign? @relation(fields: [campaignId], references: [id])
+
+  totalAmount     Float @default(0)
+  claimedAmount   Float @default(0)
+  remainingAmount Float @default(0)
+
+  @@index([campaignId])
+  @@index([campaignId, status])
 }
 
 /// Tracks every balance event (lock / unlock / disburse) for a campaign.
@@ -237,6 +247,7 @@ model Campaign {
 
   claims      Claim[]
   balanceLedger BalanceLedger[]
+  packages      AidPackage[]
 
   @@index([status])
   @@index([archivedAt])


### PR DESCRIPTION
This PR introduces campaign-level grouping and partial disbursement functionality for packages.

### Campaign Grouping
- Added `campaign_id` field to package storage
- Created indexes for efficient querying of packages by campaign
- Added database views for campaign-level package counts and locked totals

### Partial Disbursements
- Added tracking for `claimedAmount` and `remainingAmount` per package
- Enforced safeguards to prevent over-claiming
- Ensured consistent package status transitions during partial claims
- Updated aggregate views to reflect partially claimed packages

These changes improve data organization, enable campaign-level analytics, and support staged fund disbursement workflows.

closes #305 
closes #308