### PR TITLE
feat: wallet network mismatch guard for Freighter (#441)

### DIFF
--- a/app/frontend/src/components/NetworkMismatchBanner.tsx
+++ b/app/frontend/src/components/NetworkMismatchBanner.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
+
+/**
+ * Renders a sticky warning banner when the connected wallet is on the wrong
+ * network. Returns null when there is no mismatch.
+ */
+export const NetworkMismatchBanner: React.FC = () => {
+  const { isMismatch, walletNetwork, expectedNetwork } = useNetworkGuard();
+
+  if (!isMismatch) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex items-start gap-3 w-full rounded-md border border-yellow-600 bg-yellow-900/30 px-4 py-3 text-yellow-200 text-sm"
+    >
+      <AlertTriangle className="mt-0.5 shrink-0 text-yellow-400" size={16} aria-hidden="true" />
+      <div>
+        <span className="font-semibold">Network mismatch — </span>
+        your wallet is on{' '}
+        <span className="font-mono font-semibold">{walletNetwork?.toUpperCase()}</span> but this
+        app requires{' '}
+        <span className="font-mono font-semibold">{expectedNetwork.toUpperCase()}</span>.{' '}
+        Open Freighter and switch to the correct network to continue.
+      </div>
+    </div>
+  );
+};

--- a/app/frontend/src/components/WalletConnect.tsx
+++ b/app/frontend/src/components/WalletConnect.tsx
@@ -5,6 +5,7 @@ import { isConnected, setAllowed, getAddress, getNetworkDetails } from "@stellar
 import { useWalletStore } from "../lib/walletStore";
 import { useToast } from "./ToastProvider";
 import { ErrorInline } from "./ErrorInline";
