### PR TITLE
feat(security): HMAC signature validation for backend webhooks

### DIFF
--- a/app/backend/.env.example
+++ b/app/backend/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL="file:./prisma/dev.db"
+WEBHOOK_SECRET="change-me-to-a-strong-random-secret"

--- a/app/backend/src/aid/aid.controller.ts
+++ b/app/backend/src/aid/aid.controller.ts
@@ -6,9 +6,11 @@ import {
   Patch,
   Delete,
   Put,
+  UseGuards,
 } from '@nestjs/common';
 import { AidService } from './aid.service';
 import { AiTaskWebhookDto } from './dto/ai-task-webhook.dto';
+import { WebhookHmacGuard } from '../common/guards/webhook-hmac.guard';
 import {
   ApiTags,
   ApiOperation,
@@ -91,6 +93,7 @@ export class AidController {
   })
   @ApiOkResponse({ description: 'Webhook received successfully.' })
   @ApiBadRequestResponse({ description: 'Invalid webhook payload.' })
+  @UseGuards(WebhookHmacGuard)
   @Post('webhook')
   async handleTaskWebhook(@Body() payload: AiTaskWebhookDto) {
     return this.aidService.handleTaskWebhook(payload);

--- a/app/backend/src/aid/aid.module.ts
+++ b/app/backend/src/aid/aid.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { AidService } from './aid.service';
 import { AidController } from './aid.controller';
 import { RedisService } from 'cache/redis.service';
+import { HmacModule } from '../common/hmac/hmac.module';
+import { WebhookHmacGuard } from '../common/guards/webhook-hmac.guard';
 
 @Module({
-  providers: [AidService, RedisService],
+  imports: [HmacModule],
+  providers: [AidService, RedisService, WebhookHmacGuard],
   controllers: [AidController],
   exports: [AidService],
 })

--- a/app/backend/src/common/guards/webhook-hmac.guard.ts
+++ b/app/backend/src/common/guards/webhook-hmac.guard.ts
@@ -1,0 +1,73 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { HmacService } from '../hmac/hmac.service';
+import { RedisService } from '../../../cache/redis.service';
+
+/** Maximum age of a webhook timestamp before it is rejected (5 minutes). */
+const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000;
+
+/** How long to remember a nonce to prevent replays (matches tolerance + buffer). */
+const NONCE_TTL_SECONDS = 10 * 60;
+
+/**
+ * Guard that validates inbound webhook requests:
+ *  1. Verifies the HMAC-SHA256 signature in `x-webhook-signature`.
+ *  2. Rejects requests whose timestamp is outside the tolerance window.
+ *  3. Rejects replayed requests by tracking the delivery nonce in Redis.
+ *
+ * The signature is computed over the raw JSON request body.
+ * Apply with `@UseGuards(WebhookHmacGuard)` on the handler.
+ */
+@Injectable()
+export class WebhookHmacGuard implements CanActivate {
+  constructor(
+    private readonly hmac: HmacService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<Request>();
+
+    const signature = req.headers['x-webhook-signature'];
+    if (typeof signature !== 'string' || !signature) {
+      throw new UnauthorizedException('Missing webhook signature');
+    }
+
+    // Verify HMAC over the raw body string
+    const rawBody: string =
+      typeof (req as Request & { rawBody?: string }).rawBody === 'string'
+        ? (req as Request & { rawBody?: string }).rawBody!
+        : JSON.stringify(req.body);
+
+    if (!this.hmac.verify(rawBody, signature)) {
+      throw new UnauthorizedException('Invalid webhook signature');
+    }
+
+    // Replay protection — timestamp window
+    const body = req.body as { timestamp?: string; deliveryId?: string };
+    const ts = body?.timestamp ? new Date(body.timestamp).getTime() : NaN;
+    if (isNaN(ts) || Math.abs(Date.now() - ts) > TIMESTAMP_TOLERANCE_MS) {
+      throw new UnauthorizedException('Webhook timestamp out of acceptable range');
+    }
+
+    // Replay protection — nonce dedup
+    const nonce = body?.deliveryId;
+    if (!nonce) {
+      throw new UnauthorizedException('Missing deliveryId nonce');
+    }
+
+    const nonceKey = `webhook:nonce:${nonce}`;
+    const seen = await this.redis.get(nonceKey);
+    if (seen) {
+      throw new UnauthorizedException('Webhook replay detected');
+    }
+
+    await this.redis.set(nonceKey, 1, NONCE_TTL_SECONDS);
+    return true;
+  }
+}

--- a/app/backend/src/common/hmac/hmac.module.ts
+++ b/app/backend/src/common/hmac/hmac.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { HmacService } from './hmac.service';
+
+@Module({
+  providers: [HmacService],
+  exports: [HmacService],
+})
+export class HmacModule {}

--- a/app/backend/src/common/hmac/hmac.service.ts
+++ b/app/backend/src/common/hmac/hmac.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+@Injectable()
+export class HmacService {
+  private readonly secret: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.secret = this.config.getOrThrow<string>('WEBHOOK_SECRET');
+  }
+
+  /**
+   * Signs a payload string and returns the hex HMAC-SHA256 digest.
+   * Use this when sending outbound callbacks so the receiver can verify.
+   */
+  sign(payload: string): string {
+    return createHmac('sha256', this.secret).update(payload).digest('hex');
+  }
+
+  /**
+   * Timing-safe comparison of a received signature against the expected one.
+   */
+  verify(payload: string, signature: string): boolean {
+    const expected = this.sign(payload);
+    try {
+      return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements HMAC-SHA256 signing and validation for backend webhooks, preventing request spoofing and replay attacks.

## Changes

### New files
- **`src/common/hmac/hmac.service.ts`** — `HmacService` with `sign(payload)` and `verify(payload, signature)` methods using HMAC-SHA256 and `timingSafeEqual` to prevent timing attacks.
- **`src/common/hmac/hmac.module.ts`** — NestJS module that provides and exports `HmacService`.
- **`src/common/guards/webhook-hmac.guard.ts`** — `WebhookHmacGuard` that enforces three layers of protection on inbound webhook requests:
  1. Validates the `x-webhook-signature` header (HMAC-SHA256 over the raw request body).
  2. Rejects requests whose `timestamp` is outside a ±5-minute window.
  3. Deduplicates `deliveryId` nonces in Redis (10-minute TTL) to block replayed requests.

### Modified files
- **`src/aid/aid.controller.ts`** — Added `@UseGuards(WebhookHmacGuard)` to `POST /aid/webhook`.
- **`src/aid/aid.module.ts`** — Imports `HmacModule` and provides `WebhookHmacGuard`.
- **`.env.example`** — Documents the required `WEBHOOK_SECRET` environment variable.

## How it works

**Outbound callbacks** — the sender calls `HmacService.sign(JSON.stringify(payload))` and attaches the result as the `x-webhook-signature` header.

**Inbound validation** — `WebhookHmacGuard` runs before the handler, rejects any request that fails signature verification, has a stale timestamp, or carries a previously seen `deliveryId`.

## Environment variable required

```
WEBHOOK_SECRET=<strong-random-secret>
```

## Testing

- Valid signed request within the time window → accepted.
- Missing or wrong signature → `401 Unauthorized`.
- Timestamp older than 5 minutes → `401 Unauthorized`.
- Replayed `deliveryId` → `401 Unauthorized`.

Closes #456