### PR TITLE
Add async OCR job queue

### DIFF
--- a/app/ai-service/api/v1/inference.py
+++ b/app/ai-service/api/v1/inference.py
@@ -75,6 +75,22 @@ async def get_task_status(task_id: str):
     Poll this endpoint after creating a task.  Possible status values:
     ``pending``, ``processing``, ``completed``, ``failed``.
     """
+    return await _get_task_status(task_id)
+
+
+@router.get("/ai/jobs/{task_id}", response_model=TaskStatusResponse)
+async def get_job_status(task_id: str):
+    """
+    Get the current status of a queued AI job.
+
+    This is the canonical poll endpoint for backend clients.  Possible
+    status values: ``pending``, ``processing``, ``retrying``, ``completed``,
+    ``failed``, ``cancelled``.
+    """
+    return await _get_task_status(task_id)
+
+
+async def _get_task_status(task_id: str):
     logger.info(f"Checking status for task: {task_id}")
 
     try:

--- a/app/ai-service/api/v1/ocr.py
+++ b/app/ai-service/api/v1/ocr.py
@@ -5,17 +5,19 @@ Extracted from the legacy flat router so the route logic lives in a
 single place and is referenced by both the /v1 and the legacy /ai mounts.
 """
 
+import base64
 import io
 import time
 from typing import Annotated, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-import metrics
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile, status
+from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-from schemas.ocr import OCRData, OCRFieldResult, OCRResponse
-from services.ocr import OCRService
+import tasks
+from schemas.ocr import OCRResponse
+from services.ocr_job import run_ocr_from_bytes
 from config import settings
 
 router = APIRouter(tags=["ocr"])
@@ -30,7 +32,12 @@ ALLOWED_CONTENT_TYPES = {
     "image/webp",
 }
 
-ocr_service = OCRService()
+class QueuedOCRResponse(BaseModel):
+    success: bool
+    task_id: str
+    status: str
+    message: str
+    status_url: str
 
 
 @router.post("/ai/ocr")
@@ -67,49 +74,10 @@ async def process_ocr(
                 },
             )
 
-        from PIL import Image
+        _validate_image_bytes(contents)
+        result = run_ocr_from_bytes(contents, anchor_metadata)
 
-        try:
-            img = Image.open(io.BytesIO(contents))
-        except Exception as e:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "code": "invalid_image",
-                    "message": f"Could not decode image: {str(e)}",
-                },
-            )
-
-        start_inference = time.time()
-        result = ocr_service.process_image(img)
-        inference_latency = time.time() - start_inference
-
-        metrics.INFERENCE_LATENCY.labels(task_type="ocr").observe(inference_latency)
-        metrics.logger.info(f"OCR Inference completed in {inference_latency:.4f}s")
-
-        processing_time_ms = int((time.time() - start_time) * 1000)
-
-        parsed_metadata = None
-        if anchor_metadata:
-            try:
-                from schemas.common import AnchorMetadata
-                parsed_metadata = AnchorMetadata.model_validate_json(anchor_metadata)
-            except Exception:
-                pass
-
-        return OCRResponse(
-            success=True,
-            data=OCRData(
-                fields={
-                    name: OCRFieldResult(value=field.value, confidence=field.confidence)
-                    for name, field in result.fields.items()
-                },
-                raw_text=result.raw_text,
-                processing_time_ms=processing_time_ms,
-            ),
-            processing_time_ms=processing_time_ms,
-            anchor_metadata=parsed_metadata,
-        )
+        return OCRResponse(**result)
 
     except HTTPException:
         raise
@@ -123,4 +91,74 @@ async def process_ocr(
             },
             processing_time_ms=processing_time_ms,
             anchor_metadata=None, # Cannot easily re-parse here without duplicating, so omit or ignore
