### PR TITLE
feat: add deterministic test provider for staging/testnet closes #459

### DIFF
--- a/app/ai-service/.env.example
+++ b/app/ai-service/.env.example
@@ -7,6 +7,7 @@ GROQ_API_KEY=your_groq_api_key_here
 OPENAI_MODEL=gpt-4o-mini
 GROQ_MODEL=llama-3.3-70b-versatile
 AI_DETERMINISTIC_MODE=false
+TEST_PROVIDER_MODE=false
 LLM_TIMEOUT_SECONDS=30
 
 # Application Settings

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
         OPENAI_MODEL: Default OpenAI model for humanitarian verification
         GROQ_MODEL: Default Groq model for humanitarian verification
         AI_DETERMINISTIC_MODE: Enable deterministic AI results for verification and classification during tests/CI
+        TEST_PROVIDER_MODE: Enable test provider mode that returns fixture-driven results (no API keys required)
         LLM_TIMEOUT_SECONDS: Timeout for LLM API requests
         APP_ENV: Application environment (development, staging, production)
         LOG_LEVEL: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
@@ -38,6 +39,7 @@ class Settings(BaseSettings):
     openai_model: str = "gpt-4o-mini"
     groq_model: str = "llama-3.3-70b-versatile"
     ai_deterministic_mode: bool = False
+    test_provider_mode: bool = False
     llm_timeout_seconds: int = 30
     
     # Application settings
@@ -69,12 +71,12 @@ class Settings(BaseSettings):
     
     def validate_api_keys(self) -> bool:
         """
-        Validate that at least one API key is configured
+        Validate that at least one API key or test mode is configured
         
         Returns:
-            bool: True if at least one API key is present, False otherwise
+            bool: True if at least one API key or test mode is present, False otherwise
         """
-        has_key = bool(self.openai_api_key or self.groq_api_key)
+        has_key = bool(self.openai_api_key or self.groq_api_key or self.test_provider_mode)
         
         if not has_key:
             logger.warning("No API keys configured. AI features will be unavailable.")
@@ -86,11 +88,13 @@ class Settings(BaseSettings):
         Determine which AI provider is configured
         
         Returns:
