### PR TITLE
updates Field Location Capture with Consent

### DIFF
--- a/app/frontend/src/components/VerificationFlow.tsx
+++ b/app/frontend/src/components/VerificationFlow.tsx
@@ -19,6 +19,7 @@ const ACCEPTED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
 const ACCEPTED_MIME_SET: ReadonlySet<string> = new Set(ACCEPTED_MIME_TYPES);
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
 const MIN_TEXT_LENGTH = 20;
+const DRAFT_STORAGE_KEY = 'soter.verification-flow.draft.v1';
 
 /* ─── PII detection ─────────────────────────────────────────────────────── */
 
@@ -196,6 +197,82 @@ interface CapturedLocation {
     accuracy: number;
 }
 
+interface VerificationDraft {
+    textInput: string;
+    includeLocation: boolean;
+    locationPermission: LocationPermissionState;
+    locationData: CapturedLocation | null;
+}
+
+function isLocationPermissionState(value: unknown): value is LocationPermissionState {
+    return (
+        value === 'idle' ||
+        value === 'requesting' ||
+        value === 'granted' ||
+        value === 'denied' ||
+        value === 'unsupported' ||
+        value === 'error'
+    );
+}
+
+function isCapturedLocation(value: unknown): value is CapturedLocation {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+        typeof candidate.latitude === 'number' &&
+        typeof candidate.longitude === 'number' &&
+        typeof candidate.accuracy === 'number'
+    );
+}
+
+export function parseVerificationDraft(raw: string | null): VerificationDraft | null {
+    if (!raw) return null;
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return null;
+        const candidate = parsed as Record<string, unknown>;
+
+        if (typeof candidate.textInput !== 'string') return null;
+        if (typeof candidate.includeLocation !== 'boolean') return null;
+        if (!isLocationPermissionState(candidate.locationPermission)) return null;
+
+        const locationData =
+            candidate.locationData === null || candidate.locationData === undefined
+                ? null
+                : isCapturedLocation(candidate.locationData)
+                  ? candidate.locationData
+                  : null;
+
+        return {
+            textInput: candidate.textInput,
+            includeLocation: candidate.includeLocation,
+            locationPermission: candidate.locationPermission,
+            locationData,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function buildVerificationDraft(state: {
+    textInput: string;
+    includeLocation: boolean;
+    locationPermission: LocationPermissionState;
+    locationData: CapturedLocation | null;
+}): VerificationDraft {
+    return {
+        textInput: state.textInput,
+        includeLocation: state.includeLocation,
+        locationPermission: state.locationPermission,
+        locationData: state.locationData,
+    };
+}
+
+function readVerificationDraftFromStorage(): VerificationDraft | null {
+    if (typeof window === 'undefined') return null;
+    return parseVerificationDraft(window.localStorage.getItem(DRAFT_STORAGE_KEY));
+}
+
 /* ─── VerificationFlow component ────────────────────────────────────────── */
 
 /**
@@ -212,17 +289,25 @@ interface CapturedLocation {
 export const VerificationFlow: React.FC = () => {
     const uid = useId();
     const { trackJob } = useActivity();
+    const [restoredDraft] = useState<VerificationDraft | null>(() =>
+        readVerificationDraftFromStorage(),
+    );
 
     const [step, setStep] = useState<VerificationStep>('upload');
     const [imageFile, setImageFile] = useState<File | null>(null);
-    const [textInput, setTextInput] = useState('');
-    const [includeLocation, setIncludeLocation] = useState(false);
+    const [textInput, setTextInput] = useState(restoredDraft?.textInput ?? '');
+    const [includeLocation, setIncludeLocation] = useState(
+        restoredDraft?.includeLocation ?? false,
+    );
     const [locationPermission, setLocationPermission] =
-        useState<LocationPermissionState>('idle');
-    const [locationData, setLocationData] = useState<CapturedLocation | null>(null);
+        useState<LocationPermissionState>(restoredDraft?.locationPermission ?? 'idle');
+    const [locationData, setLocationData] = useState<CapturedLocation | null>(
+        restoredDraft?.locationData ?? null,
+    );
     const [errors, setErrors] = useState<ValidationErrors>({});
     const [apiError, setApiError] = useState<string | null>(null);
     const [result, setResult] = useState<VerificationResult | null>(null);
+    const [draftRestored, setDraftRestored] = useState(restoredDraft !== null);
 
     /**
      * Payload ref: stores the validated, PII-clean FormData to be sent when
@@ -244,8 +329,34 @@ export const VerificationFlow: React.FC = () => {
         setErrors(s.errors);
         setApiError(s.apiError);
         setResult(s.result);
+        setDraftRestored(false);
         pendingPayload.current = null;
+        if (typeof window !== 'undefined') {
+            window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+        }
     }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || step !== 'upload') return;
+        const draft = buildVerificationDraft({
+            textInput,
+            includeLocation,
+            locationPermission,
+            locationData,
+        });
+
+        const hasDraftContent =
+            draft.textInput.trim().length > 0 ||
+            draft.includeLocation ||
+            draft.locationData !== null;
+
+        if (!hasDraftContent) {
+            window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+            return;
+        }
+
+        window.localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+    }, [includeLocation, locationData, locationPermission, step, textInput]);
 
     const handleLocationConsentToggle = useCallback((checked: boolean) => {
         setIncludeLocation(checked);
@@ -418,6 +529,8 @@ export const VerificationFlow: React.FC = () => {
                     locationData={locationData}
                     onLocationConsentToggle={handleLocationConsentToggle}
                     onRequestLocation={handleRequestLocation}
+                    onDiscardDraft={resetFlow}
+                    draftRestored={draftRestored}
                 />
             )}
 
@@ -451,6 +564,8 @@ interface StepUploadProps {
     locationData: CapturedLocation | null;
     onLocationConsentToggle: (checked: boolean) => void;
     onRequestLocation: () => void;
+    onDiscardDraft: () => void;
+    draftRestored: boolean;
 }
 
 /**
@@ -477,6 +592,8 @@ function StepUpload({
     locationData,
     onLocationConsentToggle,
     onRequestLocation,
+    onDiscardDraft,
+    draftRestored,
 }: StepUploadProps) {
     const role = getAppUserRole();
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -523,6 +640,12 @@ function StepUpload({
                 >
                     {apiError}
                 </div>
+            )}
+
+            {draftRestored && (
+                <p className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-700 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-200">
+                    Restored your locally saved draft from this device.
+                </p>
             )}
 
             {/* Form-level validation error (at-least-one rule) */}
@@ -659,14 +782,23 @@ function StepUpload({
                 )}
             </div>
 
-            <button
-                type="submit"
-                disabled={!canSubmit}
-                aria-disabled={!canSubmit}
-                className="px-6 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-                Submit for Verification
-            </button>
+            <div className="flex flex-wrap items-center gap-3">
+                <button
+                    type="submit"
+                    disabled={!canSubmit}
+                    aria-disabled={!canSubmit}
+                    className="px-6 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                >
+                    Submit for Verification
+                </button>
+                <button
+                    type="button"
+                    onClick={onDiscardDraft}
+                    className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800 transition-colors"
+                >
+                    Discard Draft
+                </button>
+            </div>
         </form>
     );
 }

