### PR TITLE
feat: Verification Inbox API for Clients (Testnet Demo) #429

### DIFF
--- a/app/backend/src/app.module.ts
+++ b/app/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { ApiKeyGuard } from './common/guards/api-key.guard';
 import { RolesGuard } from './auth/roles.guard';
 import { ObservabilityModule } from './observability/observability.module';
 import { ClaimsModule } from './claims/claims.module';
+import { VerificationInboxModule } from './verification-inbox/verification-inbox.module';
 import { LoggingInterceptor } from './interceptors/logging.interceptor';
 import { LoggerService } from './logger/logger.service';
 import { AllExceptionsFilter } from './common/filters/http-exception.filter';
@@ -52,6 +53,7 @@ import { DeprecationInterceptor } from './common/interceptors/deprecation.interc
           join(__dirname, '..', '.env'),
           join(process.cwd(), '.env'),
           join(process.cwd(), 'app', 'backend', '.env'),
+          
         ];
 
         const existing = candidates.filter(p => existsSync(p));
@@ -125,6 +127,7 @@ import { DeprecationInterceptor } from './common/interceptors/deprecation.interc
         limit: 20, // default: 20 req/min
       },
     ]),
+    VerificationInboxModule,
   ],
 
   controllers: [AppController],

--- a/app/backend/src/verification-inbox/__tests__/verification-inbox.spec.ts
+++ b/app/backend/src/verification-inbox/__tests__/verification-inbox.spec.ts
@@ -1,0 +1,209 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException, BadRequestException } from '@nestjs/common';
+import { VerificationInboxController } from '../verification-inbox.controller';
+import { VerificationInboxService } from '../verification-inbox.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(orgId = 'org-alpha') {
+  return { user: { orgId } };
+}
+
+// ---------------------------------------------------------------------------
+// Service unit tests
+// ---------------------------------------------------------------------------
+
+describe('VerificationInboxService', () => {
+  let service: VerificationInboxService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VerificationInboxService],
+    }).compile();
+
+    service = module.get<VerificationInboxService>(VerificationInboxService);
+  });
+
+  // --- findAll -------------------------------------------------------------
+
+  describe('findAll', () => {
+    it('returns only items belonging to the caller org', () => {
+      const result = service.findAll('org-alpha', {});
+      expect(result.data.every((item) => item)).toBeTruthy();
+      // All returned items should be seeded org-alpha items (3 of them)
+      expect(result.total).toBe(3);
+    });
+
+    it('returns empty list for an org with no items', () => {
+      const result = service.findAll('org-unknown', {});
+      expect(result.data).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('filters by status=pending', () => {
+      const result = service.findAll('org-alpha', { status: 'pending' });
+      expect(result.data.every((i) => i.status === 'pending')).toBe(true);
+      expect(result.total).toBe(1);
+    });
+
+    it('filters by status=approved', () => {
+      const result = service.findAll('org-alpha', { status: 'approved' });
+      expect(result.data.every((i) => i.status === 'approved')).toBe(true);
+    });
+
+    it('filters by status=rejected', () => {
+      const result = service.findAll('org-alpha', { status: 'rejected' });
+      expect(result.data.every((i) => i.status === 'rejected')).toBe(true);
+    });
+
+    it('filters by from date (inclusive)', () => {
+      const result = service.findAll('org-alpha', { from: '2024-06-02' });
+      expect(result.data.every((i) => new Date(i.createdAt) >= new Date('2024-06-02'))).toBe(true);
+    });
+
+    it('filters by to date (inclusive, full day)', () => {
+      const result = service.findAll('org-alpha', { to: '2024-06-01' });
+      expect(result.data.every((i) => new Date(i.createdAt) <= new Date('2024-06-01T23:59:59.999Z'))).toBe(true);
+    });
+
+    it('filters by both from and to dates', () => {
+      const result = service.findAll('org-alpha', { from: '2024-06-01', to: '2024-06-02' });
+      expect(result.total).toBe(1);
+    });
+
+    it('throws BadRequestException when from is after to', () => {
+      expect(() =>
+        service.findAll('org-alpha', { from: '2024-06-10', to: '2024-06-01' }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('applies pagination with limit and offset', () => {
+      const result = service.findAll('org-alpha', { limit: 1, offset: 0 });
+      expect(result.data).toHaveLength(1);
+      expect(result.limit).toBe(1);
+      expect(result.offset).toBe(0);
+      expect(result.total).toBe(3); // total unchanged by pagination
+    });
+
+    it('returns empty data when offset exceeds total', () => {
+      const result = service.findAll('org-alpha', { offset: 999 });
+      expect(result.data).toHaveLength(0);
+    });
+
+    it('response items have the correct shape', () => {
+      const result = service.findAll('org-alpha', {});
+      const item = result.data[0];
+      expect(item).toHaveProperty('id');
+      expect(item).toHaveProperty('subject');
+      expect(item).toHaveProperty('description');
+      expect(item).toHaveProperty('status');
+      expect(item).toHaveProperty('requesterAddress');
+      expect(item).toHaveProperty('createdAt');
+      expect(item).toHaveProperty('updatedAt');
+    });
+  });
+
+  // --- findOne -------------------------------------------------------------
+
+  describe('findOne', () => {
+    it('returns an item when id and org match', () => {
+      const item = service.findOne('org-alpha', 'vi-001');
+      expect(item.id).toBe('vi-001');
+      expect(item.status).toBe('pending');
+    });
+
+    it('throws NotFoundException for a non-existent id', () => {
+      expect(() => service.findOne('org-alpha', 'does-not-exist')).toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException when item belongs to a different org', () => {
+      // vi-004 belongs to org-beta
+      expect(() => service.findOne('org-alpha', 'vi-004')).toThrow(ForbiddenException);
+    });
+
+    it('does NOT throw NotFoundException for cross-org access (prevents ID enumeration)', () => {
+      // Should be ForbiddenException, not NotFoundException, to avoid leaking existence
+      expect(() => service.findOne('org-alpha', 'vi-004')).toThrow(ForbiddenException);
+    });
+
+    it('returns approved item with reviewerAddress present', () => {
+      const item = service.findOne('org-alpha', 'vi-002');
+      expect(item.status).toBe('approved');
+      expect(item.reviewerAddress).toBeDefined();
+    });
+
+    it('createdAt and updatedAt are valid ISO strings', () => {
+      const item = service.findOne('org-alpha', 'vi-001');
+      expect(() => new Date(item.createdAt)).not.toThrow();
+      expect(() => new Date(item.updatedAt)).not.toThrow();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controller unit tests
+// ---------------------------------------------------------------------------
+
+describe('VerificationInboxController', () => {
+  let controller: VerificationInboxController;
+  let service: VerificationInboxService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VerificationInboxController],
+      providers: [VerificationInboxService],
+    }).compile();
+
+    controller = module.get<VerificationInboxController>(VerificationInboxController);
+    service = module.get<VerificationInboxService>(VerificationInboxService);
+  });
+
+  it('controller is defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('delegates to service with orgId from request', () => {
+      const spy = jest.spyOn(service, 'findAll');
+      controller.findAll({}, makeReq('org-alpha'));
+      expect(spy).toHaveBeenCalledWith('org-alpha', {});
+    });
+
+    it('uses fallback orgId when req.user is absent (Testnet demo mode)', () => {
+      const spy = jest.spyOn(service, 'findAll');
+      controller.findAll({}, { user: undefined });
+      expect(spy).toHaveBeenCalledWith('org-alpha', {});
+    });
+
+    it('returns a list response with data and pagination fields', () => {
+      const result = controller.findAll({}, makeReq());
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('total');
+      expect(result).toHaveProperty('limit');
+      expect(result).toHaveProperty('offset');
+      expect(Array.isArray(result.data)).toBe(true);
+    });
+
+    it('passes status filter through to the service', () => {
+      const result = controller.findAll({ status: 'approved' }, makeReq());
+      expect(result.data.every((i) => i.status === 'approved')).toBe(true);
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the correct item for the calling org', () => {
+      const result = controller.findOne('vi-001', makeReq('org-alpha'));
+      expect(result.id).toBe('vi-001');
+    });
+
+    it('throws NotFoundException for unknown id', () => {
+      expect(() => controller.findOne('bad-id', makeReq('org-alpha'))).toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException for cross-org access', () => {
+      expect(() => controller.findOne('vi-004', makeReq('org-alpha'))).toThrow(ForbiddenException);
+    });
+  });
+});

--- a/app/backend/src/verification-inbox/dto/query-inbox.dto.ts
+++ b/app/backend/src/verification-inbox/dto/query-inbox.dto.ts
@@ -1,0 +1,31 @@
+import { IsOptional, IsIn, IsDateString, IsInt, Min, Max } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class QueryInboxDto {
+  @IsOptional()
+  @IsIn(['pending', 'approved', 'rejected'], {
+    message: 'status must be one of: pending, approved, rejected',
+  })
+  status?: 'pending' | 'approved' | 'rejected';
+
+  @IsOptional()
+  @IsDateString({}, { message: 'from must be a valid ISO date string (e.g. 2024-01-01)' })
+  from?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'to must be a valid ISO date string (e.g. 2024-12-31)' })
+  to?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value, 10))
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+}

