### PR TITLE
feat: Manual Verification Review Dashboard

### DIFF
--- a/app/frontend/src/app/[locale]/verification-review/page.tsx
+++ b/app/frontend/src/app/[locale]/verification-review/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { StatsBar } from '@/components/verification-review/StatsBar';
+import { ReviewFiltersBar } from '@/components/verification-review/ReviewFiltersBar';
+import { ReviewQueue } from '@/components/verification-review/ReviewQueue';
+import type { ReviewFilters } from '@/types/verification-review';
+
+const DEFAULT_FILTERS: ReviewFilters = {
+  status: '',
+  riskLevel: '',
+  dateFrom: '',
+  dateTo: '',
+  page: 1,
+};
+
+export default function VerificationReviewPage() {
+  const [filters, setFilters] = useState<ReviewFilters>(DEFAULT_FILTERS);
+
+  const handleFilterChange = useCallback((patch: Partial<ReviewFilters>) => {
+    setFilters(prev => ({ ...prev, ...patch }));
+  }, []);
+
+  const handlePageChange = useCallback((page: number) => {
+    setFilters(prev => ({ ...prev, page }));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-background to-gray-50 dark:to-gray-950">
+      <main className="container mx-auto px-4 py-12">
+        <div className="max-w-6xl mx-auto space-y-6">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-4 border-b border-gray-100 dark:border-gray-800 pb-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-blue-100 dark:bg-blue-900/30">
+                <ShieldCheck
+                  size={20}
+                  className="text-blue-600 dark:text-blue-400"
+                />
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">
+                  Verification Review
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Manual review queue for flagged verification cases
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <StatsBar />
+
+          {/* Filters */}
+          <div className="p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+            <ReviewFiltersBar filters={filters} onChange={handleFilterChange} />
+          </div>
+
+          {/* Queue */}
+          <div className="p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+            <ReviewQueue filters={filters} onPageChange={handlePageChange} />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/frontend/src/components/verification-review/ReviewActionDialog.tsx
+++ b/app/frontend/src/components/verification-review/ReviewActionDialog.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import React, { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X, AlertCircle } from 'lucide-react';
+import {
+  useApproveVerification,
+  useRejectVerification,
+  useRequestResubmission,
+} from '@/hooks/useVerificationInbox';
+
+type ActionType = 'approve' | 'reject' | 'resubmission';
+
+interface ReviewActionDialogProps {
+  verificationId: string;
+  action: ActionType;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const ACTION_CONFIG: Record<
+  ActionType,
+  {
+    title: string;
+    confirmLabel: string;
+    confirmClass: string;
+    needsReason: boolean;
+  }
+> = {
+  approve: {
+    title: 'Approve Verification',
+    confirmLabel: 'Approve',
+    confirmClass:
+      'bg-green-600 hover:bg-green-700 text-white focus:ring-green-500',
+    needsReason: false,
+  },
+  reject: {
+    title: 'Reject Verification',
+    confirmLabel: 'Reject',
+    confirmClass: 'bg-red-600 hover:bg-red-700 text-white focus:ring-red-500',
+    needsReason: true,
+  },
+  resubmission: {
+    title: 'Request Resubmission',
+    confirmLabel: 'Request Resubmission',
+    confirmClass:
+      'bg-orange-600 hover:bg-orange-700 text-white focus:ring-orange-500',
+    needsReason: true,
+  },
+};
+
+export function ReviewActionDialog({
+  verificationId,
+  action,
+  open,
+  onOpenChange,
+}: ReviewActionDialogProps) {
+  const cfg = ACTION_CONFIG[action];
+
+  const [reason, setReason] = useState('');
+  const [nextStep, setNextStep] = useState('');
+  const [internalNote, setInternalNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const approve = useApproveVerification();
+  const reject = useRejectVerification();
+  const resubmit = useRequestResubmission();
+
+  const isPending = approve.isPending || reject.isPending || resubmit.isPending;
+
+  function reset() {
+    setReason('');
+    setNextStep('');
+    setInternalNote('');
+    setError(null);
+  }
+
+  async function handleConfirm() {
+    setError(null);
+
+    if (cfg.needsReason && !reason.trim()) {
+      setError('A reason is required.');
+      return;
+    }
+
+    try {
+      if (action === 'approve') {
+        await approve.mutateAsync({
+          id: verificationId,
+          payload: {
+            nextStepMessage: nextStep || undefined,
+            internalNote: internalNote || undefined,
+          },
+        });
+      } else if (action === 'reject') {
+        await reject.mutateAsync({
+          id: verificationId,
+          payload: {
+            rejectionReason: reason,
+            nextStepMessage: nextStep || undefined,
+            internalNote: internalNote || undefined,
+          },
+        });
+      } else {
+        await resubmit.mutateAsync({
+          id: verificationId,
+          payload: {
+            rejectionReason: reason,
+            nextStepMessage:
+              nextStep || 'Please resubmit the required documents.',
+            internalNote: internalNote || undefined,
+          },
+        });
+      }
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      setError(
+        (err as Error).message ?? 'Something went wrong. Please try again.',
+      );
+    }
+  }
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={v => {
+        if (!isPending) {
+          reset();
+          onOpenChange(v);
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md bg-white dark:bg-gray-900 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 p-6 space-y-4 focus:outline-none">
+          <div className="flex items-center justify-between">
+            <Dialog.Title className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              {cfg.title}
+            </Dialog.Title>
+            <Dialog.Close
+              disabled={isPending}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors disabled:opacity-50"
+            >
+              <X size={18} />
+            </Dialog.Close>
+          </div>
+
+          <div className="space-y-3">
+            {cfg.needsReason && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Reason <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={reason}
+                  onChange={e => setReason(e.target.value)}
+                  rows={3}
+                  placeholder={
+                    action === 'reject'
+                      ? 'e.g. Document appears fraudulent'
+                      : 'e.g. ID document is expired'
+                  }
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 resize-none"
+                />
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Next step message{' '}
+                <span className="text-gray-400 font-normal">(optional)</span>
+              </label>
+              <input
+                type="text"
+                value={nextStep}
+                onChange={e => setNextStep(e.target.value)}
+                placeholder="Instructions shown to the applicant"
+                className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Internal note{' '}
+                <span className="text-gray-400 font-normal">(staff only)</span>
+              </label>
+              <textarea
+                value={internalNote}
+                onChange={e => setInternalNote(e.target.value)}
+                rows={2}
+                placeholder="Private note for the review team"
+                className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 resize-none"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300">
+              <AlertCircle size={15} className="mt-0.5 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3 justify-end pt-1">
+            <Dialog.Close
+              disabled={isPending}
+              className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </Dialog.Close>
+            <button
+              onClick={handleConfirm}
+              disabled={isPending}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed ${cfg.confirmClass}`}
+            >
+              {isPending ? 'Saving…' : cfg.confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/frontend/src/components/verification-review/ReviewFiltersBar.tsx
+++ b/app/frontend/src/components/verification-review/ReviewFiltersBar.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { ChevronDown, X } from 'lucide-react';
+import type {
+  ReviewFilters,
+  VerificationStatus,
+  RiskLevel,
+} from '@/types/verification-review';
+
+const STATUS_OPTIONS: { value: VerificationStatus; label: string }[] = [
+  { value: 'pending_review', label: 'Pending Review' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'needs_resubmission', label: 'Needs Resubmission' },
+];
+
+const RISK_OPTIONS: { value: RiskLevel; label: string }[] = [
+  { value: 'low', label: 'Low Risk' },
+  { value: 'medium', label: 'Medium Risk' },
+  { value: 'high', label: 'High Risk' },
+];
+
+interface FilterSelectProps {
+  value: string;
+  onValueChange: (v: string) => void;
+  placeholder: string;
+  options: { value: string; label: string }[];
+}
+
+function FilterSelect({
+  value,
+  onValueChange,
+  placeholder,
+  options,
+}: FilterSelectProps) {
+  return (
+    <SelectPrimitive.Root
+      value={value || undefined}
+      onValueChange={onValueChange}
+    >
+      <SelectPrimitive.Trigger className="flex items-center gap-2 h-9 px-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors min-w-40">
+        <SelectPrimitive.Value placeholder={placeholder} />
+        <SelectPrimitive.Icon className="ml-auto text-gray-400">
+          <ChevronDown size={13} />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          className="z-50 min-w-(--radix-select-trigger-width) overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg"
+        >
+          <SelectPrimitive.Viewport className="p-1">
+            <SelectPrimitive.Item
+              value="__all__"
+              className="flex items-center px-3 py-2 rounded-md text-sm text-gray-500 dark:text-gray-400 cursor-pointer select-none outline-none data-[highlighted]:bg-gray-50 dark:data-[highlighted]:bg-gray-800 italic"
+            >
+              <SelectPrimitive.ItemText>{placeholder}</SelectPrimitive.ItemText>
+            </SelectPrimitive.Item>
+            <SelectPrimitive.Separator className="my-1 h-px bg-gray-100 dark:bg-gray-800" />
+            {options.map(opt => (
+              <SelectPrimitive.Item
+                key={opt.value}
+                value={opt.value}
+                className="flex items-center px-3 py-2 rounded-md text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none outline-none data-[highlighted]:bg-gray-50 dark:data-[highlighted]:bg-gray-800 data-[state=checked]:text-blue-600 dark:data-[state=checked]:text-blue-400 data-[state=checked]:font-medium"
+              >
+                <SelectPrimitive.ItemText>{opt.label}</SelectPrimitive.ItemText>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  );
+}
+
+interface ReviewFiltersBarProps {
+  filters: ReviewFilters;
+  onChange: (patch: Partial<ReviewFilters>) => void;
+}
+
+export function ReviewFiltersBar({ filters, onChange }: ReviewFiltersBarProps) {
+  const hasActive =
+    filters.status || filters.riskLevel || filters.dateFrom || filters.dateTo;
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      <FilterSelect
+        value={filters.status}
+        onValueChange={v =>
+          onChange({
+            status: v === '__all__' ? '' : (v as VerificationStatus),
+            page: 1,
+          })
+        }
+        placeholder="All Statuses"
+        options={STATUS_OPTIONS}
+      />
+
+      <FilterSelect
+        value={filters.riskLevel}
+        onValueChange={v =>
+          onChange({
+            riskLevel: v === '__all__' ? '' : (v as RiskLevel),
+            page: 1,
+          })
+        }
+        placeholder="All Risk Levels"
+        options={RISK_OPTIONS}
+      />
+
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+          From
+        </label>
+        <input
+          type="date"
+          value={filters.dateFrom}
+          onChange={e => onChange({ dateFrom: e.target.value, page: 1 })}
+          className="h-9 px-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+          To
+        </label>
+        <input
+          type="date"
+          value={filters.dateTo}
+          onChange={e => onChange({ dateTo: e.target.value, page: 1 })}
+          className="h-9 px-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
+        />
+      </div>
+
+      {hasActive && (
+        <button
+          onClick={() =>
+            onChange({
+              status: '',
+              riskLevel: '',
+              dateFrom: '',
+              dateTo: '',
+              page: 1,
+            })
+          }
+          className="flex items-center gap-1.5 h-9 px-3 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          <X size={13} />
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/verification-review/ReviewQueue.tsx
+++ b/app/frontend/src/components/verification-review/ReviewQueue.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import React, { useState } from 'react';
+import { format } from 'date-fns';
+import { ChevronLeft, ChevronRight, Inbox } from 'lucide-react';
+import { StatusBadge, RiskBadge } from './StatusBadge';
+import { VerificationDetailPanel } from './VerificationDetailPanel';
+import { useInbox } from '@/hooks/useVerificationInbox';
+import type { ReviewFilters, RiskLevel } from '@/types/verification-review';
+
+interface ReviewQueueProps {
+  filters: ReviewFilters;
+  onPageChange: (page: number) => void;
+}
+
+export function ReviewQueue({ filters, onPageChange }: ReviewQueueProps) {
+  const { data, isLoading, isError, error } = useInbox(filters);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 animate-pulse">
+        {[1, 2, 3, 4, 5].map(i => (
+          <div
+            key={i}
+            className="h-16 rounded-lg bg-gray-100 dark:bg-gray-800"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-sm text-red-700 dark:text-red-300">
+        Failed to load queue: {(error as Error).message}
+      </div>
+    );
+  }
+
+  if (!data || data.items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-gray-400 dark:text-gray-500 gap-3">
+        <Inbox size={36} strokeWidth={1.5} />
+        <p className="text-sm">
+          No verification cases match the current filters.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-4 min-h-0">
+      {/* List */}
+      <div className="flex-1 min-w-0 space-y-2">
+        {data.items.map(item => (
+          <button
+            key={item.id}
+            onClick={() =>
+              setSelectedId(item.id === selectedId ? null : item.id)
+            }
+            className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+              selectedId === item.id
+                ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                : 'border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-gray-200 dark:hover:border-gray-700'
+            }`}
+          >
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="font-mono text-xs text-gray-400 dark:text-gray-500 truncate max-w-[140px]">
+                  {item.id}
+                </span>
+                <StatusBadge status={item.status} />
+                {item.riskLevel && (
+                  <RiskBadge level={item.riskLevel as RiskLevel} />
+                )}
+              </div>
+              <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                {format(new Date(item.createdAt), 'dd MMM yyyy')}
+              </span>
+            </div>
+            {item.nextStepMessage && (
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
+                {item.nextStepMessage}
+              </p>
+            )}
+          </button>
+        ))}
+
+        {/* Pagination */}
+        {data.totalPages > 1 && (
+          <div className="flex items-center justify-between pt-2">
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              Page {data.page} of {data.totalPages} · {data.total} total
+            </span>
+            <div className="flex gap-1">
+              <button
+                onClick={() => onPageChange(data.page - 1)}
+                disabled={data.page <= 1}
+                className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <button
+                onClick={() => onPageChange(data.page + 1)}
+                disabled={data.page >= data.totalPages}
+                className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                <ChevronRight size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Detail panel */}
+      {selectedId && (
+        <div className="w-80 shrink-0 rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden flex flex-col">
+          <VerificationDetailPanel
+            verificationId={selectedId}
+            onClose={() => setSelectedId(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/verification-review/StatsBar.tsx
+++ b/app/frontend/src/components/verification-review/StatsBar.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import { useInboxStats } from '@/hooks/useVerificationInbox';
+
+interface StatTileProps {
+  label: string;
+  value: number;
+  colorClass: string;
+}
+
+function StatTile({ label, value, colorClass }: StatTileProps) {
+  return (
+    <div className="flex-1 min-w-[120px] p-4 rounded-lg border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900">
+      <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+        {label}
+      </p>
+      <p className={`text-2xl font-bold ${colorClass}`}>{value}</p>
+    </div>
+  );
+}
+
+export function StatsBar() {
+  const { data, isLoading } = useInboxStats();
+
+  if (isLoading || !data) {
+    return (
+      <div className="flex gap-3 flex-wrap animate-pulse">
+        {[1, 2, 3, 4, 5].map(i => (
+          <div
+            key={i}
+            className="flex-1 min-w-[120px] h-20 rounded-lg bg-gray-100 dark:bg-gray-800"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-3 flex-wrap">
+      <StatTile
+        label="Pending Review"
+        value={data.pending_review}
+        colorClass="text-yellow-600 dark:text-yellow-400"
+      />
+      <StatTile
+        label="Approved"
+        value={data.approved}
+        colorClass="text-green-600 dark:text-green-400"
+      />
+      <StatTile
+        label="Rejected"
+        value={data.rejected}
+        colorClass="text-red-600 dark:text-red-400"
+      />
+      <StatTile
+        label="Needs Resubmission"
+        value={data.needs_resubmission}
+        colorClass="text-orange-600 dark:text-orange-400"
+      />
+      <StatTile
+        label="Total"
+        value={data.total}
+        colorClass="text-gray-800 dark:text-gray-100"
+      />
+    </div>
+  );
+}

--- a/app/frontend/src/components/verification-review/StatusBadge.tsx
+++ b/app/frontend/src/components/verification-review/StatusBadge.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import type {
+  VerificationStatus,
+  RiskLevel,
+} from '@/types/verification-review';
+
+const STATUS_CONFIG: Record<
+  VerificationStatus,
+  { label: string; className: string }
+> = {
+  pending_review: {
+    label: 'Pending Review',
+    className:
+      'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  },
+  approved: {
+    label: 'Approved',
+    className:
+      'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  },
+  rejected: {
+    label: 'Rejected',
+    className: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  },
+  needs_resubmission: {
+    label: 'Needs Resubmission',
+    className:
+      'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  },
+};
+
+const RISK_CONFIG: Record<RiskLevel, { label: string; className: string }> = {
+  low: {
+    label: 'Low Risk',
+    className:
+      'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+  },
+  medium: {
+    label: 'Medium Risk',
+    className:
+      'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300',
+  },
+  high: {
+    label: 'High Risk',
+    className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+  },
+};
+
+export function StatusBadge({ status }: { status: VerificationStatus }) {
+  const cfg = STATUS_CONFIG[status];
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cfg.className}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+export function RiskBadge({ level }: { level: RiskLevel }) {
+  const cfg = RISK_CONFIG[level];
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cfg.className}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}

--- a/app/frontend/src/components/verification-review/VerificationDetailPanel.tsx
+++ b/app/frontend/src/components/verification-review/VerificationDetailPanel.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import React, { useState } from 'react';
+import { X, MessageSquare, Send, ChevronRight } from 'lucide-react';
+import { format } from 'date-fns';
+import { StatusBadge, RiskBadge } from './StatusBadge';
+import { ReviewActionDialog } from './ReviewActionDialog';
+import {
+  useVerificationDetail,
+  useVerificationNotes,
+  useAddNote,
+} from '@/hooks/useVerificationInbox';
+import type { RiskLevel } from '@/types/verification-review';
+
+interface VerificationDetailPanelProps {
+  verificationId: string;
+  onClose: () => void;
+}
+
+function AiScoreBar({ score }: { score: number }) {
+  const pct = Math.round(score * 100);
+  const color =
+    score >= 0.7
+      ? 'bg-green-500'
+      : score >= 0.4
+        ? 'bg-yellow-500'
+        : 'bg-red-500';
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400">
+        <span>AI Score</span>
+        <span className="font-medium text-gray-700 dark:text-gray-200">
+          {pct}%
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function VerificationDetailPanel({
+  verificationId,
+  onClose,
+}: VerificationDetailPanelProps) {
+  const { data: item, isLoading } = useVerificationDetail(verificationId);
+  const { data: notes } = useVerificationNotes(verificationId);
+  const addNote = useAddNote(verificationId);
+
+  const [noteText, setNoteText] = useState('');
+  const [activeAction, setActiveAction] = useState<
+    'approve' | 'reject' | 'resubmission' | null
+  >(null);
+
+  async function handleAddNote() {
+    if (!noteText.trim()) return;
+    await addNote.mutateAsync({ content: noteText.trim() });
+    setNoteText('');
+  }
+
+  const canReview =
+    item?.status === 'pending_review' || item?.status === 'needs_resubmission';
+
+  return (
+    <>
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-800 shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <ChevronRight size={14} className="text-gray-400 shrink-0" />
+            <span className="text-xs font-mono text-gray-500 dark:text-gray-400 truncate">
+              {verificationId}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          {isLoading || !item ? (
+            <div className="space-y-3 animate-pulse">
+              {[1, 2, 3, 4].map(i => (
+                <div
+                  key={i}
+                  className="h-8 rounded bg-gray-100 dark:bg-gray-800"
+                />
+              ))}
+            </div>
+          ) : (
+            <>
+              {/* Status + risk */}
+              <div className="flex flex-wrap gap-2">
+                <StatusBadge status={item.status} />
+                {item.riskLevel && (
+                  <RiskBadge level={item.riskLevel as RiskLevel} />
+                )}
+              </div>
+
+              {/* Evidence summary */}
+              <section className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  Evidence Summary
+                </h3>
+                <dl className="space-y-1.5 text-sm">
+                  {item.documentType && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-gray-500 dark:text-gray-400">
+                        Document type
+                      </dt>
+                      <dd className="font-medium text-gray-800 dark:text-gray-200 text-right">
+                        {item.documentType}
+                      </dd>
+                    </div>
+                  )}
+                  <div className="flex justify-between gap-4">
+                    <dt className="text-gray-500 dark:text-gray-400">
+                      Submitted
+                    </dt>
+                    <dd className="font-medium text-gray-800 dark:text-gray-200 text-right">
+                      {format(new Date(item.createdAt), 'dd MMM yyyy, HH:mm')}
+                    </dd>
+                  </div>
+                  {item.reviewedAt && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-gray-500 dark:text-gray-400">
+                        Reviewed
+                      </dt>
+                      <dd className="font-medium text-gray-800 dark:text-gray-200 text-right">
+                        {format(
+                          new Date(item.reviewedAt),
+                          'dd MMM yyyy, HH:mm',
+                        )}
+                      </dd>
+                    </div>
+                  )}
+                  {item.reviewedBy && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-gray-500 dark:text-gray-400">
+                        Reviewer
+                      </dt>
+                      <dd className="font-mono text-xs text-gray-700 dark:text-gray-300 text-right truncate max-w-[160px]">
+                        {item.reviewedBy}
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </section>
+
+              {/* AI score */}
+              {typeof item.aiScore === 'number' && (
+                <section className="space-y-2">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    AI Analysis
+                  </h3>
+                  <AiScoreBar score={item.aiScore} />
+                </section>
+              )}
+
+              {/* Rejection reason */}
+              {item.rejectionReason && (
+                <section className="space-y-1">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Rejection Reason
+                  </h3>
+                  <p className="text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 rounded-lg px-3 py-2">
+                    {item.rejectionReason}
+                  </p>
+                </section>
+              )}
+
+              {/* Next step message */}
+              {item.nextStepMessage && (
+                <section className="space-y-1">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                    Next Step
+                  </h3>
+                  <p className="text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-2">
+                    {item.nextStepMessage}
+                  </p>
+                </section>
+              )}
+
+              {/* Reviewer decision history (notes) */}
+              <section className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 flex items-center gap-1.5">
+                  <MessageSquare size={12} />
+                  Reviewer Notes
+                </h3>
+                {!notes || notes.length === 0 ? (
+                  <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+                    No notes yet.
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {notes.map(note => (
+                      <li
+                        key={note.id}
+                        className="text-sm bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-2 space-y-0.5"
+                      >
+                        <p className="text-gray-700 dark:text-gray-300">
+                          {note.content}
+                        </p>
+                        <p className="text-xs text-gray-400 dark:text-gray-500">
+                          {note.authorId} ·{' '}
+                          {format(
+                            new Date(note.createdAt),
+                            'dd MMM yyyy, HH:mm',
+                          )}
+                          {note.category && ` · ${note.category}`}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {/* Add note */}
+                <div className="flex gap-2 pt-1">
+                  <input
+                    type="text"
+                    value={noteText}
+                    onChange={e => setNoteText(e.target.value)}
+                    onKeyDown={e => e.key === 'Enter' && void handleAddNote()}
+                    placeholder="Add a note…"
+                    className="flex-1 h-8 px-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm text-gray-700 dark:text-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 transition-colors"
+                  />
+                  <button
+                    onClick={() => void handleAddNote()}
+                    disabled={!noteText.trim() || addNote.isPending}
+                    className="h-8 w-8 flex items-center justify-center rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Send size={13} />
+                  </button>
+                </div>
+              </section>
+            </>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        {canReview && (
+          <div className="px-5 py-4 border-t border-gray-100 dark:border-gray-800 shrink-0 flex gap-2">
+            <button
+              onClick={() => setActiveAction('approve')}
+              className="flex-1 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium transition-colors"
+            >
+              Approve
+            </button>
+            <button
+              onClick={() => setActiveAction('resubmission')}
+              className="flex-1 py-2 rounded-lg bg-orange-500 hover:bg-orange-600 text-white text-sm font-medium transition-colors"
+            >
+              Resubmit
+            </button>
+            <button
+              onClick={() => setActiveAction('reject')}
+              className="flex-1 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors"
+            >
+              Reject
+            </button>
+          </div>
+        )}
+      </div>
+
+      {activeAction && (
+        <ReviewActionDialog
+          verificationId={verificationId}
+          action={activeAction}
+          open={!!activeAction}
+          onOpenChange={open => !open && setActiveAction(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/frontend/src/hooks/useVerificationInbox.ts
+++ b/app/frontend/src/hooks/useVerificationInbox.ts
@@ -1,0 +1,178 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchInbox,
+  fetchStats,
+  fetchDetails,
+  fetchNotes,
+  approveVerification,
+  rejectVerification,
+  requestResubmission,
+  addNote,
+} from '@/lib/verification-inbox-api';
+import type {
+  ReviewFilters,
+  VerificationInboxItem,
+} from '@/types/verification-review';
+
+// ---------------------------------------------------------------------------
+// Query keys
+// ---------------------------------------------------------------------------
+export const inboxKeys = {
+  all: ['verification-inbox'] as const,
+  list: (filters: Partial<ReviewFilters>) =>
+    [...inboxKeys.all, 'list', filters] as const,
+  stats: () => [...inboxKeys.all, 'stats'] as const,
+  detail: (id: string) => [...inboxKeys.all, 'detail', id] as const,
+  notes: (id: string) => [...inboxKeys.all, 'notes', id] as const,
+};
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+export function useInbox(filters: Partial<ReviewFilters>) {
+  return useQuery({
+    queryKey: inboxKeys.list(filters),
+    queryFn: () => fetchInbox(filters),
+  });
+}
+
+export function useInboxStats() {
+  return useQuery({
+    queryKey: inboxKeys.stats(),
+    queryFn: fetchStats,
+    refetchInterval: 30_000, // refresh stats every 30s
+  });
+}
+
+export function useVerificationDetail(id: string) {
+  return useQuery({
+    queryKey: inboxKeys.detail(id),
+    queryFn: () => fetchDetails(id),
+    enabled: !!id,
+  });
+}
+
+export function useVerificationNotes(id: string) {
+  return useQuery({
+    queryKey: inboxKeys.notes(id),
+    queryFn: () => fetchNotes(id),
+    enabled: !!id,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — all with optimistic updates
+// ---------------------------------------------------------------------------
+
+function useReviewMutation(
+  mutationFn: (
+    id: string,
+    payload: Record<string, unknown>,
+  ) => Promise<VerificationInboxItem>,
+  targetStatus: VerificationInboxItem['status'],
+) {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: Record<string, unknown>;
+    }) => mutationFn(id, payload),
+
+    // Optimistic: flip the item's status immediately in every cached list
+    onMutate: async ({ id }) => {
+      await qc.cancelQueries({ queryKey: inboxKeys.all });
+
+      // Snapshot all list queries for rollback
+      const snapshots = qc.getQueriesData<{ items: VerificationInboxItem[] }>({
+        queryKey: inboxKeys.all,
+      });
+
+      qc.setQueriesData<{ items: VerificationInboxItem[] }>(
+        { queryKey: inboxKeys.all },
+        old => {
+          if (!old || !('items' in old)) return old;
+          return {
+            ...old,
+            items: old.items.map(item =>
+              item.id === id ? { ...item, status: targetStatus } : item,
+            ),
+          };
+        },
+      );
+
+      return { snapshots };
+    },
+
+    // Rollback on error
+    onError: (_err, _vars, context) => {
+      if (context?.snapshots) {
+        for (const [queryKey, data] of context.snapshots) {
+          qc.setQueryData(queryKey, data);
+        }
+      }
+    },
+
+    // Always refetch to sync server truth
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: inboxKeys.all });
+    },
+  });
+}
+
+export function useApproveVerification() {
+  return useReviewMutation(
+    (id, payload) =>
+      approveVerification(
+        id,
+        payload as { nextStepMessage?: string; internalNote?: string },
+      ),
+    'approved',
+  );
+}
+
+export function useRejectVerification() {
+  return useReviewMutation(
+    (id, payload) =>
+      rejectVerification(
+        id,
+        payload as {
+          rejectionReason: string;
+          nextStepMessage?: string;
+          internalNote?: string;
+        },
+      ),
+    'rejected',
+  );
+}
+
+export function useRequestResubmission() {
+  return useReviewMutation(
+    (id, payload) =>
+      requestResubmission(
+        id,
+        payload as {
+          rejectionReason: string;
+          nextStepMessage: string;
+          internalNote?: string;
+        },
+      ),
+    'needs_resubmission',
+  );
+}
+
+export function useAddNote(verificationId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: { content: string; category?: string }) =>
+      addNote(verificationId, payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: inboxKeys.notes(verificationId) });
+    },
+  });
+}

--- a/app/frontend/src/lib/user-role.ts
+++ b/app/frontend/src/lib/user-role.ts
@@ -1,4 +1,10 @@
-export const USER_ROLES = ['guest', 'client', 'operator', 'ngo', 'admin'] as const;
+export const USER_ROLES = [
+  'guest',
+  'client',
+  'operator',
+  'ngo',
+  'admin',
+] as const;
 
 export type UserRole = (typeof USER_ROLES)[number];
 
@@ -40,6 +46,12 @@ const NAVIGATION_ITEMS: readonly NavigationItem[] = [
     description: 'navigation.campaignsDescription',
     allowedRoles: CAMPAIGN_MANAGER_ROLES,
   },
+  {
+    href: '/verification-review',
+    label: 'navigation.verificationReview',
+    description: 'navigation.verificationReviewDescription',
+    allowedRoles: ['operator', 'admin'] as readonly UserRole[],
+  },
 ];
 
 export function normalizeUserRole(role?: string | null): UserRole {
@@ -54,7 +66,9 @@ export function normalizeUserRole(role?: string | null): UserRole {
     : DEFAULT_ROLE;
 }
 
-export function getUserRole(role = process.env.NEXT_PUBLIC_USER_ROLE): UserRole {
+export function getUserRole(
+  role = process.env.NEXT_PUBLIC_USER_ROLE,
+): UserRole {
   return normalizeUserRole(role);
 }
 

--- a/app/frontend/src/lib/verification-inbox-api.ts
+++ b/app/frontend/src/lib/verification-inbox-api.ts
@@ -1,0 +1,129 @@
+import { fetchClient } from '@/lib/mock-api/client';
+import type {
+  VerificationInboxResponse,
+  VerificationInboxItem,
+  VerificationStats,
+  InternalNote,
+  ReviewFilters,
+} from '@/types/verification-review';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
+const BASE = `${API_URL}/v1/verification-inbox`;
+
+function buildParams(filters: Partial<ReviewFilters>): string {
+  const p = new URLSearchParams();
+  if (filters.status) p.set('status', filters.status);
+  if (filters.page && filters.page > 1) p.set('page', String(filters.page));
+  if (filters.dateFrom) p.set('dateFrom', filters.dateFrom);
+  if (filters.dateTo) p.set('dateTo', filters.dateTo);
+  const q = p.toString();
+  return q ? `?${q}` : '';
+}
+
+export async function fetchInbox(
+  filters: Partial<ReviewFilters>,
+): Promise<VerificationInboxResponse> {
+  const res = await fetchClient(`${BASE}${buildParams(filters)}`);
+  if (!res.ok) throw new Error(`Failed to fetch inbox: ${res.status}`);
+  return res.json() as Promise<VerificationInboxResponse>;
+}
+
+export async function fetchStats(): Promise<VerificationStats> {
+  const res = await fetchClient(`${BASE}/stats`);
+  if (!res.ok) throw new Error(`Failed to fetch stats: ${res.status}`);
+  return res.json() as Promise<VerificationStats>;
+}
+
+export async function fetchDetails(id: string): Promise<VerificationInboxItem> {
+  const res = await fetchClient(`${BASE}/${id}`);
+  if (!res.ok) throw new Error(`Failed to fetch verification: ${res.status}`);
+  return res.json() as Promise<VerificationInboxItem>;
+}
+
+export async function approveVerification(
+  id: string,
+  payload: { nextStepMessage?: string; internalNote?: string },
+): Promise<VerificationInboxItem> {
+  const res = await fetchClient(`${BASE}/${id}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { message?: string }).message ?? `Approve failed: ${res.status}`,
+    );
+  }
+  return res.json() as Promise<VerificationInboxItem>;
+}
+
+export async function rejectVerification(
+  id: string,
+  payload: {
+    rejectionReason: string;
+    nextStepMessage?: string;
+    internalNote?: string;
+  },
+): Promise<VerificationInboxItem> {
+  const res = await fetchClient(`${BASE}/${id}/reject`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { message?: string }).message ?? `Reject failed: ${res.status}`,
+    );
+  }
+  return res.json() as Promise<VerificationInboxItem>;
+}
+
+export async function requestResubmission(
+  id: string,
+  payload: {
+    rejectionReason: string;
+    nextStepMessage: string;
+    internalNote?: string;
+  },
+): Promise<VerificationInboxItem> {
+  const res = await fetchClient(`${BASE}/${id}/request-resubmission`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { message?: string }).message ??
+        `Resubmission request failed: ${res.status}`,
+    );
+  }
+  return res.json() as Promise<VerificationInboxItem>;
+}
+
+export async function fetchNotes(id: string): Promise<InternalNote[]> {
+  const res = await fetchClient(`${BASE}/${id}/notes`);
+  if (!res.ok) throw new Error(`Failed to fetch notes: ${res.status}`);
+  return res.json() as Promise<InternalNote[]>;
+}
+
+export async function addNote(
+  id: string,
+  payload: { content: string; category?: string },
+): Promise<InternalNote> {
+  const res = await fetchClient(`${BASE}/${id}/notes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { message?: string }).message ??
+        `Add note failed: ${res.status}`,
+    );
+  }
+  return res.json() as Promise<InternalNote>;
+}

--- a/app/frontend/src/types/verification-review.ts
+++ b/app/frontend/src/types/verification-review.ts
@@ -1,0 +1,57 @@
+export type VerificationStatus =
+  | 'pending_review'
+  | 'approved'
+  | 'rejected'
+  | 'needs_resubmission';
+
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export interface VerificationInboxItem {
+  id: string;
+  status: VerificationStatus;
+  createdAt: string;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+  nextStepMessage: string | null;
+  deepLink: string;
+  // AI scoring fields (present when available)
+  aiScore?: number | null;
+  riskLevel?: RiskLevel | null;
+  documentType?: string | null;
+}
+
+export interface VerificationInboxResponse {
+  items: VerificationInboxItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface VerificationStats {
+  pending_review: number;
+  approved: number;
+  rejected: number;
+  needs_resubmission: number;
+  total: number;
+}
+
+export interface InternalNote {
+  id: string;
+  entityType: string;
+  entityId: string;
+  content: string;
+  authorId: string;
+  category: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewFilters {
+  status: VerificationStatus | '';
+  riskLevel: RiskLevel | '';
+  dateFrom: string;
+  dateTo: string;
+  page: number;
+}


### PR DESCRIPTION

Builds a staff-facing dashboard for reviewing verification cases flagged for manual review. Operators and admins can filter the queue, inspect evidence summaries and AI scores, view full decision history, and approve/reject/request resubmission — all with optimistic UI and error recovery.

---

## What changed

### Frontend

**New types** — `src/types/verification-review.ts`

- `VerificationInboxItem`, `VerificationInboxResponse`, `VerificationStats`, `InternalNote`, `ReviewFilters`
- Typed `VerificationStatus` (`pending_review | approved | rejected | needs_resubmission`) and `RiskLevel` (`low | medium | high`)

**API client** — `src/lib/verification-inbox-api.ts`

- Thin fetch wrappers for all 8 backend endpoints: list inbox, stats, detail, approve, reject, request-resubmission, list notes, add note
- Uses the existing `fetchClient` (mock-aware) and throws typed errors with server message passthrough

**React Query hooks** — `src/hooks/useVerificationInbox.ts`

- `useInbox(filters)` — paginated queue list
- `useInboxStats()` — stat counts, auto-refreshes every 30 seconds
- `useVerificationDetail(id)` — single item detail
- `useVerificationNotes(id)` — internal notes for a case
- `useApproveVerification`, `useRejectVerification`, `useRequestResubmission` — all three share a single optimistic mutation factory that:
  1. Cancels in-flight queries
  2. Snapshots all cached list data
  3. Flips the item status immediately in every cached list
  4. Rolls back all snapshots on error
  5. Invalidates the full inbox key on settle to sync server truth
- `useAddNote(verificationId)` — adds a note and invalidates the notes cache

**Components** — `src/components/verification-review/`

| File                          | Purpose                                                                                                                                                                   |
| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `StatusBadge.tsx`             | Colour-coded badges for status and risk level                                                                                                                             |
| `StatsBar.tsx`                | Five stat tiles (pending, approved, rejected, resubmission, total) with skeleton loading                                                                                  |
| `ReviewFiltersBar.tsx`        | Status select, risk level select, date-from/to inputs, clear-all button                                                                                                   |
| `ReviewActionDialog.tsx`      | Radix Dialog for approve/reject/resubmit — validates required reason field, shows inline error, disables controls while pending                                           |
| `VerificationDetailPanel.tsx` | Slide-in panel showing evidence summary, AI score progress bar, rejection reason, next-step message, full reviewer note history, inline note composer, and action buttons |
| `ReviewQueue.tsx`             | Paginated list of inbox items; clicking a row opens the detail panel in a split view; handles loading, error, and empty states                                            |

**Page** — `src/app/[locale]/verification-review/page.tsx`

- Client component composing StatsBar → ReviewFiltersBar → ReviewQueue
- Filter state is local (`useState`) — no URL pollution for this staff-only view
- Route is locale-aware (`/[locale]/verification-review`)

**Navigation** — `src/lib/user-role.ts`

- Added `/verification-review` to `NAVIGATION_ITEMS`, restricted to `operator` and `admin` roles

---

## How the optimistic flow works

```
User clicks Approve
  → status flips to "approved" in UI immediately
  → POST /v1/verification-inbox/:id/approve fires in background
    ✓ success → invalidate queries → server data syncs in
    ✗ error   → all snapshots restored → error shown in dialog
```

No double-submission is possible — the dialog disables all controls while the mutation is pending.

---

## Backend endpoints consumed

All endpoints already existed and are role-protected (`operator | admin`).

| Method | Path                                              | Used by                  |
| ------ | ------------------------------------------------- | ------------------------ |
| `GET`  | `/v1/verification-inbox`                          | `useInbox`               |
| `GET`  | `/v1/verification-inbox/stats`                    | `useInboxStats`          |
| `GET`  | `/v1/verification-inbox/:id`                      | `useVerificationDetail`  |
| `POST` | `/v1/verification-inbox/:id/approve`              | `useApproveVerification` |
| `POST` | `/v1/verification-inbox/:id/reject`               | `useRejectVerification`  |
| `POST` | `/v1/verification-inbox/:id/request-resubmission` | `useRequestResubmission` |
| `GET`  | `/v1/verification-inbox/:id/notes`                | `useVerificationNotes`   |
| `POST` | `/v1/verification-inbox/:id/notes`                | `useAddNote`             |

---

## No backend changes

All required endpoints, role guards, audit logging, and internal note persistence were already in place from the existing `VerificationInboxController` and `VerificationInboxService`.


closes #300 