### PR TITLE
API Deprecation Headers

### DIFF
--- a/app/backend/src/app.controller.ts
+++ b/app/backend/src/app.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { AppService } from './app.service';
 import { API_VERSIONS } from './common/constants/api-version.constants';
 import { Public } from './common/decorators/public.decorator';
+import { Deprecated } from './common/decorators/deprecated.decorator';
 
 @ApiTags('App')
 @Controller()
@@ -40,5 +41,18 @@ export class AppController {
   @ApiOkResponse({ description: 'Service is available.' })
   health() {
     return { status: 'ok', service: 'backend' };
+  }
+
+  @Public()
+  @Get('deprecated-test')
+  @Deprecated({
+    deprecatedSince: '2025-01-01',
+    sunsetDate: '2025-12-31',
+    reason: 'This endpoint is for testing deprecation headers.',
+    alternative: '/api/v1/health',
+    migrationGuide: 'https://docs.pulsefy.com/migration',
+  })
+  deprecatedTest() {
+    return { message: 'This endpoint is deprecated' };
   }
 }

--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -39,6 +39,8 @@ import { InvitesModule } from './orgs/invites.module';
 import { AdminSearchModule } from './search/admin-search.module';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { AdaptiveRateLimitGuard } from './common/guards/adaptive-rate-limit.guard';
+import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
+
 
 @Module({
   imports: [
@@ -129,6 +131,10 @@ import { AdaptiveRateLimitGuard } from './common/guards/adaptive-rate-limit.guar
     {
       provide: APP_INTERCEPTOR,
       useClass: LoggingInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: DeprecationInterceptor,
     },
   ],
 })

--- a/app/backend/src/common/index.ts
+++ b/app/backend/src/common/index.ts
@@ -9,3 +9,6 @@ export * from './constants/api-version.constants';
 
 // Decorators
 export * from './decorators/deprecated.decorator';
+
+// Interceptors
+export * from './interceptors/deprecation.interceptor';

--- a/app/backend/src/common/interceptors/deprecation.interceptor.ts
+++ b/app/backend/src/common/interceptors/deprecation.interceptor.ts
@@ -5,7 +5,6 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { Response } from 'express';
 import { getDeprecationMetadata } from '../decorators/deprecated.decorator';
 import { DEPRECATION_POLICY } from '../constants/api-version.constants';
@@ -33,12 +32,18 @@ export class DeprecationInterceptor implements NestInterceptor {
       // RFC Draft: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header-02
       // Can be a boolean or a date
       const deprecationValue = metadata.deprecatedSince || 'true';
-      response.setHeader(DEPRECATION_POLICY.DEPRECATION_HEADER, deprecationValue);
+      response.setHeader(
+        DEPRECATION_POLICY.DEPRECATION_HEADER,
+        deprecationValue,
+      );
 
       // 2. Sunset Header
       // RFC 8594: https://tools.ietf.org/html/rfc8594
       if (metadata.sunsetDate) {
-        response.setHeader(DEPRECATION_POLICY.SUNSET_HEADER, metadata.sunsetDate);
+        response.setHeader(
+          DEPRECATION_POLICY.SUNSET_HEADER,
+          metadata.sunsetDate,
+        );
       }
 
       // 3. Link Header

--- a/app/backend/src/common/interceptors/deprecation.interceptor.ts
+++ b/app/backend/src/common/interceptors/deprecation.interceptor.ts
@@ -1,0 +1,65 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Response } from 'express';
+import { getDeprecationMetadata } from '../decorators/deprecated.decorator';
+import { DEPRECATION_POLICY } from '../constants/api-version.constants';
+
+/**
+ * DeprecationInterceptor
+ *
+ * This interceptor checks for deprecation metadata on handlers and controllers.
+ * If found, it adds the appropriate RFC-standardized deprecation headers to the response.
+ */
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const handler = context.getHandler();
+    const controller = context.getClass();
+
+    // Check for deprecation metadata on handler first, then controller
+    const metadata =
+      getDeprecationMetadata(handler) || getDeprecationMetadata(controller);
+
+    if (metadata && metadata.deprecated) {
+      const response = context.switchToHttp().getResponse<Response>();
+
+      // 1. Deprecation Header
+      // RFC Draft: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header-02
+      // Can be a boolean or a date
+      const deprecationValue = metadata.deprecatedSince || 'true';
+      response.setHeader(DEPRECATION_POLICY.DEPRECATION_HEADER, deprecationValue);
+
+      // 2. Sunset Header
+      // RFC 8594: https://tools.ietf.org/html/rfc8594
+      if (metadata.sunsetDate) {
+        response.setHeader(DEPRECATION_POLICY.SUNSET_HEADER, metadata.sunsetDate);
+      }
+
+      // 3. Link Header
+      // RFC 8288: https://tools.ietf.org/html/rfc8288
+      const links: string[] = [];
+
+      if (metadata.alternative) {
+        // Link to alternative resource
+        links.push(`<${metadata.alternative}>; rel="alternate"`);
+      }
+
+      if (metadata.migrationGuide) {
+        // Link to migration documentation
+        links.push(`<${metadata.migrationGuide}>; rel="deprecation"`);
+      }
+
+      if (links.length > 0) {
+        response.setHeader(DEPRECATION_POLICY.LINK_HEADER, links.join(', '));
+      }
+    }
+
+    return next.handle();
+  }
+}

--- a/app/backend/test/deprecation.e2e-spec.ts
+++ b/app/backend/test/deprecation.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('Deprecation Headers (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/api/deprecated-test (GET) should return deprecation headers', () => {
+    return request(app.getHttpServer())
+      .get('/api/deprecated-test')
+      .expect(200)
+      .expect((res) => {
+        // Check Deprecation header
+        expect(res.header['deprecation']).toBe('2025-01-01');
+        
+        // Check Sunset header
+        expect(res.header['sunset']).toBe('2025-12-31');
+        
+        // Check Link header
+        const linkHeader = res.header['link'];
+        expect(linkHeader).toContain('</api/v1/health>; rel="alternate"');
+        expect(linkHeader).toContain('<https://docs.pulsefy.com/migration>; rel="deprecation"');
+      });
+  });
+
+  it('/api/health (GET) should NOT return deprecation headers', () => {
+    return request(app.getHttpServer())
+      .get('/api/health')
+      .expect(200)
+      .expect((res) => {
+        expect(res.header['deprecation']).toBeUndefined();
+        expect(res.header['sunset']).toBeUndefined();
+        expect(res.header['link']).toBeUndefined();
+      });
+  });
+});


### PR DESCRIPTION
I implemented a reusable system for API deprecation warnings by adding a global DeprecationInterceptor that automatically attaches standard HTTP headers (Deprecation,Sunset, and Link) to responses when an endpoint is marked with the @Deprecated decorator. 

I also registered this interceptor globally in the backend, added a demonstration endpoint (`GET /api/deprecated-test`), and created an E2E test suite to verify the header behavior.

closes #260 