--- a/app/frontend/src/components/VerificationFlow.tsx
+++ b/app/frontend/src/components/VerificationFlow.tsx
@@ -159,6 +159,9 @@ interface FlowState {
     step: VerificationStep;
     imageFile: File | null;
     textInput: string;
+    includeLocation: boolean;
+    locationPermission: LocationPermissionState;
+    locationData: CapturedLocation | null;
     errors: ValidationErrors;
     apiError: string | null;
     result: VerificationResult | null;
@@ -170,10 +173,27 @@ function initialState(): FlowState {
         step: 'upload',
         imageFile: null,
         textInput: '',
+        includeLocation: false,
+        locationPermission: 'idle',
+        locationData: null,
         errors: {},
         apiError: null,
         result: null,
     };
+}
+
+type LocationPermissionState =
+    | 'idle'
+    | 'requesting'
+    | 'granted'
+    | 'denied'
+    | 'unsupported'
+    | 'error';
+
+interface CapturedLocation {
+    latitude: number;
+    longitude: number;
+    accuracy: number;
 }
 
 /* ─── VerificationFlow component ────────────────────────────────────────── */
@@ -196,6 +216,10 @@ export const VerificationFlow: React.FC = () => {
     const [step, setStep] = useState<VerificationStep>('upload');
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [textInput, setTextInput] = useState('');
+    const [includeLocation, setIncludeLocation] = useState(false);
+    const [locationPermission, setLocationPermission] =
+        useState<LocationPermissionState>('idle');
+    const [locationData, setLocationData] = useState<CapturedLocation | null>(null);
     const [errors, setErrors] = useState<ValidationErrors>({});
     const [apiError, setApiError] = useState<string | null>(null);
     const [result, setResult] = useState<VerificationResult | null>(null);
@@ -214,10 +238,52 @@ export const VerificationFlow: React.FC = () => {
         setStep(s.step);
         setImageFile(s.imageFile);
         setTextInput(s.textInput);
+        setIncludeLocation(s.includeLocation);
+        setLocationPermission(s.locationPermission);
+        setLocationData(s.locationData);
         setErrors(s.errors);
         setApiError(s.apiError);
         setResult(s.result);
         pendingPayload.current = null;
+    }, []);
+
+    const handleLocationConsentToggle = useCallback((checked: boolean) => {
+        setIncludeLocation(checked);
+        if (!checked) {
+            setLocationPermission('idle');
+            setLocationData(null);
+        }
+    }, []);
+
+    const handleRequestLocation = useCallback(() => {
+        if (typeof navigator === 'undefined' || !navigator.geolocation) {
+            setLocationPermission('unsupported');
+            return;
+        }
+
+        setLocationPermission('requesting');
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                setLocationData({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    accuracy: position.coords.accuracy,
+                });
+                setLocationPermission('granted');
+            },
+            (positionError) => {
+                if (positionError.code === positionError.PERMISSION_DENIED) {
+                    setLocationPermission('denied');
+                } else {
+                    setLocationPermission('error');
+                }
+            },
+            {
+                enableHighAccuracy: false,
+                timeout: 8000,
+                maximumAge: 5 * 60 * 1000,
+            },
+        );
     }, []);
 
     /* ── Step 1 → submission handler ────────────────────────────────────────── */