-            str: Provider name ('openai', 'groq') or None if not configured
+            str: Provider name ('test', 'openai', 'groq') or None if not configured
         """
+        if self.test_provider_mode:
+            return "test"
         if self.openai_api_key:
             return "openai"
-        elif self.groq_api_key:
+        if self.groq_api_key:
             return "groq"
         return None
 

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -41,7 +41,8 @@ class Settings(BaseSettings):
     ai_deterministic_mode: bool = False
     test_provider_mode: bool = False
     llm_timeout_seconds: int = 30
-    
+    circuit_breaker_failure_threshold: int = 3
+    circuit_breaker_recovery_timeout_seconds: float = 30.0
     # Application settings
     app_env: str = "development"
     log_level: str = "INFO"

--- a/app/ai-service/fixtures/humanitarian_responses.json
+++ b/app/ai-service/fixtures/humanitarian_responses.json
@@ -1,0 +1,32 @@
+[
+  {
+    "verdict": "credible",
+    "confidence": 0.74,
+    "summary": "The claim is well-supported by the provided evidence and aligns with humanitarian distribution records."
+  },
+  {
+    "verdict": "credible",
+    "confidence": 0.68,
+    "summary": "Claim is consistent with field reports and monitoring data from the region."
+  },
+  {
+    "verdict": "inconclusive",
+    "confidence": 0.45,
+    "summary": "Insufficient evidence to confirm or refute the claim. Additional documentation is required."
+  },
+  {
+    "verdict": "not_credible",
+    "confidence": 0.72,
+    "summary": "Claim contradicts verified distribution records and witness statements."
+  },
+  {
+    "verdict": "credible",
+    "confidence": 0.91,
+    "summary": "Strong corroborating evidence from multiple independent sources supports this claim."
+  },
+  {
+    "verdict": "inconclusive",
+    "confidence": 0.30,
+    "summary": "Limited evidence available. Further investigation and site visits are recommended."
+  }
+]

--- a/app/ai-service/schemas/humanitarian.py
+++ b/app/ai-service/schemas/humanitarian.py
@@ -8,6 +8,7 @@ class HumanitarianVerificationRequest(BaseModel):
     supporting_evidence: List[str] = Field(default_factory=list)
     context_factors: Dict[str, Any] = Field(default_factory=dict)
     provider_preference: Literal["auto", "test", "openai", "groq"] = "auto"
+    timeout: Optional[float] = Field(default=None, description="Request-level timeout in seconds for provider call")
 
 
 class HumanitarianVerificationResponse(BaseModel):

--- a/app/ai-service/schemas/humanitarian.py
+++ b/app/ai-service/schemas/humanitarian.py
@@ -7,7 +7,7 @@ class HumanitarianVerificationRequest(BaseModel):
     aid_claim: str = Field(min_length=10, description="Aid claim to verify")
     supporting_evidence: List[str] = Field(default_factory=list)
     context_factors: Dict[str, Any] = Field(default_factory=dict)
-    provider_preference: Literal["auto", "openai", "groq"] = "auto"
+    provider_preference: Literal["auto", "test", "openai", "groq"] = "auto"
 
 
 class HumanitarianVerificationResponse(BaseModel):

--- a/app/ai-service/services/circuit_breaker.py
+++ b/app/ai-service/services/circuit_breaker.py
@@ -1,0 +1,86 @@
+import time
+import logging
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitBreaker:
+    """
+    A thread-safe implementation of the Circuit Breaker pattern.
+    
+    States:
+    - CLOSED: Normal operation. Requests flow through.
+    - OPEN: Service is failing. Requests fail-fast (return False/raise error).
+    - HALF_OPEN: Recovery window elapsed. Allow a request to test downstream health.
+    """
+
+    def __init__(self, name: str, failure_threshold: int = 3, recovery_timeout: float = 30.0):
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        
+        self.state = "CLOSED"  # CLOSED, OPEN, HALF_OPEN
+        self.failure_count = 0
+        self.last_state_change = time.time()
+        self._lock = Lock()
+
+    def allow_request(self) -> bool:
+        """
+        Check if a request is allowed to proceed.
+        If in OPEN state and recovery timeout has elapsed, transitions to HALF_OPEN.
+        """
+        with self._lock:
+            now = time.time()
+            if self.state == "OPEN":
+                if now - self.last_state_change >= self.recovery_timeout:
+                    logger.info(
+                        "Circuit breaker for provider '%s' transitioning from OPEN to HALF_OPEN "
+                        "(recovery timeout %ss elapsed)",
+                        self.name,
+                        self.recovery_timeout,
+                    )
+                    self.state = "HALF_OPEN"
+                    self.last_state_change = now
+                    return True
+                return False
+            return True
+
+    def record_success(self) -> None:
+        """
+        Record a successful request.
+        If in HALF_OPEN, transitions back to CLOSED and resets failure count.
+        """
+        with self._lock:
+            now = time.time()
+            if self.state == "HALF_OPEN":
+                logger.info(
+                    "Circuit breaker for provider '%s' transitioning from HALF_OPEN to CLOSED "
+                    "(successful probe request)",
+                    self.name,
+                )
+                self.state = "CLOSED"
+                self.failure_count = 0
+                self.last_state_change = now
+            elif self.state == "CLOSED":
+                self.failure_count = 0
+
+    def record_failure(self) -> None:
+        """
+        Record a failed request.
+        If in CLOSED and threshold is reached, or if in HALF_OPEN, transitions to OPEN.
+        """
+        with self._lock:
+            now = time.time()
+            self.failure_count += 1
+            if self.state == "HALF_OPEN" or self.failure_count >= self.failure_threshold:
+                logger.warning(
+                    "Circuit breaker for provider '%s' transitioning from %s to OPEN "
+                    "(failures: %s, threshold: %s)",
+                    self.name,
+                    self.state,
+                    self.failure_count,
+                    self.failure_threshold,
+                )
+                self.state = "OPEN"
+                self.last_state_change = now

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -23,6 +23,18 @@ class HumanitarianVerificationService:
     def __init__(self):
         self.prompt_engine = HumanitarianPromptEngine()
         self.test_provider = TestProvider()
+        self.breakers = {
+            "openai": CircuitBreaker(
+                name="openai",
+                failure_threshold=settings.circuit_breaker_failure_threshold,
+                recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
+            ),
+            "groq": CircuitBreaker(
+                name="groq",
+                failure_threshold=settings.circuit_breaker_failure_threshold,
+                recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
+            ),
+        }
 
     def verify_claim(
         self,
@@ -30,6 +42,7 @@ class HumanitarianVerificationService:
         supporting_evidence: Optional[List[str]] = None,
         context_factors: Optional[Dict[str, Any]] = None,
         provider_preference: str = "auto",
+        timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
         start_time = time.time()
         try:
@@ -68,6 +81,7 @@ class HumanitarianVerificationService:
                             model=model,
                             system_prompt=prompt["system"],
                             user_prompt=prompt["user"],
+                            timeout=timeout,
                         )
                         parsed = self._parse_json_response(raw_content)
                         return {
@@ -112,16 +126,23 @@ class HumanitarianVerificationService:
             return settings.groq_model
         raise ValueError(f"Unsupported provider: {provider}")
 
-    def _call_provider(self, provider: str, model: str, system_prompt: str, user_prompt: str) -> str:
+    def _call_provider(
+        self,
+        provider: str,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        timeout: Optional[float] = None,
+    ) -> str:
         if provider == "test":
             return self._call_test(model, system_prompt, user_prompt)
         if provider == "openai":
-            return self._call_openai(model, system_prompt, user_prompt)
+            return self._call_openai(model, system_prompt, user_prompt, timeout)
         if provider == "groq":
-            return self._call_groq(model, system_prompt, user_prompt)
+            return self._call_groq(model, system_prompt, user_prompt, timeout)
         raise ValueError(f"Unsupported provider: {provider}")
 
-    def _call_openai(self, model: str, system_prompt: str, user_prompt: str) -> str:
+    def _call_openai(self, model: str, system_prompt: str, user_prompt: str, timeout: Optional[float] = None) -> str:
         if not settings.openai_api_key:
             raise RuntimeError("OpenAI API key is not configured")
 
@@ -131,9 +152,10 @@ class HumanitarianVerificationService:
             model=model,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
+            timeout=timeout,
         )
 
-    def _call_groq(self, model: str, system_prompt: str, user_prompt: str) -> str:
+    def _call_groq(self, model: str, system_prompt: str, user_prompt: str, timeout: Optional[float] = None) -> str:
         if not settings.groq_api_key:
             raise RuntimeError("Groq API key is not configured")
 
@@ -143,6 +165,7 @@ class HumanitarianVerificationService:
             model=model,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
+            timeout=timeout,
         )
 
     def _call_chat_completion_api(
@@ -152,6 +175,7 @@ class HumanitarianVerificationService:
         model: str,
         system_prompt: str,
         user_prompt: str,
+        timeout: Optional[float] = None,
     ) -> str:
         if settings.ai_deterministic_mode:
             logger.info("Deterministic AI mode enabled: returning stable response")
@@ -171,9 +195,9 @@ class HumanitarianVerificationService:
             "Content-Type": "application/json",
         }
 
-        timeout = float(settings.llm_timeout_seconds)
+        effective_timeout = timeout if timeout is not None else float(settings.llm_timeout_seconds)
 
-        with httpx.Client(timeout=timeout) as client:
+        with httpx.Client(timeout=effective_timeout) as client:
             response = client.post(base_url, json=payload, headers=headers)
             response.raise_for_status()
             data = response.json()

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -10,6 +10,7 @@ import httpx
 
 from config import settings
 from services.humanitarian_prompt import HumanitarianPromptEngine
+from services.test_provider import TestProvider
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class HumanitarianVerificationService:
 
     def __init__(self):
         self.prompt_engine = HumanitarianPromptEngine()
+        self.test_provider = TestProvider()
 
     def verify_claim(
         self,
@@ -85,17 +87,23 @@ class HumanitarianVerificationService:
 
     def _provider_attempt_order(self, provider_preference: str) -> List[str]:
         available: List[str] = []
+        if settings.test_provider_mode:
+            available.append("test")
         if settings.openai_api_key:
             available.append("openai")
         if settings.groq_api_key:
             available.append("groq")
 
         preference = (provider_preference or "auto").lower()
-        if preference in ("openai", "groq") and preference in available:
+        if preference == "test" and settings.test_provider_mode:
+            return [preference]
+        if preference in ("openai", "groq", "test") and preference in available:
             return [preference] + [provider for provider in available if provider != preference]
         return available
 
     def _get_model_for_provider(self, provider: str) -> str:
+        if provider == "test":
+            return "test-provider/fixture"
         if provider == "openai":
             return settings.openai_model
         if provider == "groq":
@@ -103,6 +111,8 @@ class HumanitarianVerificationService:
         raise ValueError(f"Unsupported provider: {provider}")
 
     def _call_provider(self, provider: str, model: str, system_prompt: str, user_prompt: str) -> str:
+        if provider == "test":
+            return self._call_test(model, system_prompt, user_prompt)
         if provider == "openai":
             return self._call_openai(model, system_prompt, user_prompt)
         if provider == "groq":
@@ -175,6 +185,16 @@ class HumanitarianVerificationService:
             raise RuntimeError("LLM returned empty content")
 
         return str(content)
+
+    def _call_test(self, model: str, system_prompt: str, user_prompt: str) -> str:
+        response = self.test_provider.get_response(
+            endpoint="humanitarian",
+            request_data={
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+            },
+        )
+        return json.dumps(response, separators=(",", ":"), sort_keys=True)
 
     def _get_deterministic_response(self, model: str, system_prompt: str, user_prompt: str) -> str:
         stable_response = {

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -10,7 +10,9 @@ import httpx
 
 from config import settings
 from services.humanitarian_prompt import HumanitarianPromptEngine
+from services.circuit_breaker import CircuitBreaker
 from services.test_provider import TestProvider
+from exceptions import AIServiceError
 
 logger = logging.getLogger(__name__)
 

--- a/app/ai-service/services/test_provider.py
+++ b/app/ai-service/services/test_provider.py
@@ -1,0 +1,68 @@
+"""Deterministic test provider that returns fixture-driven results."""
+
+# Prevent pytest from collecting this module as test code.
+__test__ = False
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+_FIXTURES_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "fixtures")
+
+
+class TestProvider:
+    """Returns stable, fixture-driven results for staging/testnet environments.
+
+    Selects a response deterministically by hashing the endpoint name together
+    with the serialised request data, so repeated calls with the same input
+    always produce the same output.
+
+    No API keys are required; the provider reads responses from JSON fixture
+    files stored under ``<project_root>/fixtures/``.
+    """
+
+    def __init__(self, fixtures_dir: str = _FIXTURES_DIR):
+        self._fixtures_dir = fixtures_dir
+        self._cache: Dict[str, Any] = {}
+
+    def get_response(self, endpoint: str, request_data: Dict[str, Any]) -> Dict[str, Any]:
+        fixture = self._load_fixtures(endpoint)
+        key = self._deterministic_key(endpoint, request_data)
+        idx = int(hashlib.sha256(key.encode()).hexdigest(), 16) % len(fixture)
+        selected = fixture[idx]
+        logger.info(
+            "TestProvider returning fixture %d/%d for endpoint=%s",
+            idx, len(fixture), endpoint,
+        )
+        return dict(selected)
+
+    def _deterministic_key(self, endpoint: str, request_data: Dict[str, Any]) -> str:
+        data_str = json.dumps(request_data, sort_keys=True, default=str)
+        return f"{endpoint}:{data_str}"
+
+    def _load_fixtures(self, endpoint: str) -> list:
+        if endpoint in self._cache:
+            return self._cache[endpoint]
+
+        fixture_path = os.path.join(self._fixtures_dir, f"{endpoint}_responses.json")
+        if not os.path.exists(fixture_path):
+            raise RuntimeError(
+                f"No fixtures found for endpoint '{endpoint}' at {fixture_path}. "
+                f"Create {fixture_path} with a JSON array of response objects."
+            )
+
+        with open(fixture_path) as f:
+            fixtures = json.load(f)
+
+        if not isinstance(fixtures, list):
+            fixtures = [fixtures]
+
+        if not fixtures:
+            raise RuntimeError(f"Fixture file {fixture_path} is empty")
+
+        self._cache[endpoint] = fixtures
+        return fixtures

--- a/app/ai-service/tests/test_config.py
+++ b/app/ai-service/tests/test_config.py
@@ -9,3 +9,33 @@ def test_ai_deterministic_mode_can_be_enabled_from_environment(monkeypatch):
     settings = Settings()
 
     assert settings.ai_deterministic_mode is True
+
+
+def test_test_provider_mode_can_be_enabled_from_environment(monkeypatch):
+    monkeypatch.setenv("TEST_PROVIDER_MODE", "true")
+
+    settings = Settings()
+
+    assert settings.test_provider_mode is True
+
+
+def test_test_provider_mode_defaults_to_false():
+    settings = Settings()
+
+    assert settings.test_provider_mode is False
+
+
+def test_active_provider_returns_test_when_test_provider_mode_enabled(monkeypatch):
+    monkeypatch.setenv("TEST_PROVIDER_MODE", "true")
+
+    settings = Settings()
+
+    assert settings.get_active_provider() == "test"
+
+
+def test_validate_api_keys_returns_true_when_test_provider_mode(monkeypatch):
+    monkeypatch.setenv("TEST_PROVIDER_MODE", "true")
+
+    settings = Settings()
+
+    assert settings.validate_api_keys() is True

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -108,3 +108,115 @@ class TestHumanitarianVerificationService:
         )
 
         assert first_result == second_result
+
+
+class TestTestProvider:
+    """Tests for the fixture-driven test provider mode."""
+
+    def setup_method(self):
+        self.service = HumanitarianVerificationService()
+
+    def test_test_provider_returns_stable_results_across_runs(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        first = self.service.verify_claim(
+            aid_claim="Food distribution reached 500 households in the flood-affected region.",
+            supporting_evidence=["WFP distribution log #A-42"],
+            context_factors={"disaster_type": "flooding"},
+            provider_preference="auto",
+        )
+        second = self.service.verify_claim(
+            aid_claim="Food distribution reached 500 households in the flood-affected region.",
+            supporting_evidence=["WFP distribution log #A-42"],
+            context_factors={"disaster_type": "flooding"},
+            provider_preference="auto",
+        )
+
+        assert first == second
+
+    def test_test_provider_provider_string_in_response(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        result = self.service.verify_claim(
+            aid_claim="Medical supplies delivered to clinic.",
+            supporting_evidence=["delivery receipt"],
+            context_factors={},
+            provider_preference="auto",
+        )
+
+        assert result["provider"] == "test"
+        assert result["model"] == "test-provider/fixture"
+
+    def test_test_provider_verdict_is_valid(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        known_verdicts = {"credible", "inconclusive", "not_credible"}
+
+        for i in range(12):
+            result = self.service.verify_claim(
+                aid_claim=f"Test claim number {i} with unique content to exercise different fixtures.",
+                supporting_evidence=[f"doc_{i}"],
+                context_factors={"iteration": i},
+                provider_preference="auto",
+            )
+            verdict = result["verification"]["verdict"]
+            assert verdict in known_verdicts, (
+                f"Unexpected verdict '{verdict}' at iteration {i}"
+            )
+
+    def test_test_provider_different_inputs_can_produce_different_results(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        results = set()
+        for i in range(20):
+            result = self.service.verify_claim(
+                aid_claim=f"Unique aid claim description with varying details {i}.",
+                supporting_evidence=[f"evidence_{i}"],
+                context_factors={"seed": i},
+                provider_preference="auto",
+            )
+            results.add(result["verification"]["verdict"])
+
+        assert len(results) > 1, (
+            "Test provider should produce more than one distinct verdict "
+            "across different inputs"
+        )
+
+    def test_test_provider_confidence_in_expected_range(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        for i in range(10):
+            result = self.service.verify_claim(
+                aid_claim=f"Confidence range check iteration {i}.",
+                supporting_evidence=[],
+                context_factors={},
+                provider_preference="auto",
+            )
+            confidence = result["verification"]["confidence"]
+            assert 0.0 <= confidence <= 1.0, (
+                f"Confidence {confidence} out of range at iteration {i}"
+            )
+
+    def test_test_provider_does_not_require_api_keys(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        result = self.service.verify_claim(
+            aid_claim="No API keys configured, but test provider should still work.",
+            supporting_evidence=["test"],
+            context_factors={},
+        )
+
+        assert result["provider"] == "test"
+        assert result["verification"]["verdict"] in {"credible", "inconclusive", "not_credible"}


### PR DESCRIPTION
Closes #459

---

## Summary
Adds a TEST_PROVIDER_MODE environment variable that activates a fixture-driven test provider, enabling the AI service to run without any API keys in staging/testnet/CI environments. The test provider returns stable, deterministic responses loaded from JSON fixture files, selected via SHA-256 hash of the request content — guaranteeing the same input always produces identical output.
## Changes
New files:
- services/test_provider.py — TestProvider class that loads endpoint-specific fixtures from fixtures/ and returns deterministic responses based on a hash of the serialized request data
- fixtures/humanitarian_responses.json — 6 fixture responses covering credible, inconclusive, and not_credible verdicts with varied confidence scores