+        )
+
+
+@router.post(
+    "/ai/ocr/jobs",
+    response_model=QueuedOCRResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+@limiter.limit(settings.request_rate_limit)
+async def queue_ocr_job(
+    request: Request,
+    image: Annotated[UploadFile, File(description="Image file to process")],
+    anchor_metadata: Annotated[Optional[str], Form(description="JSON encoded AnchorMetadata")] = None,
+) -> QueuedOCRResponse:
+    """Queue OCR processing and return immediately with a pollable job URL."""
+    if image.content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_content_type",
+                "message": (
+                    f"Invalid content type: {image.content_type}. "
+                    f"Allowed: {', '.join(ALLOWED_CONTENT_TYPES)}"
+                ),
+            },
+        )
+
+    contents = await image.read()
+    if len(contents) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "empty_image",
+                "message": "Uploaded image is empty",
+            },
+        )
+
+    _validate_image_bytes(contents)
+
+    task_id = tasks.create_task(
+        task_type="ocr",
+        payload={
+            "image_base64": base64.b64encode(contents).decode("ascii"),
+            "content_type": image.content_type,
+            "filename": image.filename,
+            "anchor_metadata": anchor_metadata,
+        },
+    )
+
+    return QueuedOCRResponse(
+        success=True,
+        task_id=task_id,
+        status="pending",
+        message="OCR job queued for processing",
+        status_url=f"/v1/ai/jobs/{task_id}",
+    )
+
+
+def _validate_image_bytes(contents: bytes) -> None:
+    from PIL import Image
+
+    try:
+        Image.open(io.BytesIO(contents)).verify()
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_image",
+                "message": f"Could not decode image: {str(e)}",
+            },
         )

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -59,6 +59,8 @@ class Settings(BaseSettings):
 
     # Redis and Celery settings
     redis_url: str = "redis://localhost:6379/0"
+    task_max_retries: int = 3
+    task_retry_delay_seconds: int = 30
 
     # Backend webhook URL for notifications
     backend_webhook_url: Optional[str] = "http://localhost:3001/ai/webhook"

--- a/app/ai-service/main.py
+++ b/app/ai-service/main.py
@@ -97,6 +97,7 @@ _LEGACY_TO_V1: dict = {
 # Prefix-based redirects for parameterised routes (matched in order).
 _LEGACY_PREFIX_MAP: list = [
     ("/ai/status/", "/v1/ai/status/"),
+    ("/ai/jobs/", "/v1/ai/jobs/"),
     ("/ai/task/", "/v1/ai/task/"),
 ]
 

--- a/app/ai-service/services/ocr_job.py
+++ b/app/ai-service/services/ocr_job.py
@@ -1,0 +1,66 @@
+import base64
+import io
+import time
+from typing import Optional
+
+from PIL import Image
+
+import metrics
+from schemas.common import AnchorMetadata
+from schemas.ocr import OCRData, OCRFieldResult
+from services.ocr import OCRService
+
+
+ocr_service = OCRService()
+
+
+def run_ocr_from_bytes(
+    contents: bytes,
+    anchor_metadata: Optional[str] = None,
+) -> dict:
+    start_time = time.time()
+    img = Image.open(io.BytesIO(contents))
+
+    start_inference = time.time()
+    result = ocr_service.process_image(img)
+    inference_latency = time.time() - start_inference
+
+    metrics.INFERENCE_LATENCY.labels(task_type="ocr").observe(inference_latency)
+    metrics.logger.info(f"OCR Inference completed in {inference_latency:.4f}s")
+
+    processing_time_ms = int((time.time() - start_time) * 1000)
+    parsed_metadata = _parse_anchor_metadata(anchor_metadata)
+
+    response = {
+        "success": True,
+        "data": OCRData(
+            fields={
+                name: OCRFieldResult(value=field.value, confidence=field.confidence)
+                for name, field in result.fields.items()
+            },
+            raw_text=result.raw_text,
+            processing_time_ms=processing_time_ms,
+        ).model_dump(),
+        "processing_time_ms": processing_time_ms,
+        "anchor_metadata": (
+            parsed_metadata.model_dump() if parsed_metadata is not None else None
+        ),
+    }
+    return response
+
+
+def run_ocr_from_base64(
+    image_base64: str,
+    anchor_metadata: Optional[str] = None,
+) -> dict:
+    return run_ocr_from_bytes(base64.b64decode(image_base64), anchor_metadata)
+
+
+def _parse_anchor_metadata(anchor_metadata: Optional[str]) -> Optional[AnchorMetadata]:
+    if not anchor_metadata:
+        return None
+
+    try:
+        return AnchorMetadata.model_validate_json(anchor_metadata)
+    except Exception:
+        return None

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -15,6 +15,7 @@ import metrics
 from config import settings
 from services.pii_scrubber import PIIScrubberService
 from services.humanitarian_verification import HumanitarianVerificationService
+from services.ocr_job import run_ocr_from_base64
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -48,6 +49,8 @@ def get_celery_app() -> Celery:
                 task_time_limit=3600,  # 1 hour max
                 task_soft_time_limit=1800,  # 30 minutes soft limit
                 result_expires=86400,  # Results expire after 24 hours
+                task_acks_late=True,
+                task_reject_on_worker_lost=True,
             )
         except Exception as e:
             logger.warning(f"Failed to initialize Celery: {e}. Task processing disabled.")
