### PR TITLE
Add resumable evidence upload sessions to ai-service

### DIFF
--- a/app/ai-service/api/v1/router.py
+++ b/app/ai-service/api/v1/router.py
@@ -1,8 +1,8 @@
 """
-API v1 router – aggregates all versioned sub-routers.
+API v1 router - aggregates all versioned sub-routers.
 
 Every route defined here lives under the /v1 prefix (mounted in main.py).
-Add new versioned routers to the `include_router` calls below as the
+Add new versioned routers to the include_router calls below as the
 surface grows.
 """
 
@@ -16,6 +16,7 @@ from api.v1 import (
     humanitarian,
     fraud,
     artifacts,
+    uploads,
 )
 
 v1_router = APIRouter(prefix="/v1")
@@ -27,3 +28,4 @@ v1_router.include_router(anonymize.router)
 v1_router.include_router(humanitarian.router)
 v1_router.include_router(fraud.router)
 v1_router.include_router(artifacts.router)
+v1_router.include_router(uploads.router)

--- a/app/ai-service/api/v1/uploads.py
+++ b/app/ai-service/api/v1/uploads.py
@@ -1,0 +1,214 @@
+"""
+Resumable evidence upload session endpoints (v1).
+
+Large verification-evidence files can be uploaded in chunks so that an
+interrupted upload resumes from the last received chunk instead of
+restarting. Exposes session creation, chunk upload, status, and finalize
+routes under the /v1 prefix.
+"""
+
+import logging
+import os
+from typing import Annotated
+
+from fastapi import APIRouter, File, Header, HTTPException, Path, UploadFile
+
+from schemas.uploads import (
+    ChunkUploadResponse,
+    CreateUploadSessionRequest,
+    FinalizeUploadResponse,
+    UploadSessionResponse,
+)
+from services.upload_sessions import (
+    UploadSession,
+    UploadSessionError,
+    UploadSessionService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["evidence-uploads"])
+
+ALLOWED_EVIDENCE_CONTENT_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/jpg",
+    "image/webp",
+    "image/tiff",
+    "image/bmp",
+    "application/pdf",
+}
+
+EVIDENCE_UPLOAD_DIR = os.getenv(
+    "EVIDENCE_UPLOAD_DIR", "./artifacts/evidence-uploads"
+)
+EVIDENCE_MAX_UPLOAD_BYTES = int(
+    os.getenv("EVIDENCE_MAX_UPLOAD_BYTES", str(50 * 1024 * 1024))
+)
+EVIDENCE_UPLOAD_SESSION_TTL_SECONDS = int(
+    os.getenv("EVIDENCE_UPLOAD_SESSION_TTL_SECONDS", str(60 * 60))
+)
+
+upload_session_service = UploadSessionService(
+    storage_dir=EVIDENCE_UPLOAD_DIR,
+    allowed_content_types=ALLOWED_EVIDENCE_CONTENT_TYPES,
+    max_upload_bytes=EVIDENCE_MAX_UPLOAD_BYTES,
+    session_ttl_seconds=EVIDENCE_UPLOAD_SESSION_TTL_SECONDS,
+)
+
+_ERROR_STATUS = {
+    "missing_owner": 401,
+    "forbidden_owner": 403,
+    "session_not_found": 404,
+    "session_expired": 410,
+    "invalid_content_type": 415,
+    "file_too_large": 413,
+    "invalid_chunk_index": 400,
+    "invalid_request": 400,
+    "empty_chunk": 400,
+    "session_already_finalized": 409,
+    "incomplete_upload": 409,
+    "size_mismatch": 400,
+}
+
+
+def _http_error(exc: UploadSessionError) -> HTTPException:
+    status_code = _ERROR_STATUS.get(exc.code, 400)
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": exc.code, "message": exc.message},
+    )
+
+
+def _to_session_response(session: UploadSession) -> UploadSessionResponse:
+    return UploadSessionResponse(
+        session_id=session.session_id,
+        filename=session.filename,
+        content_type=session.content_type,
+        total_size=session.total_size,
+        total_chunks=session.total_chunks,
+        received_chunks=UploadSessionService.received_chunks_sorted(session),
+        status="completed" if session.completed else "in_progress",
+        expires_at=session.expires_at,
+        completed=session.completed,
+        artifact_id=session.artifact_id,
+    )
+
+
+@router.post("/ai/evidence-uploads/sessions", response_model=UploadSessionResponse)
+async def create_upload_session(
+    body: CreateUploadSessionRequest,
+    x_user_id: str = Header(default="", alias="X-User-Id"),
+):
+    """Create a resumable upload session after validating type and size."""
+    if body.content_type not in ALLOWED_EVIDENCE_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "code": "invalid_content_type",
+                "message": (
+                    f"Invalid content type: {body.content_type}. "
+                    f"Allowed: {', '.join(sorted(ALLOWED_EVIDENCE_CONTENT_TYPES))}"
+                ),
+            },
+        )
+    try:
+        session = upload_session_service.create_session(
+            owner_id=x_user_id,
+            filename=body.filename,
+            content_type=body.content_type,
+            total_size=body.total_size,
+            total_chunks=body.total_chunks,
+        )
+    except UploadSessionError as exc:
+        raise _http_error(exc)
+
+    logger.info(
+        "evidence_upload_session_created",
+        extra={
+            "event": "evidence_upload_session_created",
+            "session_id": session.session_id,
+            "owner_id": x_user_id,
+        },
+    )
+    return _to_session_response(session)
+
+
+@router.put(
+    "/ai/evidence-uploads/sessions/{session_id}/chunks/{chunk_index}",
+    response_model=ChunkUploadResponse,
+)
+async def upload_chunk(
+    session_id: Annotated[str, Path(min_length=1)],
+    chunk_index: Annotated[int, Path(ge=0)],
+    chunk: Annotated[UploadFile, File(description="Raw bytes for this chunk")],
+    x_user_id: str = Header(default="", alias="X-User-Id"),
+):
+    """Upload a single chunk for an existing session."""
+    data = await chunk.read()
+    try:
+        session = upload_session_service.save_chunk(
+            session_id=session_id,
+            owner_id=x_user_id,
+            chunk_index=chunk_index,
+            data=data,
+        )
+    except UploadSessionError as exc:
+        raise _http_error(exc)
+
+    received = UploadSessionService.received_chunks_sorted(session)
+    return ChunkUploadResponse(
+        session_id=session.session_id,
+        chunk_index=chunk_index,
+        received_chunks=received,
+        remaining_chunks=session.total_chunks - len(received),
+        status="completed" if session.completed else "in_progress",
+    )
+
+
+@router.get(
+    "/ai/evidence-uploads/sessions/{session_id}",
+    response_model=UploadSessionResponse,
+)
+async def get_upload_session(
+    session_id: Annotated[str, Path(min_length=1)],
+    x_user_id: str = Header(default="", alias="X-User-Id"),
+):
+    """Return the current state of an upload session (for resuming)."""
+    try:
+        session = upload_session_service.get_session(session_id, x_user_id)
+    except UploadSessionError as exc:
+        raise _http_error(exc)
+    return _to_session_response(session)
+
+
+@router.post(
+    "/ai/evidence-uploads/sessions/{session_id}/finalize",
+    response_model=FinalizeUploadResponse,
+)
+async def finalize_upload_session(
+    session_id: Annotated[str, Path(min_length=1)],
+    x_user_id: str = Header(default="", alias="X-User-Id"),
+):
+    """Validate all chunks and ownership, then assemble the final file."""
+    try:
+        session = upload_session_service.finalize(session_id, x_user_id)
+    except UploadSessionError as exc:
+        raise _http_error(exc)
+
+    logger.info(
+        "evidence_upload_finalized",
+        extra={
+            "event": "evidence_upload_finalized",
+            "session_id": session.session_id,
+            "artifact_id": session.artifact_id,
+        },
+    )
+    return FinalizeUploadResponse(
+        session_id=session.session_id,
+        artifact_id=session.artifact_id or "",
+        filename=session.filename,
+        content_type=session.content_type,
+        total_size=session.total_size,
+        status="completed",
+    )

