### PR TITLE
feat(onchain): add transaction status polling endpoint

### DIFF
--- a/app/backend/src/onchain/aid-escrow.controller.ts
+++ b/app/backend/src/onchain/aid-escrow.controller.ts
@@ -330,4 +330,43 @@ export class AidEscrowController {
       this.errorMapper.throwMappedError(error);
     }
   }
+
+  /**
+   * Get transaction status by hash
+   * GET /onchain/aid-escrow/transactions/:hash/status
+   */
+  @Get('transactions/:hash/status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get transaction status',
+    description:
+      'Polls Soroban RPC for the status of a transaction by its hash. Returns a normalized status: pending, succeeded, failed, or unknown.',
+  })
+  @ApiOkResponse({
+    description: 'Transaction status retrieved successfully.',
+    schema: {
+      example: {
+        hash: 'ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABCD',
+        status: 'succeeded',
+        timestamp: '2026-03-30T12:30:00.000Z',
+        ledger: 12345,
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Invalid transaction hash.' })
+  @ApiNotFoundResponse({ description: 'Transaction not found.' })
+  @ApiInternalServerErrorResponse({
+    description: 'Failed to retrieve transaction status.',
+  })
+  async getTransactionStatus(@Param('hash') hash: string): Promise<any> {
+    if (!hash || hash.length < 10) {
+      throw new BadRequestException('Invalid transaction hash');
+    }
+    try {
+      return await this.aidEscrowService.getTransactionStatus(hash);
+    } catch (error) {
+      this.logger.error('Failed to get transaction status:', error);
+      this.errorMapper.throwMappedError(error);
+    }
+  }
 }

--- a/app/backend/src/onchain/aid-escrow.service.ts
+++ b/app/backend/src/onchain/aid-escrow.service.ts
@@ -10,6 +10,7 @@ import {
   GetAidPackageStatsDto,
 } from './dto/aid-escrow.dto';
 import { BudgetService } from '../common/budget/budget.service';
+import { GetTransactionStatusResult } from './onchain.adapter';
 
 /**
  * AidEscrowService
@@ -254,6 +255,22 @@ export class AidEscrowService {
     this.logger.debug('Aid package statistics retrieved:', {
       totalCommitted: result.aggregates.totalCommitted,
       totalClaimed: result.aggregates.totalClaimed,
+    });
+
+    return result;
+  }
+
+  /**
+   * Get the status of a transaction by hash from Soroban RPC
+   */
+  async getTransactionStatus(hash: string): Promise<GetTransactionStatusResult> {
+    this.logger.debug('Getting transaction status:', { hash });
+
+    const result = await this.onchainAdapter.getTransactionStatus({ hash });
+
+    this.logger.debug('Transaction status retrieved:', {
+      hash: result.hash,
+      status: result.status,
     });
 
     return result;

--- a/app/backend/src/onchain/onchain.adapter.mock.ts
+++ b/app/backend/src/onchain/onchain.adapter.mock.ts
@@ -26,6 +26,9 @@ import {
   PauseState,
   FeeConfig,
   PackageSummary,
+  GetTransactionStatusParams,
+  GetTransactionStatusResult,
+  TxStatus,
 } from './onchain.adapter';
 import { createHash } from 'crypto';
 
@@ -267,6 +270,35 @@ export class MockOnchainAdapter implements OnchainAdapter {
       claimedAmount: '0',
       status: 'Active',
       timestamp: new Date(),
+    };
+  }
+
+  async getTransactionStatus(
+    params: GetTransactionStatusParams,
+  ): Promise<GetTransactionStatusResult> {
+    await Promise.resolve();
+    const hash = params.hash.toUpperCase();
+
+    // Deterministically map hash prefix to a status for predictable tests
+    const firstChar = hash.charAt(0);
+    let status: TxStatus;
+    if (firstChar >= '0' && firstChar <= '7') {
+      status = 'succeeded';
+    } else if (firstChar >= '8' && firstChar <= 'B') {
+      status = 'pending';
+    } else if (firstChar >= 'C' && firstChar <= 'D') {
+      status = 'failed';
+    } else {
+      status = 'unknown';
+    }
+
+    return {
+      hash,
+      status,
+      timestamp: new Date(),
+      ledger: status === 'succeeded' ? 12345 : undefined,
+      errorMessage:
+        status === 'failed' ? 'Mock contract transaction failed' : undefined,
     };
   }
 

--- a/app/backend/src/onchain/onchain.adapter.ts
+++ b/app/backend/src/onchain/onchain.adapter.ts
@@ -1,5 +1,19 @@
 export const ONCHAIN_ADAPTER_TOKEN = 'ONCHAIN_ADAPTER';
 
+export type TxStatus = 'pending' | 'succeeded' | 'failed' | 'unknown';
+
+export interface GetTransactionStatusParams {
+  hash: string;
+}
+
+export interface GetTransactionStatusResult {
+  hash: string;
+  status: TxStatus;
+  timestamp: Date;
+  ledger?: number;
+  errorMessage?: string;
+}
+
 /**
  * On-chain adapter interface for Soroban AidEscrow contract interactions
  */
@@ -249,6 +263,13 @@ export interface OnchainAdapter {
   getPauseState(): Promise<PauseState>;
   getFeeConfig(): Promise<FeeConfig>;
   getPackageSummary(packageId: string): Promise<PackageSummary>;
+
+  /**
+   * Get the status of a transaction by hash
+   */
+  getTransactionStatus(
+    params: GetTransactionStatusParams,
+  ): Promise<GetTransactionStatusResult>;
 
   // Legacy methods - kept for backward compatibility
   createClaim(params: CreateClaimParams): Promise<CreateClaimResult>;

--- a/app/backend/src/onchain/soroban-onchain.adapter.ts
+++ b/app/backend/src/onchain/soroban-onchain.adapter.ts
@@ -29,6 +29,9 @@ import {
   PauseState,
   FeeConfig,
   PackageSummary,
+  GetTransactionStatusParams,
+  GetTransactionStatusResult,
+  TxStatus,
 } from './onchain.adapter';
 
 /** Calls the Soroban RPC endpoint and returns the result value. */
@@ -316,6 +319,44 @@ export class SorobanOnchainAdapter implements OnchainAdapter {
       status: result.status,
       amountDisbursed: result.amountDisbursed,
     };
+  }
+
+  async getTransactionStatus(
+    params: GetTransactionStatusParams,
+  ): Promise<GetTransactionStatusResult> {
+    const hash = params.hash.toUpperCase();
+    try {
+      const result = await rpcCall(this.http, this.rpcUrl, 'getTransaction', {
+        hash,
+      });
+      const r = result as any;
+      let status: TxStatus;
+      switch (r?.status) {
+        case 'SUCCESS':
+          status = 'succeeded';
+          break;
+        case 'FAILED':
+          status = 'failed';
+          break;
+        case 'NOT_FOUND':
+          status = 'pending';
+          break;
+        default:
+          status = 'unknown';
+      }
+      return {
+        hash,
+        status,
+        timestamp: new Date(),
+        ledger: typeof r?.ledger === 'number' ? r.ledger : undefined,
+        errorMessage:
+          status === 'failed'
+            ? (r?.resultXdr ?? 'Transaction failed')
+            : undefined,
+      };
+    } catch {
+      return { hash, status: 'unknown', timestamp: new Date() };
+    }
   }
 }
 

--- a/app/backend/src/onchain/soroban.adapter.ts
+++ b/app/backend/src/onchain/soroban.adapter.ts
@@ -37,6 +37,9 @@ import {
   PauseState,
   FeeConfig,
   PackageSummary,
+  GetTransactionStatusParams,
+  GetTransactionStatusResult,
+  TxStatus,
 } from './onchain.adapter';
 import { SorobanErrorMapper } from './utils/soroban-error.mapper';
 import { withRetryTimeout } from './utils/retry-with-timeout';
@@ -656,6 +659,62 @@ export class SorobanAdapter implements OnchainAdapter {
       status: pkg.package.status,
       timestamp: new Date(),
     };
+  }
+
+  async getTransactionStatus(
+    params: GetTransactionStatusParams,
+  ): Promise<GetTransactionStatusResult> {
+    this.ensureConfigured();
+    const cid = this.correlationId();
+    const hash = params.hash.toUpperCase();
+    this.logger.log(`[${cid}] getTransactionStatus hash=${hash}`);
+
+    const server = this.getServer();
+
+    try {
+      const result = await withRetryTimeout(
+        () => server.getTransaction(hash),
+        `getTransaction(${hash})`,
+        cid,
+        { maxRetries: 0, operationTimeoutMs: 30000 },
+        this.logger,
+      );
+
+      let status: TxStatus;
+      switch (result.status) {
+        case SorobanRpc.Api.GetTransactionStatus.SUCCESS:
+          status = 'succeeded';
+          break;
+        case SorobanRpc.Api.GetTransactionStatus.FAILED:
+          status = 'failed';
+          break;
+        case SorobanRpc.Api.GetTransactionStatus.NOT_FOUND:
+          status = 'pending';
+          break;
+        default:
+          status = 'unknown';
+      }
+
+      return {
+        hash,
+        status,
+        timestamp: new Date(),
+        ledger:
+          'ledger' in result && typeof result.ledger === 'number'
+            ? result.ledger
+            : undefined,
+        errorMessage:
+          status === 'failed'
+            ? this.extractContractError(result)
+            : undefined,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('timed out')) {
+        return { hash, status: 'unknown', timestamp: new Date() };
+      }
+      throw error;
+    }
   }
 
   async createClaim(params: CreateClaimParams): Promise<CreateClaimResult> {

--- a/app/backend/test/transaction-status.spec.ts
+++ b/app/backend/test/transaction-status.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { AidEscrowService } from '../src/onchain/aid-escrow.service';
+import { AidEscrowController } from '../src/onchain/aid-escrow.controller';
+import { MockOnchainAdapter } from '../src/onchain/onchain.adapter.mock';
+import { ONCHAIN_ADAPTER_TOKEN } from '../src/onchain/onchain.adapter';
+import { BudgetService } from '../src/common/budget/budget.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Transaction Status Polling', () => {
+  let service: AidEscrowService;
+  let controller: AidEscrowController;
+  let mockAdapter: MockOnchainAdapter;
+
+  beforeEach(async () => {
+    mockAdapter = new MockOnchainAdapter();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AidEscrowController],
+      providers: [
+        AidEscrowService,
+        BudgetService,
+        { provide: PrismaService, useValue: {} },
+        { provide: ONCHAIN_ADAPTER_TOKEN, useValue: mockAdapter },
+      ],
+    }).compile();
+
+    service = module.get<AidEscrowService>(AidEscrowService);
+    controller = module.get<AidEscrowController>(AidEscrowController);
+  });
+
+  // ── Status mapping ────────────────────────────────────────────────────────
+
+  describe('MockOnchainAdapter: status mapping', () => {
+    it('returns "succeeded" for hash starting with 0-7', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '0ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('succeeded');
+    });
+
+    it('returns "pending" for hash starting with 8-B', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '9ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('pending');
+    });
+
+    it('returns "failed" for hash starting with C-D', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: 'CABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('failed');
+    });
+
+    it('returns "unknown" for hash starting with E-F', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: 'EABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('unknown');
+    });
+  });
+
+  // ── Response shape ────────────────────────────────────────────────────────
+
+  describe('MockOnchainAdapter: response shape', () => {
+    it('normalises hash to uppercase', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '1abc123def456abc123def456abc123def456abc123def456abc123def456ab',
+      });
+      expect(result.hash).toBe(
+        '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+    });
+
+    it('includes ledger for succeeded status', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('succeeded');
+      expect(result.ledger).toBe(12345);
+    });
+
+    it('includes errorMessage for failed status', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: 'CABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.status).toBe('failed');
+      expect(result.errorMessage).toBeTruthy();
+    });
+
+    it('does not include errorMessage for succeeded status', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('returns a Date timestamp', async () => {
+      const result = await mockAdapter.getTransactionStatus({
+        hash: '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      });
+      expect(result.timestamp).toBeInstanceOf(Date);
+    });
+  });
+
+  // ── Service layer ─────────────────────────────────────────────────────────
+
+  describe('AidEscrowService.getTransactionStatus', () => {
+    it('delegates to adapter and returns result', async () => {
+      const result = await service.getTransactionStatus(
+        '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result).toBeDefined();
+      expect(result.hash).toBe(
+        '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(['pending', 'succeeded', 'failed', 'unknown']).toContain(
+        result.status,
+      );
+    });
+  });
+
+  // ── Controller layer ──────────────────────────────────────────────────────
+
+  describe('AidEscrowController.getTransactionStatus', () => {
+    it('returns status for a valid hash', async () => {
+      const result = await controller.getTransactionStatus(
+        '1ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result).toBeDefined();
+      expect(result.status).toBeDefined();
+      expect(['pending', 'succeeded', 'failed', 'unknown']).toContain(
+        result.status,
+      );
+    });
+
+    it('throws BadRequestException for empty hash', async () => {
+      await expect(controller.getTransactionStatus('')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequestException for hash that is too short', async () => {
+      await expect(controller.getTransactionStatus('ABC')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('returns succeeded status with ledger for 0-7 prefix hash', async () => {
+      const result = await controller.getTransactionStatus(
+        '3ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result.status).toBe('succeeded');
+      expect(result.ledger).toBeDefined();
+    });
+
+    it('returns pending status for 8-B prefix hash', async () => {
+      const result = await controller.getTransactionStatus(
+        'AABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result.status).toBe('pending');
+    });
+
+    it('returns failed status with errorMessage for C-D prefix hash', async () => {
+      const result = await controller.getTransactionStatus(
+        'DABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result.status).toBe('failed');
+      expect(result.errorMessage).toBeTruthy();
+    });
+
+    it('returns unknown status for E-F prefix hash', async () => {
+      const result = await controller.getTransactionStatus(
+        'FABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456ABC123DEF456AB',
+      );
+      expect(result.status).toBe('unknown');
+    });
+  });
+
+  // ── Timeout behaviour ─────────────────────────────────────────────────────
+
+  describe('Timeout behaviour', () => {
+    it('returns unknown status when adapter times out', async () => {
+      jest
+        .spyOn(mockAdapter, 'getTransactionStatus')
+        .mockResolvedValueOnce({
+          hash: 'TIMEOUT_HASH',
+          status: 'unknown',
+          timestamp: new Date(),
+        });
+
+      const result = await service.getTransactionStatus('TIMEOUT_HASH');
+      expect(result.status).toBe('unknown');
+    });
+  });
+});


### PR DESCRIPTION
Exposes GET /onchain/aid-escrow/transactions/:hash/status for frontend/mobile to poll Soroban RPC and get normalized tx status during Testnet.

- Add TxStatus type and GetTransactionStatus interfaces to OnchainAdapter
- Implement getTransactionStatus in SorobanAdapter using getTransaction RPC call, mapping NOT_FOUND→pending, SUCCESS→succeeded, FAILED→failed, else→unknown
- Add deterministic mock implementation in MockOnchainAdapter for testing
- Add getTransactionStatus method to AidEscrowService
- Add GET transactions/:hash/status endpoint to AidEscrowController with Swagger docs
- Add 18 tests covering all status mappings, response shape, timeout behaviour, service delegation, and controller validation

Closes #437