@@ -64,9 +67,33 @@ def get_process_heavy_inference_task():
     """
     app = get_celery_app()
     # Define and register the task with the app
-    @app.task(bind=True, name='process_heavy_inference')
+    @app.task(
+        bind=True,
+        name='process_heavy_inference',
+        max_retries=settings.task_max_retries,
+        default_retry_delay=settings.task_retry_delay_seconds,
+    )
     def process_heavy_inference_task(self, task_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        return process_heavy_inference_impl(self, task_id, payload)
+        try:
+            return process_heavy_inference_impl(self, task_id, payload)
+        except Exception as exc:
+            if self.request.retries < settings.task_max_retries:
+                retry_delay = settings.task_retry_delay_seconds * (2 ** self.request.retries)
+                logger.warning(
+                    "Retrying task %s after failure %s/%s in %ss: %s",
+                    task_id,
+                    self.request.retries + 1,
+                    settings.task_max_retries,
+                    retry_delay,
+                    exc,
+                )
+                update_task_status(task_id, 'retrying', error=str(exc))
+                raise self.retry(exc=exc, countdown=retry_delay)
+
+            error_msg = str(exc)
+            update_task_status(task_id, 'failed', error=error_msg)
+            send_webhook_notification(task_id, 'failed', error=error_msg)
+            raise
     
     return process_heavy_inference_task
 
@@ -174,7 +201,9 @@ def process_heavy_inference_impl(self, task_id: str, payload: Dict[str, Any]) ->
         # - Complex model inference
         # - Batch processing
         
-        if task_type == 'image_analysis':
+        if task_type == 'ocr':
+            result = _process_ocr(payload)
+        elif task_type == 'image_analysis':
             result = _process_image_analysis(payload)
         elif task_type == 'model_inference':
             result = _process_model_inference(payload)
@@ -199,15 +228,23 @@ def process_heavy_inference_impl(self, task_id: str, payload: Dict[str, Any]) ->
         
     except Exception as e:
         logger.error(f"Task {task_id} failed: {str(e)}", exc_info=True)
-        error_msg = str(e)
-        
-        # Update status to failed
-        update_task_status(task_id, 'failed', error=error_msg)
-        
-        # Send webhook notification to backend
-        send_webhook_notification(task_id, 'failed', error=error_msg)
-        
         raise
+
+
+def _process_ocr(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Process an OCR task from base64-encoded image bytes."""
+    image_base64 = payload.get('image_base64')
+    if not image_base64:
+        raise ValueError("'image_base64' is required for ocr tasks")
+
+    return {
+        'type': 'ocr',
+        'status': 'success',
+        'result': run_ocr_from_base64(
+            image_base64,
+            payload.get('anchor_metadata'),
+        ),
+    }
 
 
 def _process_image_analysis(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -358,6 +395,13 @@ def get_task_status(task_id: str) -> Dict[str, Any]:
     Returns:
         dict: Task status information
     """
+    local_status = task_results.get(task_id)
+    if local_status and local_status.get('status') in {'completed', 'failed', 'retrying', 'cancelled'}:
+        return {
+            'task_id': task_id,
+            **local_status,
+        }
+
     # Try to get from Celery result backend first
     try:
         celery_result = AsyncResult(task_id, app=get_celery_app())
@@ -382,10 +426,10 @@ def get_task_status(task_id: str) -> Dict[str, Any]:
         pass
     
     # Fall back to local storage
-    if task_id in task_results:
+    if local_status:
         return {
             'task_id': task_id,
-            **task_results[task_id]
+            **local_status
         }
     
     return {

--- a/app/ai-service/tests/test_async_ocr_jobs.py
+++ b/app/ai-service/tests/test_async_ocr_jobs.py
@@ -1,0 +1,94 @@
+import io
+from unittest.mock import MagicMock, patch
+
+import metrics
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+import main
+import tasks
+from config import settings
+
+
+@pytest.fixture(autouse=True)
+def mock_healthy_resources():
+    with patch.object(metrics, "check_system_resources", return_value=True):
+        yield
+
+
+@pytest.fixture()
+def client():
+    return TestClient(main.app, follow_redirects=False)
+
+
+def _png_bytes() -> bytes:
+    img = Image.new("RGB", (32, 32), color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_queue_ocr_job_returns_accepted_with_status_url(client, monkeypatch):
+    captured = {}
+
+    def fake_create_task(task_type, payload):
+        captured["task_type"] = task_type
+        captured["payload"] = payload
+        return "ocr-task-123"
+
+    monkeypatch.setattr(tasks, "create_task", fake_create_task)
+
+    response = client.post(
+        "/v1/ai/ocr/jobs",
+        files={"image": ("document.png", _png_bytes(), "image/png")},
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["success"] is True
+    assert data["task_id"] == "ocr-task-123"
+    assert data["status"] == "pending"
+    assert data["status_url"] == "/v1/ai/jobs/ocr-task-123"
+    assert captured["task_type"] == "ocr"
+    assert captured["payload"]["image_base64"]
+    assert captured["payload"]["content_type"] == "image/png"
+
+
+def test_queued_ocr_job_rejects_invalid_image(client, monkeypatch):
+    create_task = MagicMock()
+    monkeypatch.setattr(tasks, "create_task", create_task)
+
+    response = client.post(
+        "/v1/ai/ocr/jobs",
+        files={"image": ("document.png", b"not-a-real-image", "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["message"].startswith("{'code': 'invalid_image'")
+    create_task.assert_not_called()
+
+
+def test_task_status_endpoint_returns_local_job_status(client):
+    tasks.update_task_status(
+        "ocr-task-complete",
+        "completed",
+        result={"type": "ocr", "result": {"success": True}},
+    )
+
+    response = client.get("/v1/ai/jobs/ocr-task-complete")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["task_id"] == "ocr-task-complete"
+    assert data["status"] == "completed"
+    assert data["result"]["type"] == "ocr"
+
+
+def test_retry_policy_is_defined_on_heavy_task():
+    task = tasks.get_process_heavy_inference_task()
+
+    assert task.max_retries == settings.task_max_retries
+    assert task.default_retry_delay == settings.task_retry_delay_seconds
+    assert tasks.get_celery_app().conf.task_acks_late is True
+    assert tasks.get_celery_app().conf.task_reject_on_worker_lost is True


### PR DESCRIPTION
## Overview
This PR moves heavy OCR processing onto the existing AI service task queue so clients can submit OCR work quickly and poll job status from the backend.

## Related Issue
Closes #617

## Changes

### Async OCR Job Queue
- Added POST /v1/ai/ocr/jobs to validate uploads, enqueue OCR work, and return 202 Accepted with a task ID.
- Reused the existing synchronous OCR response shape from the queued worker result.
- Kept the existing /v1/ai/ocr endpoint intact for backward compatibility.

### Job Status API
- Added GET /v1/ai/jobs/{task_id} as the canonical backend polling endpoint.
- Kept the existing /v1/ai/status/{task_id} route as a compatibility alias.
- Added legacy redirect support for /ai/jobs/{task_id}.

### Retry Policy
- Defined Celery retry settings using TASK_MAX_RETRIES and TASK_RETRY_DELAY_SECONDS defaults.
- Added exponential retry delay and a etrying task state before final failure.
- Enabled late acknowledgements and worker-lost rejection for safer retry behavior.

### Tests
- Added coverage for OCR job queue submission, invalid image rejection, status polling, and retry policy configuration.

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Job status endpoint exists | Completed |
| Retry policy defined for failed jobs | Completed |
| OCR jobs return quickly with a poll URL | Completed |
| Focused async OCR tests added | Completed |
| git diff --check | Passed |
| Pytest execution | Not run locally: Python launcher is unavailable in this environment |