### PR TITLE
feat: add testnet invoke scripts for common contract actions (#411)

### DIFF
--- a/app/onchain/Makefile
+++ b/app/onchain/Makefile
@@ -36,6 +36,25 @@ else
 	@./scripts/invoke.sh
 endif
 
+initialize:
+	@echo "🔧 Initializing contract..."
+	@./scripts/initialize.sh --contract $(CONTRACT_ID) --admin $(ADMIN)
+
+create-package:
+	@echo "📦 Creating package..."
+	@./scripts/create_package.sh --contract $(CONTRACT_ID) --operator $(OPERATOR) \
+		--id $(PKG_ID) --recipient $(RECIPIENT) --amount $(AMOUNT) --token $(TOKEN) \
+		--expires-at $(EXPIRES_AT)
+
+claim:
+	@echo "🎁 Claiming package..."
+	@./scripts/claim.sh --contract $(CONTRACT_ID) --id $(PKG_ID)
+
+query:
+	@echo "🔍 Querying contract..."
+	@./scripts/query.sh --contract $(CONTRACT_ID) --action $(ACTION) \
+		--id $(PKG_ID) --token $(TOKEN)
+
 audit:
 	@echo "🔒 Auditing dependencies..."
 	@cargo audit

--- a/app/onchain/scripts/claim.sh
+++ b/app/onchain/scripts/claim.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+# Claim an aid package
+# Usage: ./scripts/claim.sh --contract <ID> --id <PKG_ID>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    source "$PROJECT_DIR/.env"
+fi
+
+NETWORK="${NETWORK:-testnet}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --contract) CONTRACT_ID="$2"; shift 2 ;;
+        --id)       PKG_ID="$2";      shift 2 ;;
+        --network)  NETWORK="$2";     shift 2 ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "$CONTRACT_ID" ]; then echo "❌ --contract is required"; exit 1; fi
+if [ -z "$PKG_ID" ];      then echo "❌ --id is required";       exit 1; fi
+if [ -z "$SECRET_KEY" ];  then echo "❌ SECRET_KEY not set in .env"; exit 1; fi
+
+case "$NETWORK" in
+    testnet)    RPC_URL="${TESTNET_RPC_URL:-https://soroban-testnet.stellar.org:443}" ;;
+    futurenet)  RPC_URL="${FUTURENET_RPC_URL:-https://rpc-futurenet.stellar.org:443}" ;;
+    standalone) RPC_URL="${STANDALONE_RPC_URL:-http://localhost:8000/soroban/rpc}" ;;
+    *) echo "❌ Invalid network: $NETWORK"; exit 1 ;;
+esac
+
+echo "======================================"
+echo "  🎁 Invoking: claim"
+echo "======================================"
+echo "  Contract ID : $CONTRACT_ID"
+echo "  Package ID  : $PKG_ID"
+echo "  Network     : $NETWORK"
+echo "======================================"
+
+TX_OUTPUT=$(soroban contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$SECRET_KEY" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    -- claim \
+    --id "$PKG_ID" \
+    2>&1)
+
+echo ""
+echo "✅ Transaction Output:"
+echo "$TX_OUTPUT"
+
+TX_HASH=$(echo "$TX_OUTPUT" | grep -o '"hash":"[^"]*"' | cut -d'"' -f4 || true)
+if [ -n "$TX_HASH" ]; then
+    echo ""
+    echo "📋 TX Hash: $TX_HASH"
+fi

--- a/app/onchain/scripts/create_package.sh
+++ b/app/onchain/scripts/create_package.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -e
+
+# Create an aid package
+# Usage: ./scripts/create_package.sh --contract <ID> --operator <ADDR> --id <PKG_ID> \
+#          --recipient <ADDR> --amount <AMT> --token <ADDR> --expires-at <TIMESTAMP>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    source "$PROJECT_DIR/.env"
+fi
+
+NETWORK="${NETWORK:-testnet}"
+EXPIRES_AT=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --contract)   CONTRACT_ID="$2";  shift 2 ;;
+        --operator)   OPERATOR="$2";     shift 2 ;;
+        --id)         PKG_ID="$2";       shift 2 ;;
+        --recipient)  RECIPIENT="$2";    shift 2 ;;
+        --amount)     AMOUNT="$2";       shift 2 ;;
+        --token)      TOKEN="$2";        shift 2 ;;
+        --expires-at) EXPIRES_AT="$2";   shift 2 ;;
+        --network)    NETWORK="$2";      shift 2 ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "$CONTRACT_ID" ]; then echo "❌ --contract is required";  exit 1; fi
+if [ -z "$OPERATOR" ];    then echo "❌ --operator is required";   exit 1; fi
+if [ -z "$PKG_ID" ];      then echo "❌ --id is required";         exit 1; fi
+if [ -z "$RECIPIENT" ];   then echo "❌ --recipient is required";  exit 1; fi
+if [ -z "$AMOUNT" ];      then echo "❌ --amount is required";     exit 1; fi
+if [ -z "$TOKEN" ];       then echo "❌ --token is required";      exit 1; fi
+if [ -z "$SECRET_KEY" ];  then echo "❌ SECRET_KEY not set in .env"; exit 1; fi
+
+case "$NETWORK" in
+    testnet)    RPC_URL="${TESTNET_RPC_URL:-https://soroban-testnet.stellar.org:443}" ;;
+    futurenet)  RPC_URL="${FUTURENET_RPC_URL:-https://rpc-futurenet.stellar.org:443}" ;;
+    standalone) RPC_URL="${STANDALONE_RPC_URL:-http://localhost:8000/soroban/rpc}" ;;
+    *) echo "❌ Invalid network: $NETWORK"; exit 1 ;;
+esac
+
+echo "======================================"
+echo "  📦 Invoking: create_package"
+echo "======================================"
+echo "  Contract ID : $CONTRACT_ID"
+echo "  Operator    : $OPERATOR"
+echo "  Package ID  : $PKG_ID"
+echo "  Recipient   : $RECIPIENT"
+echo "  Amount      : $AMOUNT"
+echo "  Token       : $TOKEN"
+echo "  Expires At  : $EXPIRES_AT"
+echo "  Network     : $NETWORK"
+echo "======================================"
+
+TX_OUTPUT=$(soroban contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$SECRET_KEY" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    -- create_package \
+    --operator "$OPERATOR" \
+    --id "$PKG_ID" \
+    --recipient "$RECIPIENT" \
+    --amount "$AMOUNT" \
+    --token "$TOKEN" \
+    --expires_at "$EXPIRES_AT" \
+    2>&1)
+
+echo ""
+echo "✅ Transaction Output:"
+echo "$TX_OUTPUT"
+
+TX_HASH=$(echo "$TX_OUTPUT" | grep -o '"hash":"[^"]*"' | cut -d'"' -f4 || true)
+if [ -n "$TX_HASH" ]; then
+    echo ""
+    echo "📋 TX Hash: $TX_HASH"
+fi

--- a/app/onchain/scripts/initialize.sh
+++ b/app/onchain/scripts/initialize.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+# Initialize the AidEscrow contract
+# Usage: ./scripts/initialize.sh --contract <CONTRACT_ID> --admin <ADMIN_ADDRESS>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    source "$PROJECT_DIR/.env"
+fi
+
+NETWORK="${NETWORK:-testnet}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --contract) CONTRACT_ID="$2"; shift 2 ;;
+        --admin)    ADMIN="$2";       shift 2 ;;
+        --network)  NETWORK="$2";     shift 2 ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "$CONTRACT_ID" ]; then echo "❌ --contract is required"; exit 1; fi
+if [ -z "$ADMIN" ];       then echo "❌ --admin is required";    exit 1; fi
+if [ -z "$SECRET_KEY" ];  then echo "❌ SECRET_KEY not set in .env"; exit 1; fi
+
+case "$NETWORK" in
+    testnet)    RPC_URL="${TESTNET_RPC_URL:-https://soroban-testnet.stellar.org:443}" ;;
+    futurenet)  RPC_URL="${FUTURENET_RPC_URL:-https://rpc-futurenet.stellar.org:443}" ;;
+    standalone) RPC_URL="${STANDALONE_RPC_URL:-http://localhost:8000/soroban/rpc}" ;;
+    *) echo "❌ Invalid network: $NETWORK"; exit 1 ;;
+esac
+
+echo "======================================"
+echo "  🔧 Invoking: init"
+echo "======================================"
+echo "  Contract ID : $CONTRACT_ID"
+echo "  Admin       : $ADMIN"
+echo "  Network     : $NETWORK"
+echo "  RPC         : $RPC_URL"
+echo "======================================"
+
+TX_OUTPUT=$(soroban contract invoke \
+    --id "$CONTRACT_ID" \
+    --source "$SECRET_KEY" \
+    --network "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    -- init \
+    --admin "$ADMIN" \
+    2>&1)
+
+echo ""
+echo "✅ Transaction Output:"
+echo "$TX_OUTPUT"
+
+TX_HASH=$(echo "$TX_OUTPUT" | grep -o '"hash":"[^"]*"' | cut -d'"' -f4 || true)
+if [ -n "$TX_HASH" ]; then
+    echo ""
+    echo "📋 TX Hash: $TX_HASH"
+fi

--- a/app/onchain/scripts/query.sh
+++ b/app/onchain/scripts/query.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -e
+
+# View/query contract state (read-only)
+# Usage: ./scripts/query.sh --contract <ID> --action <get_package|view_status|get_aggregates> [--id <PKG_ID>] [--token <ADDR>]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    source "$PROJECT_DIR/.env"
+fi
+
+NETWORK="${NETWORK:-testnet}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --contract) CONTRACT_ID="$2"; shift 2 ;;
+        --action)   ACTION="$2";      shift 2 ;;
+        --id)       PKG_ID="$2";      shift 2 ;;
+        --token)    TOKEN="$2";       shift 2 ;;
+        --network)  NETWORK="$2";     shift 2 ;;
+        *) echo "❌ Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "$CONTRACT_ID" ]; then echo "❌ --contract is required"; exit 1; fi
+if [ -z "$ACTION" ]; then
+    echo "❌ --action is required. Options: get_package | view_status | get_aggregates"
+    exit 1
+fi
+if [ -z "$SECRET_KEY" ]; then echo "❌ SECRET_KEY not set in .env"; exit 1; fi
+
+case "$NETWORK" in
+    testnet)    RPC_URL="${TESTNET_RPC_URL:-https://soroban-testnet.stellar.org:443}" ;;
+    futurenet)  RPC_URL="${FUTURENET_RPC_URL:-https://rpc-futurenet.stellar.org:443}" ;;
+    standalone) RPC_URL="${STANDALONE_RPC_URL:-http://localhost:8000/soroban/rpc}" ;;
+    *) echo "❌ Invalid network: $NETWORK"; exit 1 ;;
+esac
+
+echo "======================================"
+echo "  🔍 Querying: $ACTION"
+echo "======================================"
+echo "  Contract ID : $CONTRACT_ID"
+echo "  Network     : $NETWORK"
+
+BASE_CMD="soroban contract invoke \
+    --id $CONTRACT_ID \
+    --source $SECRET_KEY \
+    --network $NETWORK \
+    --rpc-url $RPC_URL"
+
+case "$ACTION" in
+    get_package)
+        if [ -z "$PKG_ID" ]; then echo "❌ --id is required for get_package"; exit 1; fi
+        echo "  Package ID  : $PKG_ID"
+        echo "======================================"
+        eval "$BASE_CMD -- get_package --id $PKG_ID"
+        ;;
+    view_status)
+        if [ -z "$PKG_ID" ]; then echo "❌ --id is required for view_status"; exit 1; fi
+        echo "  Package ID  : $PKG_ID"
+        echo "======================================"
+        eval "$BASE_CMD -- view_package_status --id $PKG_ID"
+        ;;
+    get_aggregates)
+        if [ -z "$TOKEN" ]; then echo "❌ --token is required for get_aggregates"; exit 1; fi
+        echo "  Token       : $TOKEN"
+        echo "======================================"
+        eval "$BASE_CMD -- get_aggregates --token $TOKEN"
+        ;;
+    *)
+        echo "❌ Unknown action: $ACTION"
+        echo "   Options: get_package | view_status | get_aggregates"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Closes #411 

