### PR TITLE
Add Stellar explorer links to claim receipts

### DIFF
--- a/app/frontend/src/app/[locale]/claim-receipt/page.tsx
+++ b/app/frontend/src/app/[locale]/claim-receipt/page.tsx
@@ -37,6 +37,8 @@ export default function ClaimReceiptPage() {
           amount: 150.5,
           tokenAddress:
             'GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ5LKG3FZTSZ3NYNEJBBENSN',
+          transactionHash:
+            '2f2d55a527dd3a313a21f3d2b8d95bbd9680d4c6e5f3fdab3c8f8888fd1f0d0c',
           timestamp: new Date().toISOString(),
         };
 

--- a/app/frontend/src/components/ClaimReceipt.tsx
+++ b/app/frontend/src/components/ClaimReceipt.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Share2, Download, Copy, Check } from 'lucide-react';
-import { useTheme } from 'next-themes';
+import { Share2, Download, Copy, Check, ExternalLink } from 'lucide-react';
 import { format } from 'date-fns';
+import { getStellarExpertTransactionUrl } from '@/lib/stellar-explorer';
 
 export interface ClaimReceiptData {
   claimId: string;
@@ -11,6 +11,7 @@ export interface ClaimReceiptData {
   status: 'requested' | 'verified' | 'approved' | 'disbursed' | 'archived';
   amount: number;
   tokenAddress?: string;
+  transactionHash?: string;
   timestamp: string;
   recipientRef?: string;
 }
@@ -26,7 +27,6 @@ export const ClaimReceipt: React.FC<ClaimReceiptProps> = ({
   onShare,
   compact = false,
 }) => {
-  const { theme } = useTheme();
   const [copied, setCopied] = React.useState(false);
   const [sharing, setSharing] = React.useState(false);
 
@@ -55,14 +55,23 @@ export const ClaimReceipt: React.FC<ClaimReceiptProps> = ({
   }, [claim.timestamp]);
 
   const receiptText = useMemo(() => {
+    const explorerUrl = getStellarExpertTransactionUrl(claim.transactionHash);
+
     return `Claim Receipt
 Claim ID: ${claim.claimId}
 Package ID: ${claim.packageId}
 Status: ${claim.status.toUpperCase()}
 Amount: ${claim.amount} tokens
 Date: ${formattedDate}
-${claim.tokenAddress ? `Token Address: ${claim.tokenAddress}` : ''}`;
+${claim.tokenAddress ? `Token Address: ${claim.tokenAddress}` : ''}
+${claim.transactionHash ? `Transaction Hash: ${claim.transactionHash}` : ''}
+${explorerUrl ? `Explorer: ${explorerUrl}` : ''}`;
   }, [claim, formattedDate]);
+
+  const explorerUrl = useMemo(
+    () => getStellarExpertTransactionUrl(claim.transactionHash),
+    [claim.transactionHash],
+  );
 
   const handleCopy = async () => {
     try {
@@ -163,6 +172,23 @@ ${claim.tokenAddress ? `Token Address: ${claim.tokenAddress}` : ''}`;
           <div className="col-span-2">
             <p className="text-xs font-semibold opacity-75 mb-1">TOKEN ADDRESS</p>
             <p className="font-mono text-xs break-all">{claim.tokenAddress}</p>
+          </div>
+        )}
+        {claim.transactionHash && (
+          <div className="col-span-2">
+            <p className="text-xs font-semibold opacity-75 mb-1">TRANSACTION HASH</p>
+            <p className="font-mono text-xs break-all">{claim.transactionHash}</p>
+            {explorerUrl && (
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1 text-sm font-medium underline-offset-2 hover:underline"
+              >
+                View on Stellar Expert
+                <ExternalLink size={14} aria-hidden />
+              </a>
+            )}
           </div>
         )}
       </div>

--- a/app/frontend/src/lib/stellar-explorer.test.ts
+++ b/app/frontend/src/lib/stellar-explorer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { getStellarExpertTransactionUrl } from './stellar-explorer';
+
+jest.mock('./env', () => ({
+  stellarNetwork: 'testnet',
+}));
+
+describe('getStellarExpertTransactionUrl', () => {
+  it('returns a Stellar Expert testnet transaction URL', () => {
+    expect(getStellarExpertTransactionUrl(' abc123 ')).toBe(
+      'https://stellar.expert/explorer/testnet/tx/abc123',
+    );
+  });
+
+  it('returns null when no transaction hash is available', () => {
+    expect(getStellarExpertTransactionUrl()).toBeNull();
+    expect(getStellarExpertTransactionUrl('   ')).toBeNull();
+  });
+});

--- a/app/frontend/src/lib/stellar-explorer.ts
+++ b/app/frontend/src/lib/stellar-explorer.ts
@@ -1,0 +1,27 @@
+import { stellarNetwork } from './env';
+
+const STELLAR_EXPERT_NETWORKS: Record<string, string> = {
+  mainnet: 'public',
+  public: 'public',
+  testnet: 'testnet',
+  futurenet: 'futurenet',
+};
+
+export function getStellarExpertTransactionUrl(
+  transactionHash?: string | null,
+): string | null {
+  const normalizedHash = transactionHash?.trim();
+
+  if (!normalizedHash) {
+    return null;
+  }
+
+  const normalizedNetwork = stellarNetwork.trim().toLowerCase();
+  const explorerNetwork = STELLAR_EXPERT_NETWORKS[normalizedNetwork];
+
+  if (!explorerNetwork) {
+    return null;
+  }
+
+  return `https://stellar.expert/explorer/${explorerNetwork}/tx/${encodeURIComponent(normalizedHash)}`;
+}


### PR DESCRIPTION
## Summary
- add a client-safe Stellar Expert URL helper for supported networks
- show transaction hash and external explorer link on claim receipts when a hash is available
- include explorer metadata in copied/downloaded receipt text
- cover URL generation with focused unit tests

Closes #449

## Verification
- npm --prefix app/frontend test -- --runTestsByPath src/lib/stellar-explorer.test.ts
- npm --prefix app/frontend run lint -- src/components/ClaimReceipt.tsx src/lib/stellar-explorer.ts

Note: full type-check currently fails on existing unrelated errors in InlineFeedback.tsx and useOptimisticCampaignMutations.ts.