### PR TITLE
Add testnet observability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repository contains the **Soter** mobile application. The **Diagnostics** s
 - **Configured Contract ID** – pulls the Soroban contract identifier from the app config.  No secrets/tokens are displayed.
 - **Copy‑to‑Clipboard** – a button that copies a sanitized diagnostics string to the clipboard for easy sharing with support.
 
+## Testnet Observability
+
+The backend exposes Prometheus metrics at `/metrics`, queue health at `/jobs/health`, and request correlation IDs in `x-correlation-id` / `x-request-id` headers. For Testnet incident response, use [docs/testnet-observability-dashboard.md](docs/testnet-observability-dashboard.md) to track contract call latency, transaction submission failures, callback failures, and correlated job logs.
+
 ## Why this matters
 - **Fast troubleshooting** – no need to open a debugger or logs; the relevant info is right in the UI.
 - **No secrets exposed** – the clipboard string omits any API keys or private tokens.

--- a/app/backend/src/aid/aid.module.ts
+++ b/app/backend/src/aid/aid.module.ts
@@ -4,9 +4,10 @@ import { AidController } from './aid.controller';
 import { RedisService } from 'cache/redis.service';
 import { HmacModule } from '../common/hmac/hmac.module';
 import { WebhookHmacGuard } from '../common/guards/webhook-hmac.guard';