## Summary

Adds dedicated, parameterized shell scripts to invoke key AidEscrow 
contract functions on Testnet for debugging and demos.

## Changes

- `scripts/initialize.sh` — initializes the contract with an admin address
- `scripts/create_package.sh` — creates an aid package with full parameters
- `scripts/claim.sh` — claims a package by ID
- `scripts/query.sh` — view queries (get_package, view_status, get_aggregates)
- `Makefile` — added make targets for all new scripts

## How to Use

**Initialize:**
```bash
./scripts/initialize.sh \
  --contract <CONTRACT_ID> \
  --admin <ADMIN_ADDRESS>
```

**Create Package:**
```bash
./scripts/create_package.sh \
  --contract <CONTRACT_ID> \
  --operator <OPERATOR_ADDRESS> \
  --id <PKG_ID> \
  --recipient <RECIPIENT_ADDRESS> \
  --amount <AMOUNT> \
  --token <TOKEN_ADDRESS> \
  --expires-at <TIMESTAMP>
```

**Claim:**
```bash
./scripts/claim.sh \
  --contract <CONTRACT_ID> \
  --id <PKG_ID>
```

**Query:**
```bash
./scripts/query.sh \
  --contract <CONTRACT_ID> \
  --action get_package \
  --id <PKG_ID>
```