### PR TITLE
feat(contracts): safe testnet redeployment and versioning (#413)

### DIFF
--- a/app/onchain/DEPLOY_TESTNET_RUNBOOK.md
+++ b/app/onchain/DEPLOY_TESTNET_RUNBOOK.md
@@ -265,3 +265,44 @@ Fix:
 ---
 
 If the public Soroban Testnet RPC is failing repeatedly, use a secondary provider or local standalone node for consistent deployment.
+
+## 11. Handling Testnet Contract Upgrades & State Migration
+
+When iterating on the `aid_escrow` contract on Testnet, changes fall into two categories: non-breaking and breaking.
+
+### Non-Breaking Changes
+*Examples: Adding a new read-only function, fixing a bug that doesn't change storage formats.*
+1. **Redeploy**: Soroban doesn't support true in-place upgrades of Wasm code for the same Contract ID yet. You must deploy a **new Contract ID**.
+2. **Version Bump**: Ensure you bump the semantic `version` in `Cargo.toml`.
+3. **No Migration Needed**: Since it's a new instance, old state is lost. If this is purely a logic update and you don't care about old testnet packages, just use the new Contract ID.
+
+### Breaking Changes (State/Storage Layout)
+*Examples: Changing the `Package` struct fields, changing `DataKey` symbols.*
+1. **Redeploy**: Deploy the new Wasm, which generates a new Contract ID.
+2. **State Migration Strategy**: 
+   - **Reset**: Since it's Testnet, the preferred approach is often to reset the environment (wipe the database, deploy a fresh contract).
+   - **Migrate**: If state must be preserved, you must write an off-chain script to read packages from the old contract and re-create them in the new contract using the admin or a dedicated migration function.
+
+**Note on Queryable Versions:** 
+The contract semantic version is queryable on-chain via the `contract_version()` function. Additionally, `deploy.sh` automatically parses the `Cargo.toml` version and exports it as `CONTRACT_VERSION` in your `.env` artifact.
+
+## 12. Redeployment Checklist (Preventing Orphaned Integrations)
+
+When a new contract is deployed, its **Contract ID changes**. If downstream components are not updated, they will interact with the orphaned contract, causing out-of-sync state or failures.
+
+**Whenever you run `./scripts/deploy.sh` and get a new Contract ID, complete this checklist:**
+
+- [ ] **1. Backend Update:** 
+  - Update `CONTRACT_ID` and `CONTRACT_VERSION` in `app/backend/.env`.
+  - Restart the backend server (`pnpm --filter backend start:dev` or trigger a production redeploy).
+- [ ] **2. Database Sync:** 
+  - If the upgrade involved breaking storage changes, truncate the local/testnet database tables related to packages to avoid mismatched on-chain vs. off-chain state.
+- [ ] **3. Frontend Update:** 
+  - Ensure the frontend receives the new `CONTRACT_ID` (usually fetched via a config endpoint from the backend).
+  - Clear local storage or cached states if they reference old package IDs.
+- [ ] **4. Mobile App Update:** 
+  - Ensure the React Native app restarts or fetches the updated config from the backend.
+- [ ] **5. Indexer / Event Listeners:** 
+  - If you run an off-chain indexer, point it to the new `CONTRACT_ID` and restart it so it begins streaming events from the new deployment ledger.
+- [ ] **6. Announce Change:** 
+  - Notify the team in Discord/Slack that Testnet has migrated to `<NEW_CONTRACT_ID>` (v`<VERSION>`) so other developers pull the latest `.env` config.

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -254,6 +254,11 @@ impl AidEscrow {
         env.storage().instance().get(&KEY_VERSION).unwrap_or(0)
     }
 
+    /// Returns the semantic version of the contract package.
+    pub fn contract_version(env: Env) -> String {
+        String::from_str(&env, env!("CARGO_PKG_VERSION"))
+    }
+
     /// Admin-only. Bumps the contract version and runs any required migration logic.
     ///
     /// # Arguments

--- a/app/onchain/scripts/deploy.sh
+++ b/app/onchain/scripts/deploy.sh
@@ -76,7 +76,13 @@ if [ ! -f "$WASM_FILE" ]; then
     exit 1
 fi
 
-echo "📦 Contract: $CONTRACT_NAME"
+# Extract contract version
+CONTRACT_VERSION=$(grep '^version =' "contracts/${CONTRACT_NAME}/Cargo.toml" | head -1 | awk -F'"' '{print $2}')
+if [ -z "$CONTRACT_VERSION" ]; then
+    CONTRACT_VERSION="unknown"
+fi
+
+echo "📦 Contract: $CONTRACT_NAME (v$CONTRACT_VERSION)"
 echo "📄 WASM file: $WASM_FILE"
 echo "🔑 Using key: ${SECRET_KEY:0:10}..."
 
@@ -104,6 +110,7 @@ if [ -n "$CONTRACT_ID" ]; then
     echo ""
     echo "✅ Deployment successful!"
     echo "📋 Contract ID: $CONTRACT_ID"
+    echo "🏷️  Contract Version: $CONTRACT_VERSION"
     echo ""
     echo "💡 Save this ID for future interactions:"
     echo "export CONTRACT_ID=\"$CONTRACT_ID\""
@@ -115,7 +122,15 @@ if [ -n "$CONTRACT_ID" ]; then
         else
             echo "CONTRACT_ID=$CONTRACT_ID" >> "$PROJECT_DIR/.env"
         fi
-        echo "📝 Updated .env with contract ID"
+        
+        # Log contract version to .env
+        if grep -q "CONTRACT_VERSION=" "$PROJECT_DIR/.env"; then
+            sed -i.bak "s|CONTRACT_VERSION=.*|CONTRACT_VERSION=$CONTRACT_VERSION|" "$PROJECT_DIR/.env"
+        else
+            echo "CONTRACT_VERSION=$CONTRACT_VERSION" >> "$PROJECT_DIR/.env"
+        fi
+        
+        echo "📝 Updated .env with contract ID and version"
     fi
 else
     echo "⚠️  Could not extract contract ID from output:"


### PR DESCRIPTION
Closes #413

## Summary
Implements a safe approach for redeploying and migrating contract state during Testnet iteration.

## Changes
- **On-chain Versioning:** Added \contract_version()\ to \id_escrow\ to query the \Cargo.toml\ semantic version on-chain.
- **Deployment Artifacts:** Updated \deploy.sh\ to parse the semantic version and export it to the \.env\ deployment artifact.
- **Documentation:** Added clear strategies for handling breaking vs non-breaking changes on testnet to \DEPLOY_TESTNET_RUNBOOK.md\.
- **Checklist:** Added a Redeployment Checklist to the runbook to prevent orphaning integrations when contract IDs change.