+import { MetricsModule } from '../observability/metrics/metrics.module';
 
 @Module({
-  imports: [HmacModule],
+  imports: [HmacModule, MetricsModule],
   providers: [AidService, RedisService, WebhookHmacGuard],
   controllers: [AidController],
   exports: [AidService],

--- a/app/backend/src/aid/aid.service.spec.ts
+++ b/app/backend/src/aid/aid.service.spec.ts
@@ -3,6 +3,7 @@ import { AidService } from './aid.service';
 import { AuditService } from '../audit/audit.service';
 import { RedisService } from '../../cache/redis.service';
 import { AiTaskWebhookDto, TaskStatus } from './dto/ai-task-webhook.dto';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 describe('AidService - Webhook Reliability Checks', () => {
   let service: AidService;
@@ -11,8 +12,13 @@ describe('AidService - Webhook Reliability Checks', () => {
   let redisGetSpy: jest.SpyInstance;
   let redisSetSpy: jest.SpyInstance;
   let auditRecordSpy: jest.SpyInstance;
+  let metricsService: { incrementCallbackFailure: jest.Mock };
 
   beforeEach(async () => {
+    metricsService = {
+      incrementCallbackFailure: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AidService,
@@ -23,6 +29,10 @@ describe('AidService - Webhook Reliability Checks', () => {
         {
           provide: RedisService,
           useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+        {
+          provide: MetricsService,
+          useValue: metricsService,
         },
       ],
     }).compile();
@@ -132,5 +142,25 @@ describe('AidService - Webhook Reliability Checks', () => {
 
     expect(result.status).toEqual('completed');
     expect(auditRecordSpy).toHaveBeenCalled();
+  });
+
+  it('5. should record callback failures for failed AI tasks', async () => {
+    const failedPayload: AiTaskWebhookDto = {
+      taskId: 'task-1',
+      deliveryId: 'del-4',
+      timestamp: '2024-03-24T12:00:00Z',
+      status: TaskStatus.FAILED,
+      error: 'model_timeout',
+    };
+
+    redisGetSpy.mockResolvedValueOnce(null);
+    redisGetSpy.mockResolvedValueOnce(null);
+
+    await service.handleTaskWebhook(failedPayload);
+
+    expect(metricsService.incrementCallbackFailure).toHaveBeenCalledWith(
+      'ai_task_webhook',
+      'model_timeout',
+    );
   });
 });

--- a/app/backend/src/aid/aid.service.ts
+++ b/app/backend/src/aid/aid.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { AuditService } from '../audit/audit.service';
 import { RedisService } from '../../cache/redis.service';
 import { AiTaskWebhookDto, TaskStatus } from './dto/ai-task-webhook.dto';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 @Injectable()
 export class AidService {
@@ -10,6 +11,7 @@ export class AidService {
   constructor(
     private auditService: AuditService,
     private redisService: RedisService,
+    private metricsService: MetricsService,
   ) {}
 
   async createCampaign(data: Record<string, unknown>) {
@@ -114,6 +116,10 @@ export class AidService {
           this.logger.log(`[AI Webhook] Result:`, payload.result);
         break;
       case TaskStatus.FAILED:
+        this.metricsService.incrementCallbackFailure(
+          'ai_task_webhook',
+          payload.error ?? 'task_failed',
+        );
         this.logger.error(
           `[AI Webhook] Task ${payload.taskId} failed:`,
           payload.error,

--- a/app/backend/src/logger/logger.service.ts
+++ b/app/backend/src/logger/logger.service.ts
@@ -46,7 +46,7 @@ export class LoggerService implements NestLoggerService {
   /**
    * Get correlation ID from async local storage
    */
-  private getCorrelationId(): string | undefined {
+  getCorrelationId(): string | undefined {
     const store = this.asyncLocalStorage.getStore();
     return store?.get(CORRELATION_ID_KEY) as string | undefined;
   }

--- a/app/backend/src/notifications/notifications.module.ts
+++ b/app/backend/src/notifications/notifications.module.ts
@@ -5,6 +5,8 @@ import { NotificationsService } from './notifications.service';
 import { NotificationProcessor } from './notifications.processor';
 import { OutboxController } from './outbox.controller';
 import { JobsModule } from '../jobs/jobs.module';
+import { MetricsModule } from '../observability/metrics/metrics.module';
+import { LoggerModule } from '../logger/logger.module';
 
 @Module({
   imports: [
@@ -21,6 +23,8 @@ import { JobsModule } from '../jobs/jobs.module';
       inject: [ConfigService],
     }),
     JobsModule,
+    MetricsModule,
+    LoggerModule,
   ],
   controllers: [OutboxController],
   providers: [NotificationsService, NotificationProcessor],

--- a/app/backend/src/notifications/notifications.processor.spec.ts
+++ b/app/backend/src/notifications/notifications.processor.spec.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { NotificationType } from './interfaces/notification-job.interface';
 import { Job } from 'bullmq';
 import { DlqService } from '../jobs/dlq.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 describe('NotificationProcessor', () => {
   let processor: NotificationProcessor;
@@ -12,6 +13,7 @@ describe('NotificationProcessor', () => {
       update: jest.Mock;
     };
   };
+  let metricsMock: { incrementCallbackFailure: jest.Mock };
 
   const makeJob = (
     overrides: Partial<{
@@ -40,6 +42,7 @@ describe('NotificationProcessor', () => {
         update: jest.fn().mockResolvedValue({}),
       },
     };
+    metricsMock = { incrementCallbackFailure: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -53,6 +56,10 @@ describe('NotificationProcessor', () => {
           useValue: {
             moveToDlq: jest.fn(),
           },
+        },
+        {
+          provide: MetricsService,
+          useValue: metricsMock,
         },
       ],
     }).compile();
@@ -153,6 +160,11 @@ describe('NotificationProcessor', () => {
       const error = new Error('Something went wrong');
 
       await processor.onFailed(job, error);
+
+      expect(metricsMock.incrementCallbackFailure).toHaveBeenCalledWith(
+        'notification_job',
+        'Something went wrong',
+      );
 
       expect(prismaMock.notificationOutbox.update).toHaveBeenCalledWith({
         where: { id: 'outbox-abc' },

--- a/app/backend/src/notifications/notifications.processor.ts
+++ b/app/backend/src/notifications/notifications.processor.ts
@@ -8,6 +8,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 
 import { DlqService } from '../jobs/dlq.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 @Processor('notifications', {
   concurrency: parseInt(process.env.QUEUE_CONCURRENCY || '5'),
@@ -18,6 +19,7 @@ export class NotificationProcessor extends WorkerHost {
   constructor(
     private readonly prisma: PrismaService,
     private readonly dlqService: DlqService,
+    private readonly metricsService: MetricsService,
   ) {
     super();
   }
@@ -67,6 +69,10 @@ export class NotificationProcessor extends WorkerHost {
         `Notification job ${job.id} failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         error instanceof Error ? error.stack : undefined,
       );
+      this.metricsService.incrementCallbackFailure(
+        'notification_delivery',
+        error instanceof Error ? error.message : String(error),
+      );
       throw error;
     }
   }
@@ -105,6 +111,10 @@ export class NotificationProcessor extends WorkerHost {
     if (job) {
       this.logger.error(
         `Notification job ${job.id} for ${job.data.recipient} failed: ${error.message}`,
+      );
+      this.metricsService.incrementCallbackFailure(
+        'notification_job',
+        error.message,
       );
       await this.dlqService.moveToDlq('notifications', job, error);
     } else {

--- a/app/backend/src/notifications/notifications.service.spec.ts
+++ b/app/backend/src/notifications/notifications.service.spec.ts
@@ -3,10 +3,12 @@ import { NotificationsService } from './notifications.service';
 import { getQueueToken } from '@nestjs/bullmq';
 import { NotificationType } from './interfaces/notification-job.interface';
 import { PrismaService } from '../prisma/prisma.service';
+import { LoggerService } from '../logger/logger.service';
 
 describe('NotificationsService', () => {
   let service: NotificationsService;
   let queueMock: jest.Mocked<{ add: jest.Mock }>;
+  let loggerMock: { getCorrelationId: jest.Mock };
   let prismaMock: {
     notificationOutbox: {
       create: jest.Mock;
@@ -38,6 +40,9 @@ describe('NotificationsService', () => {
     queueMock = {
       add: jest.fn().mockResolvedValue({ id: 'job-123' }),
     };
+    loggerMock = {
+      getCorrelationId: jest.fn().mockReturnValue(undefined),
+    };
 
     prismaMock = {
       notificationOutbox: {
@@ -62,6 +67,10 @@ describe('NotificationsService', () => {
         {
           provide: PrismaService,
           useValue: prismaMock,
+        },
+        {
+          provide: LoggerService,
+          useValue: loggerMock,
         },
       ],
     }).compile();
@@ -129,6 +138,20 @@ describe('NotificationsService', () => {
         expect.objectContaining({
           type: NotificationType.EMAIL,
           outboxId: mockOutbox.id,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should default email job correlationId from the active request context', async () => {
+      loggerMock.getCorrelationId.mockReturnValue('request-correlation-123');
+
+      await service.sendEmail('test@example.com', 'Subject', 'Message');
+
+      expect(queueMock.add).toHaveBeenCalledWith(
+        'send-email',
+        expect.objectContaining({
+          correlationId: 'request-correlation-123',
         }),
         expect.any(Object),
       );
@@ -235,6 +258,20 @@ describe('NotificationsService', () => {
         expect.objectContaining({
           type: NotificationType.SMS,
           outboxId: mockOutbox.id,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should default SMS job correlationId from the active request context', async () => {
+      loggerMock.getCorrelationId.mockReturnValue('sms-correlation-123');
+
+      await service.sendSms('+1234567890', 'Test SMS');
+
+      expect(queueMock.add).toHaveBeenCalledWith(
+        'send-sms',
+        expect.objectContaining({
+          correlationId: 'sms-correlation-123',
         }),
         expect.any(Object),
       );

--- a/app/backend/src/notifications/notifications.service.ts
+++ b/app/backend/src/notifications/notifications.service.ts
@@ -7,6 +7,7 @@ import {
   NotificationType,
 } from './interfaces/notification-job.interface';
 import { PrismaService } from '../prisma/prisma.service';
+import { LoggerService } from '../logger/logger.service';
 
 @Injectable()
 export class NotificationsService {
@@ -15,6 +16,7 @@ export class NotificationsService {
   constructor(
     @InjectQueue('notifications') private readonly notificationsQueue: Queue,
     private readonly prisma: PrismaService,
+    private readonly loggerService: LoggerService,
   ) {}
 
   async sendEmail(
@@ -35,6 +37,9 @@ export class NotificationsService {
     });
 
     // 2. Enqueue the BullMQ job (carries outboxId and correlationId)
+    const propagatedCorrelationId =
+      correlationId ?? this.loggerService.getCorrelationId();
+
     const data: NotificationJobData = {
       type: NotificationType.EMAIL,
       recipient,
@@ -42,7 +47,7 @@ export class NotificationsService {
       message,
       timestamp: Date.now(),
       outboxId: outbox.id,
-      correlationId,
+      correlationId: propagatedCorrelationId,
     };
 
     const job = await this.notificationsQueue.add('send-email', data, {
@@ -62,8 +67,11 @@ export class NotificationsService {
       },
     });
 
+    const correlationSuffix = propagatedCorrelationId
+      ? ` [correlationId=${propagatedCorrelationId}]`
+      : '';
     this.logger.log(
-      `Enqueued email job: ${job.id} for ${recipient} (outboxId: ${outbox.id})`,
+      `Enqueued email job: ${job.id} for ${recipient} (outboxId: ${outbox.id})${correlationSuffix}`,
     );
     return { outboxId: outbox.id, jobId: String(job.id) };
   }
@@ -84,13 +92,16 @@ export class NotificationsService {
     });
 
     // 2. Enqueue the BullMQ job (carries outboxId and correlationId)
+    const propagatedCorrelationId =
+      correlationId ?? this.loggerService.getCorrelationId();
+
     const data: NotificationJobData = {
       type: NotificationType.SMS,
       recipient,
       message,
       timestamp: Date.now(),
       outboxId: outbox.id,
-      correlationId,
+      correlationId: propagatedCorrelationId,
     };
 
     const job = await this.notificationsQueue.add('send-sms', data, {
@@ -110,8 +121,11 @@ export class NotificationsService {
       },
     });
 
+    const correlationSuffix = propagatedCorrelationId
+      ? ` [correlationId=${propagatedCorrelationId}]`
+      : '';
     this.logger.log(
-      `Enqueued SMS job: ${job.id} for ${recipient} (outboxId: ${outbox.id})`,
+      `Enqueued SMS job: ${job.id} for ${recipient} (outboxId: ${outbox.id})${correlationSuffix}`,
     );
     return { outboxId: outbox.id, jobId: String(job.id) };
   }

--- a/app/backend/src/observability/metrics/metrics.providers.ts
+++ b/app/backend/src/observability/metrics/metrics.providers.ts
@@ -60,6 +60,17 @@ export const metricsProviders = [
     labelNames: ['operation', 'adapter'],
     buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5],
   }),
+  makeHistogramProvider({
+    name: 'contract_call_latency_seconds',
+    help: 'Latency of Testnet contract calls grouped by operation and status',
+    labelNames: ['operation', 'status'],
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+  }),
+  makeCounterProvider({
+    name: 'tx_submission_failures_total',
+    help: 'Total number of Testnet transaction submission failures',
+    labelNames: ['operation', 'reason'],
+  }),
 
   // Ingestion Metrics
   makeGaugeProvider({
@@ -79,6 +90,11 @@ export const metricsProviders = [
     help: 'Duration of webhook delivery attempts in seconds',
     labelNames: ['webhook_type'],
     buckets: [0.1, 0.5, 1, 2, 5, 10, 30],
+  }),
+  makeCounterProvider({
+    name: 'callback_failures_total',
+    help: 'Total number of callback or async processing failures',
+    labelNames: ['callback_type', 'reason'],
   }),
 
   // Error Rate Metrics

--- a/app/backend/src/observability/metrics/metrics.service.ts
+++ b/app/backend/src/observability/metrics/metrics.service.ts
@@ -23,12 +23,18 @@ export class MetricsService {
     public onchainOperationsCounter: Counter<string>,
     @InjectMetric('onchain_operation_duration_seconds')
     public onchainOperationDuration: Histogram<string>,
+    @InjectMetric('contract_call_latency_seconds')
+    public contractCallLatency: Histogram<string>,
+    @InjectMetric('tx_submission_failures_total')
+    public txSubmissionFailuresCounter: Counter<string>,
     @InjectMetric('ingestion_lag_seconds')
     public ingestionLagGauge: Gauge<string>,
     @InjectMetric('webhook_retries_total')
     public webhookRetriesCounter: Counter<string>,
     @InjectMetric('webhook_delivery_duration_seconds')
     public webhookDeliveryDuration: Histogram<string>,
+    @InjectMetric('callback_failures_total')
+    public callbackFailuresCounter: Counter<string>,
     @InjectMetric('error_rate_total')
     public errorRateCounter: Counter<string>,
     @InjectMetric('analytics_cache_hits_total')
@@ -150,6 +156,21 @@ export class MetricsService {
     );
   }
 
+  recordContractCallLatency(
+    operation: string,
+    status: 'success' | 'failed',
+    durationSeconds: number,
+  ): void {
+    this.contractCallLatency.observe({ operation, status }, durationSeconds);
+  }
+
+  incrementTxSubmissionFailure(operation: string, reason: string): void {
+    this.txSubmissionFailuresCounter.inc({
+      operation,
+      reason: reason.slice(0, 80),
+    });
+  }
+
   /**
    * Set ingestion lag gauge (time between event creation and processing)
    */
@@ -177,6 +198,13 @@ export class MetricsService {
       },
       duration,
     );
+  }
+
+  incrementCallbackFailure(callbackType: string, reason: string): void {
+    this.callbackFailuresCounter.inc({
+      callback_type: callbackType,
+      reason: reason.slice(0, 80),
+    });
   }
 
   /**

--- a/app/backend/src/onchain/interfaces/onchain-job.interface.ts
+++ b/app/backend/src/onchain/interfaces/onchain-job.interface.ts
@@ -8,6 +8,7 @@ export interface OnchainJobData {
   type: OnchainOperationType;
   params: any;
   timestamp: number;
+  correlationId?: string;
 }
 
 export interface OnchainJobResult {

--- a/app/backend/src/onchain/onchain.module.ts
+++ b/app/backend/src/onchain/onchain.module.ts
@@ -11,6 +11,8 @@ import { LedgerBackfillService } from './ledger-backfill.service';
 import { LedgerReconciliationService } from './ledger-reconciliation.service';
 import { LedgerAdminController } from './ledger-admin.controller';
 import { JobsModule } from '../jobs/jobs.module';
+import { LoggerModule } from '../logger/logger.module';
+import { MetricsModule } from '../observability/metrics/metrics.module';
 
 /**
  * Factory function to create the appropriate adapter based on configuration
@@ -54,6 +56,8 @@ const onchainAdapterProvider: Provider = {
       inject: [ConfigService],
     }),
     JobsModule,
+    LoggerModule,
+    MetricsModule,
   ],
   controllers: [LedgerAdminController],
   providers: [

--- a/app/backend/src/onchain/onchain.processor.ts
+++ b/app/backend/src/onchain/onchain.processor.ts
@@ -10,6 +10,7 @@ import {
 import { ONCHAIN_ADAPTER_TOKEN, OnchainAdapter } from './onchain.adapter';
 
 import { DlqService } from '../jobs/dlq.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 @Processor('onchain', {
   concurrency: 1, // Usually sequential for blockchain transactions
@@ -21,6 +22,7 @@ export class OnchainProcessor extends WorkerHost {
     @Inject(ONCHAIN_ADAPTER_TOKEN)
     private readonly onchainAdapter: OnchainAdapter,
     private readonly dlqService: DlqService,
+    private readonly metricsService: MetricsService,
   ) {
     super();
   }
@@ -28,8 +30,14 @@ export class OnchainProcessor extends WorkerHost {
   async process(
     job: Job<OnchainJobData, OnchainJobResult, string>,
   ): Promise<OnchainJobResult> {
+    const startedAt = Date.now();
+    const operation = String(job.data.type);
+    const correlationSuffix = job.data.correlationId
+      ? ` [correlationId=${job.data.correlationId}]`
+      : '';
+
     this.logger.log(
-      `Processing onchain ${job.data.type} (attempt ${job.attemptsMade + 1})`,
+      `Processing onchain ${operation} (attempt ${job.attemptsMade + 1})${correlationSuffix}`,
     );
 
     try {
@@ -53,6 +61,12 @@ export class OnchainProcessor extends WorkerHost {
       if (result && 'status' in result && result.status === 'failed') {
         throw new Error(`Onchain operation failed: ${String(job.data.type)}`);
       }
+
+      this.metricsService.recordContractCallLatency(
+        operation,
+        'success',
+        (Date.now() - startedAt) / 1000,
+      );
 
       return {
         success: true,
@@ -81,6 +95,17 @@ export class OnchainProcessor extends WorkerHost {
           error instanceof Error ? error.stack : undefined,
         );
       }
+      this.metricsService.recordContractCallLatency(
+        operation,
+        'failed',
+        (Date.now() - startedAt) / 1000,
+      );
+      if (errMessage.includes('transaction') || errMessage.includes('tx_')) {
+        this.metricsService.incrementTxSubmissionFailure(
+          operation,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
       throw error;
     }
   }
@@ -94,6 +119,10 @@ export class OnchainProcessor extends WorkerHost {
   async onFailed(job: Job<OnchainJobData> | undefined, error: Error) {
     if (job) {
       this.logger.error(`Onchain job ${job.id} failed: ${error.message}`);
+      this.metricsService.incrementCallbackFailure(
+        'onchain_job',
+        error.message,
+      );
       await this.dlqService.moveToDlq('onchain', job, error);
     } else {
       this.logger.error(`Onchain job failed: ${error.message}`);

--- a/app/backend/src/onchain/onchain.service.ts
+++ b/app/backend/src/onchain/onchain.service.ts
@@ -5,6 +5,7 @@ import {
   OnchainJobData,
   OnchainOperationType,
 } from './interfaces/onchain-job.interface';
+import { LoggerService } from '../logger/logger.service';
 
 export interface CreateClaimJobParams {
   claimId: string;
@@ -32,7 +33,10 @@ export interface InitEscrowJobParams {
 export class OnchainService {
   private readonly logger = new Logger(OnchainService.name);
 
-  constructor(@InjectQueue('onchain') private readonly onchainQueue: Queue) {}
+  constructor(
+    @InjectQueue('onchain') private readonly onchainQueue: Queue,
+    private readonly loggerService: LoggerService,
+  ) {}
 
   async enqueueInitEscrow(params: InitEscrowJobParams) {
     return this.enqueue(OnchainOperationType.INIT_ESCROW, params);
@@ -59,6 +63,7 @@ export class OnchainService {
       type,
       params,
       timestamp: Date.now(),
+      correlationId: this.loggerService.getCorrelationId(),
     };
 
     const job = await this.onchainQueue.add(type, data, {
@@ -70,7 +75,12 @@ export class OnchainService {
       removeOnComplete: true,
     });
 
-    this.logger.log(`Enqueued onchain job: ${job.id} for ${type}`);
+    const correlationSuffix = data.correlationId
+      ? ` [correlationId=${data.correlationId}]`
+      : '';
+    this.logger.log(
+      `Enqueued onchain job: ${job.id} for ${type}${correlationSuffix}`,
+    );
     return job;
   }
 }

--- a/docs/testnet-observability-dashboard.md
+++ b/docs/testnet-observability-dashboard.md
@@ -1,0 +1,40 @@
+# Testnet Observability Dashboard
+
+Use the backend `/metrics`, `/health`, `/api/v1/health`, and `/jobs/health` endpoints together when Testnet behavior is unclear. Start with the request correlation ID, then check contract latency, transaction submission failures, callback failures, queue depth, and RPC health.
+
+## Request Correlation
+
+- Every HTTP request receives `x-correlation-id` and `x-request-id` response headers.
+- Pass `x-correlation-id` on operator requests when investigating an incident.
+- Onchain BullMQ jobs copy the active request correlation ID into `job.data.correlationId`, so job logs can be matched back to the API request that queued the contract action.
+- Notification jobs already accept correlation IDs; use the same header value when enqueueing callbacks from request handlers.
+
+## Metrics To Watch
+
+| Signal | Metric | What it means |
+| --- | --- | --- |
+| Contract latency | `contract_call_latency_seconds{operation,status}` | Slow or failed Soroban contract operations by queue operation. Watch p95/p99 by `operation`. |
+| Transaction submission failures | `tx_submission_failures_total{operation,reason}` | Transaction submission or `tx_*` failures from onchain jobs. Spikes usually mean RPC congestion, expired transactions, bad sequence state, or network mismatch. |
+| Callback failures | `callback_failures_total{callback_type,reason}` | Failed AI webhooks, notification delivery jobs, and onchain job failure callbacks. |
+| Onchain throughput | `onchain_operations_total{operation,adapter,status}` | Existing onchain success/failure counter by adapter. |
+| Job failures | `jobs_failed_total{job_type}` | Background job failures across queues. Pair with `/jobs/health`. |
+| Webhook retries | `webhook_retries_total{webhook_type,reason}` | Retry pressure for webhook delivery paths. |
+
+## Incident Checklist
+
+1. Find the `x-correlation-id` from the failed API response or client logs.
+2. Search backend logs for that correlation ID. Follow it from the request log to any queued onchain or notification job.
+3. Check `contract_call_latency_seconds` for slow `create-claim`, `disburse`, or `init-escrow` jobs.
+4. Check `tx_submission_failures_total` for transaction failures. If it is increasing, compare the reason label with Stellar RPC status and the configured Testnet RPC URL.
+5. Check `callback_failures_total` for failed AI task webhooks, notification delivery, or onchain job callbacks.
+6. Check `/jobs/health` for waiting, active, delayed, and failed queue counts. A healthy RPC with growing queue depth points to worker capacity or Redis issues.
+7. Check `/health` and `/api/v1/health` for backend, database, Redis, and Testnet RPC reachability.
+
+## Dashboard Panels
+
+- Contract call latency: p50, p95, p99 from `contract_call_latency_seconds` by operation and status.
+- Transaction submission failures: rate of `tx_submission_failures_total` by operation and reason.
+- Callback failures: rate of `callback_failures_total` by callback type and reason.
+- Queue pressure: waiting, active, delayed, and failed jobs from `/jobs/status`.
+- RPC health: Testnet RPC probe status from the health endpoint.
+- Correlated request errors: HTTP 4xx/5xx rate grouped by route, then inspect logs by `correlationId`.


### PR DESCRIPTION
## Summary
- add Prometheus metrics for Testnet contract call latency, transaction submission failures, and callback/job failures
- propagate request correlation IDs into onchain and notification BullMQ jobs for log tracing
- document the Testnet observability dashboard signals and incident checklist

Closes #438

## Verification
- git diff --check
- attempted: npm test -- --runInBand src/aid/aid.service.spec.ts src/notifications/notifications.processor.spec.ts (blocked: dependencies not installed, jest not found)
- attempted: npm ci --ignore-scripts --legacy-peer-deps (blocked: existing backend package-lock is out of sync with @stellar/stellar-sdk entries)
- attempted: npm install --ignore-scripts --legacy-peer-deps (blocked locally by ENOSPC; partial install was removed)