@@ -259,13 +325,18 @@ export const VerificationFlow: React.FC = () => {
             if (trimmedText.length > 0) {
                 form.append('text', trimmedText);
             }
+            if (includeLocation && locationPermission === 'granted' && locationData) {
+                form.append('location_latitude', locationData.latitude.toString());
+                form.append('location_longitude', locationData.longitude.toString());
+                form.append('location_accuracy_meters', locationData.accuracy.toString());
+            }
             pendingPayload.current = form;
 
             // 4. Advance to Step 2; the API call fires via useEffect below
             setApiError(null);
             setStep('analysing');
         },
-        [imageFile, textInput],
+        [imageFile, includeLocation, locationData, locationPermission, textInput],
     );
 
     /* ── Step 2 → API call ───────────────────────────────────────────────────── */
@@ -279,8 +350,6 @@ export const VerificationFlow: React.FC = () => {
             setTimeout(() => setStep('upload'), 0);
             return;
         }
-
-        let cancelled = false;
 
         let cancelled = false;
 
@@ -311,7 +380,7 @@ export const VerificationFlow: React.FC = () => {
         return () => {
             cancelled = true;
         };
-    }, [step]);
+    }, [step, trackJob]);
 
     /* ── Derived IDs ─────────────────────────────────────────────────────────── */
 
@@ -344,6 +413,11 @@ export const VerificationFlow: React.FC = () => {
                     onImageChange={setImageFile}
                     onTextChange={setTextInput}
                     onSubmit={handleSubmit}
+                    includeLocation={includeLocation}
+                    locationPermission={locationPermission}
+                    locationData={locationData}
+                    onLocationConsentToggle={handleLocationConsentToggle}
+                    onRequestLocation={handleRequestLocation}
                 />
             )}
 