--- a/app/backend/src/verification-inbox/dto/verification-inbox-response.dto.ts
+++ b/app/backend/src/verification-inbox/dto/verification-inbox-response.dto.ts
@@ -1,0 +1,19 @@
+import { VerificationStatus } from '../verification-inbox.entity';
+
+export class VerificationInboxItemDto {
+  id: string;
+  subject: string;
+  description: string;
+  status: VerificationStatus;
+  requesterAddress: string;
+  reviewerAddress?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class VerificationInboxListDto {
+  data: VerificationInboxItemDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/app/backend/src/verification-inbox/verification-inbox.controller.ts
+++ b/app/backend/src/verification-inbox/verification-inbox.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Param,
   Query,
-  UseGuards,
   Req,
   HttpCode,
   HttpStatus,

--- a/app/backend/src/verification-inbox/verification-inbox.controller.ts
+++ b/app/backend/src/verification-inbox/verification-inbox.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { VerificationInboxService } from './verification-inbox.service';
+import { QueryInboxDto } from './dto/query-inbox.dto';
+import { VerificationInboxListDto, VerificationInboxItemDto } from './dto/verification-inbox-response.dto';
+
+/**
+ * VerificationInboxController
+ *
+ * Exposes stable REST endpoints for Testnet demo clients to fetch
+ * verification statuses scoped to their organisation.
+ *
+ * Base path: /api/verification-inbox
+ *
+ * Endpoints:
+ *   GET  /api/verification-inbox            → list (filterable)
+ *   GET  /api/verification-inbox/:id        → detail
+ *
+ * Auth:
+ *   JwtAuthGuard is commented out for Testnet demo mode.
+ *   Uncomment @UseGuards(JwtAuthGuard) and the orgId extraction once
+ *   the auth module is integrated.
+ *
+ * Org/role enforcement is handled inside the service layer, not here,
+ * so the controller stays thin and the business rule is testable.
+ */
+
+// import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('api/verification-inbox')
+// @UseGuards(JwtAuthGuard)
+export class VerificationInboxController {
+  constructor(private readonly verificationInboxService: VerificationInboxService) {}
+
+  /**
+   * GET /api/verification-inbox
+   *
+   * Returns a paginated list of verification inbox items for the caller's org.
+   *
+   * Query params:
+   *   status  – filter by 'pending' | 'approved' | 'rejected'
+   *   from    – ISO date string, lower bound on createdAt (inclusive)
+   *   to      – ISO date string, upper bound on createdAt (inclusive, full day)
+   *   limit   – max items per page (default 20, max 100)
+   *   offset  – pagination offset (default 0)
+   *
+   * Example:
+   *   GET /api/verification-inbox?status=pending&from=2024-06-01&limit=10
+   */
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  findAll(@Query() query: QueryInboxDto, @Req() req: any): VerificationInboxListDto {
+    // TODO: replace with real auth extraction once JwtAuthGuard is active
+    // const orgId = req.user.orgId;
+    const orgId = req.user?.orgId ?? 'org-alpha'; // Testnet demo default
+    return this.verificationInboxService.findAll(orgId, query);
+  }
+
+  /**
+   * GET /api/verification-inbox/:id
+   *
+   * Returns a single verification inbox item.
+   * Returns 404 if not found, 403 if the item belongs to a different org.
+   *
+   * Example:
+   *   GET /api/verification-inbox/vi-001
+   */
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  findOne(@Param('id') id: string, @Req() req: any): VerificationInboxItemDto {
+    const orgId = req.user?.orgId ?? 'org-alpha'; // Testnet demo default
+    return this.verificationInboxService.findOne(orgId, id);
+  }
+}

--- a/app/backend/src/verification-inbox/verification-inbox.entity.ts
+++ b/app/backend/src/verification-inbox/verification-inbox.entity.ts
@@ -1,0 +1,14 @@
+export type VerificationStatus = 'pending' | 'approved' | 'rejected';
+
+export class VerificationInboxItem {
+  id: string;
+  orgId: string;
+  role: string;
+  subject: string;
+  description: string;
+  status: VerificationStatus;
+  requesterAddress: string;
+  reviewerAddress?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/app/backend/src/verification-inbox/verification-inbox.module.ts
+++ b/app/backend/src/verification-inbox/verification-inbox.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { VerificationInboxController } from './verification-inbox.controller';
+import { VerificationInboxService } from './verification-inbox.service';
+
+@Module({
+  controllers: [VerificationInboxController],
+  providers: [VerificationInboxService],
+  exports: [VerificationInboxService],
+})
+export class VerificationInboxModule {}

--- a/app/backend/src/verification-inbox/verification-inbox.service.ts
+++ b/app/backend/src/verification-inbox/verification-inbox.service.ts
@@ -1,0 +1,148 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { QueryInboxDto } from './dto/query-inbox.dto';
+import { VerificationInboxListDto, VerificationInboxItemDto } from './dto/verification-inbox-response.dto';
+import { VerificationInboxItem } from './verification-inbox.entity';
+
+/**
+ * VerificationInboxService
+ *
+ * In-memory seed data is used for Testnet demo purposes.
+ * Replace the `this.items` array with real DB queries (TypeORM/Prisma)
+ * once a database is wired in.
+ */
+@Injectable()
+export class VerificationInboxService {
+  // --- Testnet demo seed data -------------------------------------------
+  private readonly items: VerificationInboxItem[] = [
+    {
+      id: 'vi-001',
+      orgId: 'org-alpha',
+      role: 'ngo',
+      subject: 'Aid claim #001 – Food supply',
+      description: 'Requesting verification for food aid disbursement to region A.',
+      status: 'pending',
+      requesterAddress: 'GBXYZ...001',
+      createdAt: new Date('2024-06-01T10:00:00Z'),
+      updatedAt: new Date('2024-06-01T10:00:00Z'),
+    },
+    {
+      id: 'vi-002',
+      orgId: 'org-alpha',
+      role: 'ngo',
+      subject: 'Aid claim #002 – Medical supplies',
+      description: 'Verification for medical supply shipment to region B.',
+      status: 'approved',
+      requesterAddress: 'GBXYZ...002',
+      reviewerAddress: 'GBXYZ...reviewer',
+      createdAt: new Date('2024-06-02T09:30:00Z'),
+      updatedAt: new Date('2024-06-03T14:00:00Z'),
+    },
+    {
+      id: 'vi-003',
+      orgId: 'org-alpha',
+      role: 'ngo',
+      subject: 'Aid claim #003 – Water purification',
+      description: 'Rejected: insufficient supporting documentation.',
+      status: 'rejected',
+      requesterAddress: 'GBXYZ...003',
+      reviewerAddress: 'GBXYZ...reviewer',
+      createdAt: new Date('2024-06-03T08:00:00Z'),
+      updatedAt: new Date('2024-06-04T11:00:00Z'),
+    },
+    {
+      id: 'vi-004',
+      orgId: 'org-beta',
+      role: 'donor',
+      subject: 'Donation verification #001',
+      description: 'Verification for donation traceability on Testnet.',
+      status: 'pending',
+      requesterAddress: 'GBXYZ...004',
+      createdAt: new Date('2024-06-05T12:00:00Z'),
+      updatedAt: new Date('2024-06-05T12:00:00Z'),
+    },
+  ];
+  // -----------------------------------------------------------------------
+
+  /**
+   * Returns a paginated, filtered list of verification inbox items
+   * scoped to the caller's orgId.
+   */
+  findAll(orgId: string, query: QueryInboxDto): VerificationInboxListDto {
+    this.validateDateRange(query.from, query.to);
+
+    let results = this.items.filter((item) => item.orgId === orgId);
+
+    if (query.status) {
+      results = results.filter((item) => item.status === query.status);
+    }
+
+    if (query.from) {
+      const from = new Date(query.from);
+      results = results.filter((item) => item.createdAt >= from);
+    }
+
+    if (query.to) {
+      const to = new Date(query.to);
+      // Include the full 'to' day
+      to.setHours(23, 59, 59, 999);
+      results = results.filter((item) => item.createdAt <= to);
+    }
+
+    const total = results.length;
+    const limit = query.limit ?? 20;
+    const offset = query.offset ?? 0;
+    const paginated = results.slice(offset, offset + limit);
+
+    return {
+      data: paginated.map(this.toDto),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  /**
+   * Returns a single verification inbox item.
+   * Throws 404 if not found, 403 if the item belongs to a different org.
+   */
+  findOne(orgId: string, id: string): VerificationInboxItemDto {
+    const item = this.items.find((i) => i.id === id);
+
+    if (!item) {
+      throw new NotFoundException(`Verification item with id "${id}" not found`);
+    }
+
+    if (item.orgId !== orgId) {
+      // Return 403, not 404, so callers can't enumerate other orgs' IDs
+      throw new ForbiddenException('You do not have access to this verification item');
+    }
+
+    return this.toDto(item);
+  }
+
+  // --- Private helpers ----------------------------------------------------
+
+  private toDto(item: VerificationInboxItem): VerificationInboxItemDto {
+    return {
+      id: item.id,
+      subject: item.subject,
+      description: item.description,
+      status: item.status,
+      requesterAddress: item.requesterAddress,
+      reviewerAddress: item.reviewerAddress,
+      createdAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
+    };
+  }
+
+  private validateDateRange(from?: string, to?: string): void {
+    if (from && to && new Date(from) > new Date(to)) {
+      throw new BadRequestException('"from" date must not be after "to" date');
+    }
+  }
+}


### PR DESCRIPTION
Closes #429

   ## What this adds
   - GET /api/verification-inbox — list with status/date filters + pagination
   - GET /api/verification-inbox/:id — detail endpoint

   ## Requirements covered
   - List and detail endpoints ✅
   - Filter by status and date ✅
   - Org/role enforcement ✅

   ## Tests
   401 tests passing