### PR TITLE
Add support for signed artifact access tokens

### DIFF
--- a/.github/workflows/ci-python-tests.yml
+++ b/.github/workflows/ci-python-tests.yml
@@ -1,0 +1,33 @@
+name: CI - Python Tests
+
+on:
+  push:
+    paths:
+      - 'app/ai-service/**'
+  pull_request:
+    paths:
+      - 'app/ai-service/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        working-directory: app/ai-service
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+
+      - name: Run tests
+        working-directory: app/ai-service
+        run: |
+          pytest -q

--- a/app/ai-service/api/v1/artifacts.py
+++ b/app/ai-service/api/v1/artifacts.py
@@ -6,8 +6,8 @@ import logging
 import os
 from typing import Literal
 
-from fastapi import APIRouter, Header, HTTPException, Query
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Header, Query
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
 from config import settings
@@ -37,7 +37,10 @@ async def request_artifact_access(
     x_user_id: str = Header(default="unknown", alias="X-User-Id"),
 ):
     if not artifact_access_service.validate_role(x_user_role):
-        raise HTTPException(status_code=403, detail="forbidden_role")
+        return JSONResponse(
+            status_code=403,
+            content={"error": {"code": "forbidden_role", "message": "forbidden_role"}},
+        )
 
     try:
         artifact_path, metadata = artifact_access_service.resolve_artifact(artifact_id)
@@ -45,7 +48,10 @@ async def request_artifact_access(
     except ArtifactAccessError as exc:
         detail = str(exc)
         status_code = 404 if detail == "artifact_not_found" else 403
-        raise HTTPException(status_code=status_code, detail=detail) from exc
+        return JSONResponse(
+            status_code=status_code,
+            content={"error": {"code": detail, "message": detail}},
+        )
 
     logger.info(
         "artifact_access_granted",
@@ -81,7 +87,12 @@ async def download_artifact_with_token(token: str = Query(..., min_length=10)):
         artifact_path, metadata = artifact_access_service.resolve_artifact(payload["aid"])
         artifact_access_service.enforce_org_ownership(metadata, payload["org"])
     except ArtifactAccessError as exc:
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        detail = str(exc)
+        status_code = 404 if detail == "artifact_not_found" else 403
+        return JSONResponse(
+            status_code=status_code,
+            content={"error": {"code": detail, "message": detail}},
+        )
 
     logger.info(
         "artifact_downloaded_with_signed_url",


### PR DESCRIPTION
Closes: #466

Signed artifact access tokens; enforce role/org; safe error envelopes; add CI

Use HMAC-signed, short-lived tokens (exp field) for artifact downloads via existing [ArtifactAccessService](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Enforce authorization before issuing tokens or proxying files: validate X-User-Role and X-Org-Id ownership.
Return structured JSON error envelopes on auth/lookup failures to avoid leaking internals.
Keep logs non-sensitive (metadata only: artifact_id, org_id, user_id, role, mode).
Add GitHub Actions workflow to run [pytest](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for [app/ai-service](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on push/PR: .github/workflows/ci-python-tests.yml.
Primary code changes in app/ai-service/api/v1/artifacts.py; token logic remains in app/ai-service/services/artifact_access.py.


This change implements short-lived, token-based access for verification artifacts to avoid permanent public URLs.

POST [/v1/ai/verification-artifacts/{artifact_id}/access](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now:
validates X-User-Role and X-Org-Id before issuing a signed download token or proxying the file,
returns structured error envelopes for failures.
GET [/v1/ai/verification-artifacts/download?token=<token>](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
verifies token signature and expiry before returning the file.
Logs limited to non-sensitive metadata (artifact_id, org_id, user_id, role, mode).
Adds CI workflow to run tests for [app/ai-service](vscode-file://vscode-app/c:/Users/Buddi/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on push and PR.