+import { useNetworkGuard } from "../hooks/useNetworkGuard";
 
 export const WalletConnect: React.FC = () => {
   const [loading, setLoading] = useState(false);
@@ -12,6 +13,7 @@ export const WalletConnect: React.FC = () => {
   const { publicKey, setPublicKey, network, setNetwork, disconnect } = useWalletStore();
   const [mounted, setMounted] = useState(false);
   const { toast } = useToast();
+  const { isMismatch } = useNetworkGuard();
 
   // Keep track of previous public key to avoid infinite toast loops and state updates
   const prevPublicKeyRef = useRef<string | null>(publicKey);
@@ -140,10 +142,14 @@ export const WalletConnect: React.FC = () => {
       <div className="flex flex-col items-end space-y-1">
         <div className="flex items-center space-x-2">
           {network && (
-            <span className={`text-xs px-2 py-1 rounded-md border font-medium ${network.toUpperCase().includes("MAINNET") || network.toUpperCase().includes("PUBLIC")
-              ? "bg-green-900/30 text-green-400 border-green-800"
-              : "bg-yellow-900/30 text-yellow-500 border-yellow-700"
-              }`}>
+            <span className={`text-xs px-2 py-1 rounded-md border font-medium ${
+              isMismatch
+                ? "bg-red-900/40 text-red-300 border-red-700"
+                : network.toUpperCase().includes("MAINNET") || network.toUpperCase().includes("PUBLIC")
+                  ? "bg-green-900/30 text-green-400 border-green-800"
+                  : "bg-yellow-900/30 text-yellow-500 border-yellow-700"
+            }`}>
+              {isMismatch && <span aria-label="Network mismatch" title="Network mismatch">⚠ </span>}
               {network.toUpperCase()}
             </span>
           )}

--- a/app/frontend/src/hooks/__tests__/useNetworkGuard.test.ts
+++ b/app/frontend/src/hooks/__tests__/useNetworkGuard.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { useWalletStore } from '@/lib/walletStore';
+import { useNetworkGuard } from '../useNetworkGuard';
+
+// Mock env so EXPECTED_NETWORK is deterministic in tests
+jest.mock('@/lib/env', () => ({
+  EXPECTED_NETWORK: 'testnet',
+  stellarNetwork: 'testnet',
+}));
+
+function setWallet(publicKey: string | null, network: string | null) {
+  act(() => {
+    useWalletStore.setState({ publicKey, network });
+  });
+}
+
+afterEach(() => {
+  setWallet(null, null);
+});
+
+describe('useNetworkGuard', () => {
+  it('returns no mismatch when wallet is not connected', () => {
+    setWallet(null, null);
+    const { result } = renderHook(() => useNetworkGuard());
+    expect(result.current.isMismatch).toBe(false);
+    expect(result.current.isCorrectNetwork).toBe(false);
+  });
+
+  it('returns isCorrectNetwork=true when wallet is on expected network', () => {
+    setWallet('GABC', 'testnet');
+    const { result } = renderHook(() => useNetworkGuard());
+    expect(result.current.isCorrectNetwork).toBe(true);
+    expect(result.current.isMismatch).toBe(false);
+  });
+
+  it('is case-insensitive when comparing networks', () => {
+    setWallet('GABC', 'TESTNET');
+    const { result } = renderHook(() => useNetworkGuard());
+    expect(result.current.isCorrectNetwork).toBe(true);
+    expect(result.current.isMismatch).toBe(false);
+  });
+
+  it('detects mismatch when wallet is on a different network', () => {
+    setWallet('GABC', 'mainnet');
+    const { result } = renderHook(() => useNetworkGuard());
+    expect(result.current.isMismatch).toBe(true);
+    expect(result.current.isCorrectNetwork).toBe(false);
+    expect(result.current.walletNetwork).toBe('mainnet');
+    expect(result.current.expectedNetwork).toBe('testnet');
+  });
+
+  it('recovers when wallet switches to the correct network', () => {
+    setWallet('GABC', 'mainnet');
+    const { result } = renderHook(() => useNetworkGuard());
+    expect(result.current.isMismatch).toBe(true);
+
+    act(() => {
+      useWalletStore.setState({ network: 'testnet' });
+    });
+    expect(result.current.isMismatch).toBe(false);
+    expect(result.current.isCorrectNetwork).toBe(true);
+  });
+});

--- a/app/frontend/src/hooks/useNetworkGuard.ts
+++ b/app/frontend/src/hooks/useNetworkGuard.ts
@@ -1,0 +1,34 @@
+import { useWalletStore } from '@/lib/walletStore';
+import { EXPECTED_NETWORK } from '@/lib/env';
+
+export interface NetworkGuardResult {
+  /** true when the wallet is connected and on the correct network */
+  isCorrectNetwork: boolean;
+  /** true when a wallet is connected but on the wrong network */
+  isMismatch: boolean;
+  /** The network the wallet is currently reporting (null if not connected) */
+  walletNetwork: string | null;
+  /** The network this app expects */
+  expectedNetwork: string;
+}
+
+/**
+ * Compares the Freighter-reported network against EXPECTED_NETWORK.
+ * Comparison is case-insensitive and ignores surrounding whitespace.
+ */
+export function useNetworkGuard(): NetworkGuardResult {
+  const { publicKey, network: walletNetwork } = useWalletStore();
+
+  const isConnected = Boolean(publicKey);
+  const isCorrectNetwork =
+    isConnected &&
+    walletNetwork != null &&
+    walletNetwork.trim().toLowerCase() === EXPECTED_NETWORK.trim().toLowerCase();
+
+  return {
+    isCorrectNetwork,
+    isMismatch: isConnected && !isCorrectNetwork,
+    walletNetwork,
+    expectedNetwork: EXPECTED_NETWORK,
+  };
+}

--- a/app/frontend/src/lib/env.ts
+++ b/app/frontend/src/lib/env.ts
@@ -16,6 +16,12 @@ export const stellarNetwork =
   process.env.NEXT_PUBLIC_NETWORK ??
   'unknown';
 
+/**
+ * The network the wallet must be on for on-chain actions to be allowed.
+ * Compared case-insensitively against the Freighter-reported network string.
+ */
+export const EXPECTED_NETWORK = stellarNetwork;
+
 /** Application environment label (e.g. dev, staging, prod). Optional. */
 export const envName: string | null =
   process.env.NEXT_PUBLIC_ENV_NAME?.trim() ?? null;

--- a/app/frontend/src/lib/stellarUtils.test.ts
+++ b/app/frontend/src/lib/stellarUtils.test.ts
@@ -1,0 +1,52 @@
+import { act } from 'react';
+import { useWalletStore } from '@/lib/walletStore';
+import { signTransaction, NetworkMismatchError } from '@/lib/stellarUtils';
+
+jest.mock('@/lib/env', () => ({
+  EXPECTED_NETWORK: 'testnet',
+  stellarNetwork: 'testnet',
+}));
+
+jest.mock('@stellar/freighter-api', () => ({
+  signTransaction: jest.fn().mockResolvedValue({ signedTxXdr: 'signed-xdr' }),
+}));
+
+function setWalletNetwork(network: string | null) {
+  act(() => {
+    useWalletStore.setState({ publicKey: network ? 'GABC' : null, network });
+  });
+}
+
+afterEach(() => {
+  setWalletNetwork(null);
+  jest.clearAllMocks();
+});
+
+describe('signTransaction network guard', () => {
+  it('throws NetworkMismatchError when wallet network is null', async () => {
+    setWalletNetwork(null);
+    await expect(signTransaction('xdr')).rejects.toThrow(NetworkMismatchError);
+  });
+
+  it('throws NetworkMismatchError when wallet is on wrong network', async () => {
+    setWalletNetwork('mainnet');
+    await expect(signTransaction('xdr')).rejects.toThrow(NetworkMismatchError);
+  });
+
+  it('includes remediation message in the error', async () => {
+    setWalletNetwork('mainnet');
+    await expect(signTransaction('xdr')).rejects.toThrow(/Switch networks in Freighter/);
+  });
+
+  it('proceeds to sign when wallet is on the correct network', async () => {
+    setWalletNetwork('testnet');
+    const result = await signTransaction('xdr');
+    expect(result).toBe('signed-xdr');
+  });
+
+  it('proceeds when network comparison is case-insensitive', async () => {
+    setWalletNetwork('TESTNET');
+    const result = await signTransaction('xdr');
+    expect(result).toBe('signed-xdr');
+  });
+});

--- a/app/frontend/src/lib/stellarUtils.ts
+++ b/app/frontend/src/lib/stellarUtils.ts
@@ -1,4 +1,17 @@
 import { signTransaction as freighterSignTransaction } from "@stellar/freighter-api";
+import { EXPECTED_NETWORK } from "./env";
+import { useWalletStore } from "./walletStore";
+
+/** Error thrown when the wallet is on the wrong network. */
+export class NetworkMismatchError extends Error {
+  constructor(walletNetwork: string | null, expectedNetwork: string) {
+    super(
+      `Wallet is on ${walletNetwork?.toUpperCase() ?? 'unknown'} but this app requires ${expectedNetwork.toUpperCase()}. ` +
+      `Switch networks in Freighter and try again.`
+    );
+    this.name = 'NetworkMismatchError';
+  }
+}
 
 /**
  * Signs a base64 encoded XDR transaction using Freighter.
@@ -8,6 +21,15 @@ import { signTransaction as freighterSignTransaction } from "@stellar/freighter-
  */
 export async function signTransaction(xdr: string, networkPassphrase?: string): Promise<string> {
   try {
+    // Guard: reject if wallet is on the wrong network
+    const { network: walletNetwork } = useWalletStore.getState();
+    if (
+      walletNetwork == null ||
+      walletNetwork.trim().toLowerCase() !== EXPECTED_NETWORK.trim().toLowerCase()
+    ) {
+      throw new NetworkMismatchError(walletNetwork, EXPECTED_NETWORK);
+    }
+
     const opts: { networkPassphrase?: string } = {};
     if (networkPassphrase) {
       opts.networkPassphrase = networkPassphrase;
@@ -22,6 +44,11 @@ export async function signTransaction(xdr: string, networkPassphrase?: string): 
     return (signedTx.signedTxXdr || signedTx) as string;
   } catch (error: unknown) {
     console.error("Error signing transaction with Freighter:", error);
+    
+    // Network mismatch — re-throw as-is so callers can distinguish it
+    if (error instanceof NetworkMismatchError) {
+      throw error;
+    }
     
     // Attempt to handle known Freighter UI rejection strings gracefully
     if (typeof error === "string" && error.includes("User declined")) {


### PR DESCRIPTION
closes #441 
- Add EXPECTED_NETWORK constant to env.ts
- Add useNetworkGuard hook to detect wallet/app network mismatch
- Add NetworkMismatchBanner component with remediation instructions
- Update WalletConnect to show red warning badge on mismatch
- Block signTransaction with NetworkMismatchError on wrong network
- Add tests for mismatch states and recovery (10/10 passing)