--- a/app/ai-service/schemas/uploads.py
+++ b/app/ai-service/schemas/uploads.py
@@ -1,0 +1,52 @@
+"""
+Pydantic schemas for resumable evidence upload sessions.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CreateUploadSessionRequest(BaseModel):
+    """Request body for starting a new resumable upload session."""
+
+    filename: str = Field(..., min_length=1, max_length=255)
+    content_type: str = Field(..., min_length=1)
+    total_size: int = Field(..., gt=0, description="Total file size in bytes")
+    total_chunks: int = Field(..., gt=0, description="Number of chunks to be sent")
+
+
+class UploadSessionResponse(BaseModel):
+    """Current state of an upload session."""
+
+    session_id: str
+    filename: str
+    content_type: str
+    total_size: int
+    total_chunks: int
+    received_chunks: List[int]
+    status: str
+    expires_at: float
+    completed: bool = False
+    artifact_id: Optional[str] = None
+
+
+class ChunkUploadResponse(BaseModel):
+    """Result of uploading a single chunk."""
+
+    session_id: str
+    chunk_index: int
+    received_chunks: List[int]
+    remaining_chunks: int
+    status: str
+
+
+class FinalizeUploadResponse(BaseModel):
+    """Result of finalizing an assembled upload."""
+
+    session_id: str
+    artifact_id: str
+    filename: str
+    content_type: str
+    total_size: int
+    status: str

--- a/app/ai-service/services/upload_sessions.py
+++ b/app/ai-service/services/upload_sessions.py
@@ -1,0 +1,212 @@
+"""
+Resumable evidence upload session management.
+
+Supports creating upload sessions, receiving file chunks in any order,
+tracking session state and expiry, and validating content type, size,
+and ownership before assembling the final artifact.
+
+Chunks are persisted to disk per session so that an interrupted upload
+can resume from the last successfully received chunk instead of
+restarting from zero.
+"""
+
+import os
+import shutil
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+class UploadSessionError(Exception):
+    """Raised when an upload session operation fails.
+
+    ``code`` is a stable, machine-readable identifier that the API layer
+    maps to an HTTP status code.
+    """
+
+    def __init__(self, code: str, message: Optional[str] = None) -> None:
+        self.code = code
+        self.message = message or code
+        super().__init__(self.code)
+
+
+@dataclass
+class UploadSession:
+    """In-memory record describing a single resumable upload."""
+
+    session_id: str
+    owner_id: str
+    filename: str
+    content_type: str
+    total_size: int
+    total_chunks: int
+    created_at: float
+    expires_at: float
+    received_chunks: Set[int] = field(default_factory=set)
+    received_bytes: int = 0
+    completed: bool = False
+    artifact_id: Optional[str] = None
+
+
+class UploadSessionService:
+    """Manages resumable upload sessions and their on-disk chunks."""
+
+    def __init__(
+        self,
+        storage_dir: str,
+        allowed_content_types: Set[str],
+        max_upload_bytes: int,
+        session_ttl_seconds: int,
+    ) -> None:
+        self.storage_dir = storage_dir
+        self.allowed_content_types = set(allowed_content_types)
+        self.max_upload_bytes = max_upload_bytes
+        self.session_ttl_seconds = session_ttl_seconds
+        self._sessions: Dict[str, UploadSession] = {}
+        self._lock = threading.Lock()
+        os.makedirs(self.storage_dir, exist_ok=True)
+
+    # -- internal helpers ----------------------------------------------------
+
+    def _session_dir(self, session_id: str) -> str:
+        return os.path.join(self.storage_dir, "sessions", session_id)
+
+    def _chunk_path(self, session_id: str, index: int) -> str:
+        return os.path.join(self._session_dir(session_id), f"chunk_{index:06d}.part")
+
+    def _is_expired(self, session: UploadSession) -> bool:
+        return time.time() > session.expires_at
+
+    def _purge(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+        session_dir = self._session_dir(session_id)
+        if os.path.isdir(session_dir):
+            shutil.rmtree(session_dir, ignore_errors=True)
+
+    def _require_active_session(self, session_id: str, owner_id: str) -> UploadSession:
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise UploadSessionError("session_not_found")
+        if self._is_expired(session):
+            self._purge(session_id)
+            raise UploadSessionError("session_expired")
+        if not owner_id or session.owner_id != owner_id:
+            raise UploadSessionError("forbidden_owner")
+        return session
+
+    def _recalculate_received_bytes(self, session: UploadSession) -> int:
+        total = 0
+        for index in session.received_chunks:
+            path = self._chunk_path(session.session_id, index)
+            if os.path.exists(path):
+                total += os.path.getsize(path)
+        return total
+
+    # -- public API ----------------------------------------------------------
+
+    def create_session(
+        self,
+        owner_id: str,
+        filename: str,
+        content_type: str,
+        total_size: int,
+        total_chunks: int,
+    ) -> UploadSession:
+        if not owner_id:
+            raise UploadSessionError("missing_owner")
+        if content_type not in self.allowed_content_types:
+            raise UploadSessionError("invalid_content_type")
+        if total_size <= 0 or total_chunks <= 0:
+            raise UploadSessionError("invalid_request")
+        if total_size > self.max_upload_bytes:
+            raise UploadSessionError("file_too_large")
+
+        session_id = uuid.uuid4().hex
+        now = time.time()
+        session = UploadSession(
+            session_id=session_id,
+            owner_id=owner_id,
+            filename=filename,
+            content_type=content_type,
+            total_size=total_size,
+            total_chunks=total_chunks,
+            created_at=now,
+            expires_at=now + self.session_ttl_seconds,
+        )
+        with self._lock:
+            self._sessions[session_id] = session
+            os.makedirs(self._session_dir(session_id), exist_ok=True)
+        return session
+
+    def get_session(self, session_id: str, owner_id: str) -> UploadSession:
+        with self._lock:
+            return self._require_active_session(session_id, owner_id)
+
+    def save_chunk(
+        self,
+        session_id: str,
+        owner_id: str,
+        chunk_index: int,
+        data: bytes,
+    ) -> UploadSession:
+        with self._lock:
+            session = self._require_active_session(session_id, owner_id)
+            if session.completed:
+                raise UploadSessionError("session_already_finalized")
+            if chunk_index < 0 or chunk_index >= session.total_chunks:
+                raise UploadSessionError("invalid_chunk_index")
+            if not data:
+                raise UploadSessionError("empty_chunk")
+
+            chunk_path = self._chunk_path(session_id, chunk_index)
+            with open(chunk_path, "wb") as handle:
+                handle.write(data)
+            session.received_chunks.add(chunk_index)
+            session.received_bytes = self._recalculate_received_bytes(session)
+
+            if session.received_bytes > self.max_upload_bytes:
+                # Roll back the chunk that pushed us over the limit.
+                os.remove(chunk_path)
+                session.received_chunks.discard(chunk_index)
+                session.received_bytes = self._recalculate_received_bytes(session)
+                raise UploadSessionError("file_too_large")
+
+            return session
+
+    def finalize(self, session_id: str, owner_id: str) -> UploadSession:
+        with self._lock:
+            session = self._require_active_session(session_id, owner_id)
+            if session.completed:
+                return session
+
+            missing = [
+                index
+                for index in range(session.total_chunks)
+                if index not in session.received_chunks
+            ]
+            if missing:
+                raise UploadSessionError("incomplete_upload")
+
+            if session.received_bytes != session.total_size:
+                raise UploadSessionError("size_mismatch")
+
+            safe_name = os.path.basename(session.filename) or "artifact"
+            artifact_id = uuid.uuid4().hex
+            artifact_path = os.path.join(
+                self.storage_dir, f"{artifact_id}_{safe_name}"
+            )
+            with open(artifact_path, "wb") as output:
+                for index in range(session.total_chunks):
+                    with open(self._chunk_path(session_id, index), "rb") as part:
+                        shutil.copyfileobj(part, output)
+
+            session.completed = True
+            session.artifact_id = artifact_id
+            shutil.rmtree(self._session_dir(session_id), ignore_errors=True)
+            return session
+
+    @staticmethod
+    def received_chunks_sorted(session: UploadSession) -> List[int]:
+        return sorted(session.received_chunks)

--- a/app/ai-service/tests/test_upload_sessions.py
+++ b/app/ai-service/tests/test_upload_sessions.py
@@ -1,0 +1,111 @@
+"""
+Tests for the resumable evidence upload session service.
+"""
+
+import os
+
+import pytest
+
+from services.upload_sessions import UploadSessionError, UploadSessionService
+
+ALLOWED_TYPES = {"image/png", "application/pdf"}
+
+
+def _make_service(tmp_path, ttl_seconds=3600, max_bytes=1024):
+    return UploadSessionService(
+        storage_dir=str(tmp_path / "uploads"),
+        allowed_content_types=ALLOWED_TYPES,
+        max_upload_bytes=max_bytes,
+        session_ttl_seconds=ttl_seconds,
+    )
+
+
+def test_create_upload_and_finalize_in_order(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session(
+        owner_id="user-1",
+        filename="evidence.png",
+        content_type="image/png",
+        total_size=6,
+        total_chunks=3,
+    )
+
+    # Upload out of order to prove the service reassembles by index.
+    service.save_chunk(session.session_id, "user-1", 2, b"cc")
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    service.save_chunk(session.session_id, "user-1", 1, b"bb")
+
+    finalized = service.finalize(session.session_id, "user-1")
+    assert finalized.completed is True
+    assert finalized.artifact_id
+
+    artifact_path = os.path.join(
+        service.storage_dir, f"{finalized.artifact_id}_evidence.png"
+    )
+    with open(artifact_path, "rb") as handle:
+        assert handle.read() == b"aabbcc"
+
+
+def test_finalize_requires_all_chunks_then_resumes(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 4, 2)
+
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.finalize(session.session_id, "user-1")
+    assert exc_info.value.code == "incomplete_upload"
+
+    # Resume by sending the missing chunk, then finalize succeeds.
+    service.save_chunk(session.session_id, "user-1", 1, b"bb")
+    finalized = service.finalize(session.session_id, "user-1")
+    assert finalized.completed is True
+
+
+def test_rejects_invalid_content_type(tmp_path):
+    service = _make_service(tmp_path)
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.create_session(
+            "user-1", "bad.exe", "application/x-msdownload", 4, 1
+        )
+    assert exc_info.value.code == "invalid_content_type"
+
+
+def test_rejects_file_larger_than_limit(tmp_path):
+    service = _make_service(tmp_path, max_bytes=10)
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.create_session("user-1", "e.png", "image/png", 50, 1)
+    assert exc_info.value.code == "file_too_large"
+
+
+def test_enforces_size_limit_across_chunks(tmp_path):
+    service = _make_service(tmp_path, max_bytes=3)
+    session = service.create_session("user-1", "e.png", "image/png", 3, 2)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.save_chunk(session.session_id, "user-1", 1, b"bb")
+    assert exc_info.value.code == "file_too_large"
+
+
+def test_enforces_ownership(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.save_chunk(session.session_id, "intruder", 0, b"aa")
+    assert exc_info.value.code == "forbidden_owner"
+
+
+def test_expired_session_is_rejected(tmp_path):
+    service = _make_service(tmp_path, ttl_seconds=-1)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.get_session(session.session_id, "user-1")
+    assert exc_info.value.code == "session_expired"
+
+
+def test_finalize_detects_size_mismatch(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 10, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    with pytest.raises(UploadSessionError) as exc_info:
+        service.finalize(session.session_id, "user-1")
+    assert exc_info.value.code == "size_mismatch"


### PR DESCRIPTION
## What this adds

Support for uploading verification-evidence files in chunks, so a large upload can resume from the last received chunk instead of starting over if the connection drops.

New endpoints under `/v1`:

- `POST /ai/evidence-uploads/sessions` — start a session (validates content type and size up front)
- `PUT /ai/evidence-uploads/sessions/{session_id}/chunks/{chunk_index}` — upload a chunk (any order)
- `GET /ai/evidence-uploads/sessions/{session_id}` — check progress and which chunks are still missing (used to resume)
- `POST /ai/evidence-uploads/sessions/{session_id}/finalize` — assemble the final file once every chunk is in

## How it works

- Chunks are written to disk per session, so an interrupted upload can pick up where it left off.
- Ownership is enforced with the `X-User-Id` header, following the same pattern as the existing artifacts routes.
- Sessions expire after a configurable TTL, and total size is checked both when the session is created and as chunks arrive (with rollback if a chunk pushes it over the limit).
- Configurable via env vars: `EVIDENCE_UPLOAD_DIR`, `EVIDENCE_MAX_UPLOAD_BYTES` (default 50MB), `EVIDENCE_UPLOAD_SESSION_TTL_SECONDS` (default 1h).

## Testing

- Added `tests/test_upload_sessions.py` (8 tests): in-order and out-of-order assembly, resume after a missing chunk, invalid content type, size limits at creation and across chunks, ownership, expiry, and size mismatch.
- Full suite passes locally: `194 passed`.

Closes #254