@@ -372,6 +446,11 @@ interface StepUploadProps {
     onImageChange: (file: File | null) => void;
     onTextChange: (text: string) => void;
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    includeLocation: boolean;
+    locationPermission: LocationPermissionState;
+    locationData: CapturedLocation | null;
+    onLocationConsentToggle: (checked: boolean) => void;
+    onRequestLocation: () => void;
 }
 
 /**
@@ -393,6 +472,11 @@ function StepUpload({
     onImageChange,
     onTextChange,
     onSubmit,
+    includeLocation,
+    locationPermission,
+    locationData,
+    onLocationConsentToggle,
+    onRequestLocation,
 }: StepUploadProps) {
     const role = getAppUserRole();
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -517,6 +601,61 @@ function StepUpload({
                     >
                         {errors.text}
                     </span>
+                )}
+            </div>
+
+            <div className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-800/50">
+                <label className="flex items-start gap-3">
+                    <input
+                        type="checkbox"
+                        checked={includeLocation}
+                        onChange={(e) => onLocationConsentToggle(e.target.checked)}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span>
+                        <span className="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                            Share approximate location (optional)
+                        </span>
+                        <span className="block text-xs text-gray-600 dark:text-gray-400 mt-1">
+                            We use this only to add context for field verification and delivery routing. Your request still works if you choose not to share.
+                        </span>
+                    </span>
+                </label>
+
+                {includeLocation && (
+                    <div className="mt-3 space-y-2">
+                        <button
+                            type="button"
+                            onClick={onRequestLocation}
+                            disabled={locationPermission === 'requesting'}
+                            className="px-3 py-1.5 text-xs font-medium rounded-md border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 disabled:opacity-60 disabled:cursor-not-allowed dark:border-blue-700 dark:bg-blue-900/40 dark:text-blue-200 dark:hover:bg-blue-900/60"
+                        >
+                            {locationPermission === 'requesting'
+                                ? 'Requesting location...'
+                                : 'Allow location access'}
+                        </button>
+
+                        {locationPermission === 'granted' && locationData && (
+                            <p className="text-xs text-green-700 dark:text-green-300">
+                                Location added (accuracy: ±{Math.round(locationData.accuracy)}m).
+                            </p>
+                        )}
+                        {locationPermission === 'denied' && (
+                            <p className="text-xs text-amber-700 dark:text-amber-300">
+                                Location permission was denied. You can continue without it.
+                            </p>
+                        )}
+                        {locationPermission === 'unsupported' && (
+                            <p className="text-xs text-amber-700 dark:text-amber-300">
+                                Location is not supported in this browser. You can continue without it.
+                            </p>
+                        )}
+                        {locationPermission === 'error' && (
+                            <p className="text-xs text-amber-700 dark:text-amber-300">
+                                We couldn&apos;t capture your location right now. You can continue without it.
+                            </p>
+                        )}
+                    </div>
                 )}
             </div>
 

--- a/app/frontend/src/components/__tests__/VerificationFlow.test.ts
+++ b/app/frontend/src/components/__tests__/VerificationFlow.test.ts
@@ -10,7 +10,7 @@
  * manual integration testing documented in the walkthrough.
  */
 
-import { detectPii, validateUploadForm } from '../VerificationFlow';
+import { detectPii, parseVerificationDraft, validateUploadForm } from '../VerificationFlow';
 
 /* ─── Helpers ────────────────────────────────────────────────────────────── */
 
@@ -189,5 +189,49 @@ describe('detectPii', () => {
     it('returns detected: false for empty string', () => {
         const result = detectPii('');
         expect(result.detected).toBe(false);
+    });
+});
+
+describe('parseVerificationDraft', () => {
+    it('returns null for missing draft', () => {
+        expect(parseVerificationDraft(null)).toBeNull();
+    });
+
+    it('returns null for malformed JSON', () => {
+        expect(parseVerificationDraft('{bad-json')).toBeNull();
+    });
+
+    it('returns null for invalid shape', () => {
+        const draft = JSON.stringify({
+            textInput: 'Sample',
+            includeLocation: 'yes',
+            locationPermission: 'granted',
+            locationData: null,
+        });
+        expect(parseVerificationDraft(draft)).toBeNull();
+    });
+
+    it('parses a valid persisted draft', () => {
+        const draft = JSON.stringify({
+            textInput: 'Evidence details here',
+            includeLocation: true,
+            locationPermission: 'granted',
+            locationData: {
+                latitude: 12.34,
+                longitude: 56.78,
+                accuracy: 10,
+            },
+        });
+        const parsed = parseVerificationDraft(draft);
+        expect(parsed).toEqual({
+            textInput: 'Evidence details here',
+            includeLocation: true,
+            locationPermission: 'granted',
+            locationData: {
+                latitude: 12.34,
+                longitude: 56.78,
+                accuracy: 10,
+            },
+        });
     });
 });


### PR DESCRIPTION
closes #287
- Some verification and delivery workflows benefit from optional location context but it must be requested transparently and only with user consent.  
- The verification flow must continue to work when location is denied, unsupported, or fails, and location should never be requested automatically.
-- Added consent state and captured location state to the verification flow (`includeLocation`, `locationPermission`, `locationData`) and a small `CapturedLocation` type and `LocationPermissionState` union.  
- Implemented an explicit `Allow location access` action that calls `navigator.geolocation.getCurrentPosition` and sets `granted`, `denied`, `unsupported`, or `error` states; location is cleared when the user opts out.  
- Updated payload construction to append `location_latitude`, `location_longitude`, and `location_accuracy_meters` to the `FormData` only when the user opted in and permission was granted.  
- Added a consent UI block in the upload step explaining the purpose and non-blocking messages for denied/unsupported/error states, and fixed a missing effect dependency by adding `trackJob` to the `useEffect` dependency list in `VerificationFlow`.