### PR TITLE
Harden token validation and transfer errors

### DIFF
--- a/app/backend/src/onchain/SOROBAN_INTEGRATION.md
+++ b/app/backend/src/onchain/SOROBAN_INTEGRATION.md
@@ -81,6 +81,8 @@ Maps Soroban contract errors to standardized backend errors.
 | PackageNotFound | 404 | Package not found |
 | PackageExpired | 410 | Package has expired |
 | ContractPaused | 503 | Contract is paused |
+| InvalidToken | 400 | Invalid token contract address |
+| TokenTransferFailed | 502 | Token transfer failed |
 
 #### 5. **AidEscrowService** (`aid-escrow.service.ts`)
 

--- a/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
@@ -1,0 +1,62 @@
+import { SorobanErrorMapper } from './soroban-error.mapper';
+
+describe('SorobanErrorMapper', () => {
+  const mapper = new SorobanErrorMapper();
+
+  it('maps invalid token contract errors from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 17 })).toEqual({
+      statusCode: 400,
+      message: 'Invalid token contract address',
+      details: {
+        error_code: 17,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps reverted token transfers from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 18 })).toEqual({
+      statusCode: 502,
+      message: 'Token transfer failed',
+      details: {
+        error_code: 18,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps token errors from contract error messages', () => {
+    expect(
+      mapper.mapError(new Error('HostError: Error(Contract, #17) InvalidToken')),
+    ).toMatchObject({
+      statusCode: 400,
+      message: 'Invalid token contract address',
+      details: {
+        error_name: 'InvalidToken',
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps token errors embedded in Soroban JSON-RPC responses', () => {
+    expect(
+      mapper.mapError({
+        response: {
+          data: {
+            error: {
+              code: -32603,
+              message: 'HostError: Error(Contract, #18)',
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      statusCode: 502,
+      message: 'Token transfer failed',
+      details: {
+        error_code: 18,
+        error_type: 'contract_error',
+      },
+    });
+  });
+});

--- a/app/backend/src/onchain/utils/soroban-error.mapper.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.ts
@@ -32,6 +32,10 @@ export class SorobanErrorMapper {
     },
     13: { code: 400, message: 'Insufficient surplus funds' },
     14: { code: 503, message: 'Contract is paused' },
+    15: { code: 400, message: 'Claim window has not started' },
+    16: { code: 400, message: 'Invalid claim proof' },
+    17: { code: 400, message: 'Invalid token contract address' },
+    18: { code: 502, message: 'Token transfer failed' },
   };
 
   /**
@@ -91,7 +95,11 @@ export class SorobanErrorMapper {
         message.includes('AlreadyInitialized') ||
         message.includes('NotAuthorized') ||
         message.includes('PackageNotFound') ||
-        message.includes('PackageExpired'))
+        message.includes('PackageExpired') ||
+        message.includes('ClaimTooEarly') ||
+        message.includes('InvalidProof') ||
+        message.includes('InvalidToken') ||
+        message.includes('TokenTransferFailed'))
     ) {
       return this.mapContractErrorMessage(message);
     }
@@ -144,6 +152,10 @@ export class SorobanErrorMapper {
     const code = jsonRpcError.code;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const message = (jsonRpcError.message as string) || '';
+
+    if (message.includes('Error(Contract')) {
+      return this.mapContractErrorMessage(message);
+    }
 
     // JSON-RPC error codes mapping
     switch (code) {
@@ -215,6 +227,10 @@ export class SorobanErrorMapper {
       },
       InsufficientSurplus: { code: 400, message: 'Insufficient surplus funds' },
       ContractPaused: { code: 503, message: 'Contract is paused' },
+      ClaimTooEarly: { code: 400, message: 'Claim window has not started' },
+      InvalidProof: { code: 400, message: 'Invalid claim proof' },
+      InvalidToken: { code: 400, message: 'Invalid token contract address' },
+      TokenTransferFailed: { code: 502, message: 'Token transfer failed' },
     };
 
     for (const [errorKey, errorInfo] of Object.entries(errorMap)) {
@@ -225,6 +241,19 @@ export class SorobanErrorMapper {
           details: {
             error_type: 'contract_error',
             error_name: errorKey,
+          },
+        };
+      }
+    }
+
+    for (const [errorCode, errorInfo] of Object.entries(this.contractErrors)) {
+      if (new RegExp(`#${errorCode}(?!\\d)`).test(message)) {
+        return {
+          statusCode: errorInfo.code,
+          message: errorInfo.message,
+          details: {
+            error_type: 'contract_error',
+            error_code: Number(errorCode),
           },
         };
       }
@@ -290,6 +319,14 @@ export class SorobanErrorMapper {
     if (mapped.statusCode === 503) {
       throw new InternalServerErrorException({
         code: 503,
+        message: mapped.message,
+        details: mapped.details,
+      });
+    }
+
+    if (mapped.statusCode === 502) {
+      throw new InternalServerErrorException({
+        code: 502,
         message: mapped.message,
         details: mapped.details,
       });

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -21,8 +21,8 @@
 //! - Tests for invalid/edge cases are in `tests/aid_escrow_tests.rs`.
 
 use soroban_sdk::{
-    contract, contracterror, contractevent, contractimpl, contracttype, symbol_short, token,
-    Address, Bytes, Env, Map, String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, contracttype, symbol_short, Address,
+    Bytes, Env, IntoVal, Map, String, Symbol, Val, Vec,
 };
 
 // --- Storage Keys ---
@@ -103,6 +103,8 @@ pub enum Error {
     ContractPaused = 14,
     ClaimTooEarly = 15,
     InvalidProof = 16,
+    InvalidToken = 17,
+    TokenTransferFailed = 18,
 }
 
 // --- Contract Events (indexer-friendly; stable topics & payloads) ---
@@ -338,6 +340,11 @@ impl AidEscrow {
             return Err(Error::InvalidAmount);
         }
 
+        for i in 0..config.allowed_tokens.len() {
+            let token = config.allowed_tokens.get(i).ok_or(Error::InvalidToken)?;
+            Self::validate_token(&env, &token)?;
+        }
+
         env.storage().instance().set(&KEY_CONFIG, &config);
         Ok(())
     }
@@ -436,10 +443,8 @@ impl AidEscrow {
             return Err(Error::InvalidAmount);
         }
 
-        // 2. Fetch Decimals Dynamically
-        // This is the "production-ready" way. It ensures the check matches the token.
-        let token_client = token::Client::new(&env, &token);
-        let decimals = token_client.decimals();
+        // 2. Validate token interface and fetch decimals dynamically.
+        let decimals = Self::validate_token(&env, &token)?;
 
         // 3. Dynamic Precision Check
         // Instead of checking 6 AND 8, we check ONLY the decimals this token uses.
@@ -454,7 +459,13 @@ impl AidEscrow {
         from.require_auth();
 
         // 5. Perform Transfer
-        token_client.transfer(&from, env.current_contract_address(), &amount);
+        Self::transfer_token(
+            &env,
+            &token,
+            &from,
+            &env.current_contract_address(),
+            &amount,
+        )?;
 
         // 6. Events
         let timestamp = env.ledger().timestamp();
@@ -501,9 +512,8 @@ impl AidEscrow {
         }
 
         // --- DYNAMIC PRECISION CHECK ---
-        // Fetch the actual decimals from the token contract to avoid hardcoded traps.
-        let token_client = token::Client::new(&env, &token);
-        let decimals = token_client.decimals();
+        // Fetch the actual decimals from a validated token contract.
+        let decimals = Self::validate_token(&env, &token)?;
         let unit = 10i128.pow(decimals);
 
         // Enforce that only whole units can be used (if that is your business requirement).
@@ -534,7 +544,7 @@ impl AidEscrow {
         }
 
         // --- SOLVENCY CHECK ---
-        let contract_balance = token_client.balance(&env.current_contract_address());
+        let contract_balance = Self::token_balance(&env, &token, &env.current_contract_address())?;
 
         let mut locked_map: Map<Address, i128> = env
             .storage()
@@ -617,14 +627,24 @@ impl AidEscrow {
     ) -> Result<Vec<u64>, Error> {
         Self::check_action_paused(&env, symbol_short!("create"))?;
         Self::require_admin_or_distributor(&env, &operator)?;
+        let config = Self::get_config(env.clone());
 
         // Validate array lengths match
         if recipients.len() != amounts.len() || recipients.len() != metadatas.len() {
             return Err(Error::MismatchedArrays);
         }
 
-        let token_client = token::Client::new(&env, &token);
-        let contract_balance = token_client.balance(&env.current_contract_address());
+        if !config.allowed_tokens.is_empty() && !config.allowed_tokens.contains(token.clone()) {
+            return Err(Error::InvalidState);
+        }
+
+        if config.max_expires_in > 0 && (expires_in == 0 || expires_in > config.max_expires_in) {
+            return Err(Error::InvalidState);
+        }
+
+        let decimals = Self::validate_token(&env, &token)?;
+        let unit = 10i128.pow(decimals);
+        let contract_balance = Self::token_balance(&env, &token, &env.current_contract_address())?;
 
         let mut locked_map: Map<Address, i128> = env
             .storage()
@@ -656,6 +676,10 @@ impl AidEscrow {
 
             // Validate amount
             if amount <= 0 {
+                return Err(Error::InvalidAmount);
+            }
+
+            if amount < config.min_amount || amount % unit != 0 {
                 return Err(Error::InvalidAmount);
             }
 
@@ -835,20 +859,22 @@ impl AidEscrow {
             return Err(Error::PackageNotActive);
         }
 
+        // Transfer before accounting updates so reverted token transfers cannot
+        // leave the escrow state inconsistent.
+        Self::transfer_token(
+            &env,
+            &package.token,
+            &env.current_contract_address(),
+            &package.recipient,
+            &package.amount,
+        )?;
+
         // State Transition
         package.status = PackageStatus::Claimed;
         env.storage().persistent().set(&key, &package);
 
         // Update Locked
         Self::decrement_locked(&env, &package.token, package.amount);
-
-        // Transfer
-        let token_client = token::Client::new(&env, &package.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &package.recipient,
-            &package.amount,
-        );
 
         let timestamp = env.ledger().timestamp();
         PackageDisbursed {
@@ -913,12 +939,13 @@ impl AidEscrow {
         // Can only refund if Expired or Cancelled.
         // If Created, must Revoke first. If Claimed, impossible.
         // If Refunded, impossible.
+        let should_unlock_locked =
+            package.status == PackageStatus::Created || package.status == PackageStatus::Expired;
+
         if package.status == PackageStatus::Created {
             // Check if actually expired
             if package.expires_at > 0 && env.ledger().timestamp() > package.expires_at {
                 package.status = PackageStatus::Expired;
-                // If we just expired it, we need to unlock the funds first
-                Self::decrement_locked(&env, &package.token, package.amount);
             } else {
                 return Err(Error::InvalidState);
             }
@@ -929,15 +956,24 @@ impl AidEscrow {
         }
 
         // If Cancelled, funds were already unlocked in `revoke`.
-        // If Expired (logic above), funds were just unlocked.
+        // Expired packages are unlocked only after a successful refund transfer.
+
+        // Transfer Contract -> Admin
+        Self::transfer_token(
+            &env,
+            &package.token,
+            &env.current_contract_address(),
+            &admin,
+            &package.amount,
+        )?;
+
+        if should_unlock_locked {
+            Self::decrement_locked(&env, &package.token, package.amount);
+        }
 
         // State Transition
         package.status = PackageStatus::Refunded;
         env.storage().persistent().set(&key, &package);
-
-        // Transfer Contract -> Admin
-        let token_client = token::Client::new(&env, &package.token);
-        token_client.transfer(&env.current_contract_address(), &admin, &package.amount);
 
         let timestamp = env.ledger().timestamp();
         PackageRefunded {
@@ -1087,8 +1123,8 @@ impl AidEscrow {
         }
 
         // 3. Get contract's current balance for the token
-        let token_client = token::Client::new(&env, &token);
-        let contract_balance = token_client.balance(&env.current_contract_address());
+        Self::validate_token(&env, &token)?;
+        let contract_balance = Self::token_balance(&env, &token, &env.current_contract_address())?;
 
         // 4. Get total locked amount for the token
         let locked_map: Map<Address, i128> = env
@@ -1105,7 +1141,7 @@ impl AidEscrow {
         }
 
         // 6. Transfer funds from contract to recipient
-        token_client.transfer(&env.current_contract_address(), &to, &amount);
+        Self::transfer_token(&env, &token, &env.current_contract_address(), &to, &amount)?;
 
         // 7. Emit event
         SurplusWithdrawnEvent {
@@ -1166,6 +1202,43 @@ impl AidEscrow {
         env.storage().instance().set(&KEY_TOTAL_LOCKED, &locked_map);
     }
 
+    fn validate_token(env: &Env, token: &Address) -> Result<u32, Error> {
+        let args: Vec<Val> = Vec::new(env);
+
+        match env.try_invoke_contract::<u32, Error>(token, &symbol_short!("decimals"), args) {
+            Ok(Ok(decimals)) if decimals <= 38 => Ok(decimals),
+            _ => Err(Error::InvalidToken),
+        }
+    }
+
+    fn token_balance(env: &Env, token: &Address, account: &Address) -> Result<i128, Error> {
+        let mut args: Vec<Val> = Vec::new(env);
+        args.push_back(account.clone().into_val(env));
+
+        match env.try_invoke_contract::<i128, Error>(token, &symbol_short!("balance"), args) {
+            Ok(Ok(balance)) => Ok(balance),
+            _ => Err(Error::InvalidToken),
+        }
+    }
+
+    fn transfer_token(
+        env: &Env,
+        token: &Address,
+        from: &Address,
+        to: &Address,
+        amount: &i128,
+    ) -> Result<(), Error> {
+        let mut args: Vec<Val> = Vec::new(env);
+        args.push_back(from.clone().into_val(env));
+        args.push_back(to.clone().into_val(env));
+        args.push_back((*amount).into_val(env));
+
+        match env.try_invoke_contract::<(), Error>(token, &symbol_short!("transfer"), args) {
+            Ok(Ok(())) => Ok(()),
+            _ => Err(Error::TokenTransferFailed),
+        }
+    }
+
     fn resolve_claim_starts_at(
         env: &Env,
         metadata: &Map<Symbol, String>,
@@ -1206,6 +1279,14 @@ impl AidEscrow {
         payout_recipient: &Address,
         now: u64,
     ) -> Result<(), Error> {
+        Self::transfer_token(
+            env,
+            &package.token,
+            &env.current_contract_address(),
+            payout_recipient,
+            &package.amount,
+        )?;
+
         // State Transition
         package.status = PackageStatus::Claimed;
         env.storage().persistent().set(key, package);
@@ -1223,13 +1304,6 @@ impl AidEscrow {
         env.storage()
             .instance()
             .set(&KEY_TOTAL_CLAIMED, &claimed_map);
-
-        let token_client = token::Client::new(env, &package.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            payout_recipient,
-            &package.amount,
-        );
 
         PackageClaimed {
             package_id,

--- a/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
@@ -203,6 +203,73 @@ mod create_package {
 // claim — Tests
 // ===========================================================================
 
+// ===========================================================================
+// token validation and transfer failure tests
+// ===========================================================================
+
+mod token_interactions {
+    use super::*;
+
+    #[test]
+    fn create_package_rejects_invalid_token_address() {
+        let t = TestSetup::new();
+        let invalid_token = t.env.register(AidEscrow, ());
+
+        let result = t.client.try_create_package(
+            &t.admin,
+            &1u64,
+            &Address::generate(&t.env),
+            &ONE_TOKEN,
+            &invalid_token,
+            &(t.now() + 3600),
+            &Map::new(&t.env),
+        );
+
+        assert_eq!(result, Err(Ok(Error::InvalidToken)));
+    }
+
+    #[test]
+    fn set_config_rejects_invalid_allowed_token_address() {
+        let t = TestSetup::new();
+        let invalid_token = t.env.register(AidEscrow, ());
+        let mut allowed_tokens = Vec::new(&t.env);
+        allowed_tokens.push_back(invalid_token);
+
+        let result = t.client.try_set_config(&Config {
+            min_amount: 1,
+            max_expires_in: 0,
+            allowed_tokens,
+        });
+
+        assert_eq!(result, Err(Ok(Error::InvalidToken)));
+    }
+
+    #[test]
+    fn fund_maps_reverted_token_transfer_to_clear_contract_error() {
+        let t = TestSetup::new();
+
+        let result = t.client.try_fund(&t.token, &t.admin, &ONE_TOKEN);
+
+        assert_eq!(result, Err(Ok(Error::TokenTransferFailed)));
+    }
+
+    #[test]
+    fn claim_keeps_accounting_unchanged_when_token_transfer_reverts() {
+        let t = TestSetup::new();
+        let recipient = Address::generate(&t.env);
+        let id = t.create_default_package(&recipient, ONE_TOKEN);
+
+        t.token_sac.burn(&t.client.address, &ONE_TOKEN);
+
+        let result = t.client.try_claim(&id);
+
+        assert_eq!(result, Err(Ok(Error::TokenTransferFailed)));
+        assert_eq!(t.client.get_package(&id).status, PackageStatus::Created);
+        assert_eq!(t.client.get_total_locked(&t.token), ONE_TOKEN);
+        assert_eq!(TokenClient::new(&t.env, &t.token).balance(&recipient), 0);
+    }
+}
+
 mod claim {
     use super::*;
 


### PR DESCRIPTION
Closes #416

## Summary
- Added explicit token contract validation before token-dependent accounting paths.
- Routed token balance and transfer calls through checked contract invocation helpers so invalid tokens and reverted transfers become clear AidEscrow errors.
- Added regression coverage for invalid token addresses, reverted token transfers, and accounting staying unchanged when a payout transfer fails.
- Extended backend Soroban error mapping and docs for InvalidToken and TokenTransferFailed.

## Verification
- cargo fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu check -p aid_escrow
- git diff --check

Note: Full cargo test could not complete locally on this Windows machine before PR because the MSVC linker was missing and the GNU linker failed while linking the aid_escrow test DLL. Backend Jest execution was also blocked by npm registry ECONNRESET during dependency install.