### PR TITLE
testnet contract

### DIFF
--- a/app/backend/src/campaigns/campaigns.service.spec.ts
+++ b/app/backend/src/campaigns/campaigns.service.spec.ts
@@ -50,7 +50,7 @@ describe('CampaignsService', () => {
     });
 
     const createArgs = prismaMock.campaign.create.mock.calls[0]?.[0];
-    
+
     // Clean match validation instead of strict object equivalence structures
     expect(createArgs).toMatchObject({
       data: {

--- a/app/backend/src/common/budget/budget.service.spec.ts
+++ b/app/backend/src/common/budget/budget.service.spec.ts
@@ -55,4 +55,3 @@ describe('BudgetService', () => {
     );
   });
 });
-

--- a/app/backend/src/common/guards/adaptive-rate-limit.guard.ts
+++ b/app/backend/src/common/guards/adaptive-rate-limit.guard.ts
@@ -8,6 +8,12 @@ import {
 import { RedisService } from '@liaoliaots/nestjs-redis';
 import { Request } from 'express';
 
+interface RateLimitUser {
+  id?: string;
+  apiKeyId?: string;
+  authType?: 'apiKey' | 'envApiKey';
+}
+
 @Injectable()
 export class AdaptiveRateLimitGuard implements CanActivate {
   private readonly limits = {
@@ -20,7 +26,7 @@ export class AdaptiveRateLimitGuard implements CanActivate {
   constructor(private readonly redisService: RedisService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest<Request>();
+    const request: Request = context.switchToHttp().getRequest<Request>();
     const client = this.redisService.getOrThrow();
 
     const strategy = this.getStrategy(request);
@@ -50,10 +56,13 @@ export class AdaptiveRateLimitGuard implements CanActivate {
   }
 
   private getStrategy(request: Request): keyof typeof this.limits {
-    const path: string = request.path ?? request.url ?? '';
+    const path: string =
+      (request.path as string | undefined) ??
+      (request.url as string | undefined) ??
+      '';
     if (path.includes('/search')) return 'search';
 
-    const user = request.user;
+    const user = request.user as RateLimitUser | undefined;
     if (user) {
       if (user.authType === 'apiKey' || user.authType === 'envApiKey') {
         return 'apiKey';
@@ -65,12 +74,12 @@ export class AdaptiveRateLimitGuard implements CanActivate {
   }
 
   private getIdentifier(request: Request): string {
-    const user = request.user;
+    const user = request.user as RateLimitUser | undefined;
     if (user?.id) return user.id;
     if (user?.apiKeyId) return user.apiKeyId;
 
-    const ips = request.ips;
-    const forwardedIp =
+    const ips: string[] = request.ips;
+    const forwardedIp: string | undefined =
       Array.isArray(ips) && ips.length > 0 ? ips[0] : undefined;
     return forwardedIp ?? request.ip ?? 'anonymous';
   }

--- a/app/backend/src/common/guards/adaptive-rate-limit.guard.ts
+++ b/app/backend/src/common/guards/adaptive-rate-limit.guard.ts
@@ -20,7 +20,7 @@ export class AdaptiveRateLimitGuard implements CanActivate {
   constructor(private readonly redisService: RedisService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest<any>();
+    const request = context.switchToHttp().getRequest<Request>();
     const client = this.redisService.getOrThrow();
 
     const strategy = this.getStrategy(request);
@@ -49,8 +49,8 @@ export class AdaptiveRateLimitGuard implements CanActivate {
     return true;
   }
 
-  private getStrategy(request: any): keyof typeof this.limits {
-    const path = request.path ?? request.url ?? '';
+  private getStrategy(request: Request): keyof typeof this.limits {
+    const path: string = request.path ?? request.url ?? '';
     if (path.includes('/search')) return 'search';
 
     const user = request.user;
@@ -64,15 +64,14 @@ export class AdaptiveRateLimitGuard implements CanActivate {
     return 'public';
   }
 
-  private getIdentifier(request: any): string {
+  private getIdentifier(request: Request): string {
     const user = request.user;
     if (user?.id) return user.id;
     if (user?.apiKeyId) return user.apiKeyId;
 
+    const ips = request.ips;
     const forwardedIp =
-      Array.isArray(request.ips) && request.ips.length > 0
-        ? request.ips[0]
-        : undefined;
+      Array.isArray(ips) && ips.length > 0 ? ips[0] : undefined;
     return forwardedIp ?? request.ip ?? 'anonymous';
   }
 }

--- a/app/backend/src/common/utils/explorer-url.util.spec.ts
+++ b/app/backend/src/common/utils/explorer-url.util.spec.ts
@@ -1,0 +1,82 @@
+import {
+  explorerBase,
+  explorerTxUrl,
+  explorerContractUrl,
+} from './explorer-url.util';
+
+describe('explorer-url.util', () => {
+  describe('explorerBase', () => {
+    it('returns mainnet URL for mainnet', () => {
+      expect(explorerBase('mainnet')).toBe(
+        'https://stellar.expert/explorer/public',
+      );
+    });
+
+    it('returns testnet URL for testnet', () => {
+      expect(explorerBase('testnet')).toBe(
+        'https://stellar.expert/explorer/testnet',
+      );
+    });
+
+    it('returns futurenet URL for futurenet', () => {
+      expect(explorerBase('futurenet')).toBe(
+        'https://stellar.expert/explorer/futurenet',
+      );
+    });
+
+    it('defaults to testnet for unknown network', () => {
+      expect(explorerBase('unknown')).toBe(
+        'https://stellar.expert/explorer/testnet',
+      );
+    });
+
+    it('is case-insensitive', () => {
+      expect(explorerBase('Mainnet')).toBe(
+        'https://stellar.expert/explorer/public',
+      );
+      expect(explorerBase('TESTNET')).toBe(
+        'https://stellar.expert/explorer/testnet',
+      );
+    });
+  });
+
+  describe('explorerTxUrl', () => {
+    it('builds a testnet tx URL', () => {
+      expect(explorerTxUrl('ABCD1234', 'testnet')).toBe(
+        'https://stellar.expert/explorer/testnet/tx/ABCD1234',
+      );
+    });
+
+    it('builds a mainnet tx URL', () => {
+      expect(explorerTxUrl('ABCD1234', 'mainnet')).toBe(
+        'https://stellar.expert/explorer/public/tx/ABCD1234',
+      );
+    });
+
+    it('defaults to testnet for unknown network', () => {
+      expect(explorerTxUrl('ABCD1234', 'staging')).toBe(
+        'https://stellar.expert/explorer/testnet/tx/ABCD1234',
+      );
+    });
+  });
+
+  describe('explorerContractUrl', () => {
+    it('builds a testnet contract URL', () => {
+      expect(explorerContractUrl('CABC123', 'testnet')).toBe(
+        'https://stellar.expert/explorer/testnet/contract/CABC123',
+      );
+    });
+
+    it('builds a mainnet contract URL', () => {
+      expect(explorerContractUrl('CABC123', 'mainnet')).toBe(
+        'https://stellar.expert/explorer/public/contract/CABC123',
+      );
+    });
+
+    it('defaults to testnet for unknown network', () => {
+      expect(explorerContractUrl('CABC123', 'unknown')).toBe(
+        'https://stellar.expert/explorer/testnet/contract/CABC123',
+      );
+    });
+  });
+});

--- a/app/backend/src/common/utils/explorer-url.util.ts
+++ b/app/backend/src/common/utils/explorer-url.util.ts
@@ -1,0 +1,20 @@
+const EXPLORER_BASE: Record<string, string> = {
+  mainnet: 'https://stellar.expert/explorer/public',
+  testnet: 'https://stellar.expert/explorer/testnet',
+  futurenet: 'https://stellar.expert/explorer/futurenet',
+};
+
+/** Returns the explorer base URL for the given network, defaulting to testnet. */
+export function explorerBase(network: string): string {
+  return EXPLORER_BASE[network.toLowerCase()] ?? EXPLORER_BASE['testnet'];
+}
+
+/** Returns a link to a transaction on stellar.expert. */
+export function explorerTxUrl(txHash: string, network: string): string {
+  return `${explorerBase(network)}/tx/${txHash}`;
+}
+
+/** Returns a link to a contract (account) on stellar.expert. */
+export function explorerContractUrl(contractId: string, network: string): string {
+  return `${explorerBase(network)}/contract/${contractId}`;
+}

--- a/app/backend/src/common/utils/explorer-url.util.ts
+++ b/app/backend/src/common/utils/explorer-url.util.ts
@@ -15,6 +15,9 @@ export function explorerTxUrl(txHash: string, network: string): string {
 }
 
 /** Returns a link to a contract (account) on stellar.expert. */
-export function explorerContractUrl(contractId: string, network: string): string {
+export function explorerContractUrl(
+  contractId: string,
+  network: string,
+): string {
   return `${explorerBase(network)}/contract/${contractId}`;
 }

--- a/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
@@ -74,7 +74,7 @@ export class DeploymentMetadataController {
     );
     try {
       return await this.deploymentMetadataService.create(dto);
-    } catch (error) {
+    } catch (error: unknown) {
       this.logger.error('Failed to create deployment metadata:', error);
       if ((error as { code?: string }).code === 'P2002') {
         throw new BadRequestException(

--- a/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
@@ -76,7 +76,7 @@ export class DeploymentMetadataController {
       return await this.deploymentMetadataService.create(dto);
     } catch (error) {
       this.logger.error('Failed to create deployment metadata:', error);
-      if (error.code === 'P2002') {
+      if ((error as { code?: string }).code === 'P2002') {
         throw new BadRequestException(
           `Deployment metadata already exists for ${dto.network}/${dto.contractName}`,
         );

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.ts
@@ -34,7 +34,7 @@ export class DeploymentMetadataService {
         deployer: dto.deployer ?? null,
         transactionHash: dto.transactionHash ?? null,
         // Use Prisma.DbNull instead of standard null variables for Json fields
-        metadata: dto.metadata ?? Prisma.DbNull,
+        metadata: (dto.metadata as Prisma.InputJsonValue) ?? Prisma.DbNull,
       },
     });
 
@@ -115,7 +115,7 @@ export class DeploymentMetadataService {
         deployer: dto.deployer,
         transactionHash: dto.transactionHash,
         // Ensure explicit fallback behavior for Json type check compliance
-        metadata: dto.metadata === null ? Prisma.DbNull : dto.metadata,
+        metadata: dto.metadata === null ? Prisma.DbNull : (dto.metadata as Prisma.InputJsonValue | undefined),
       },
     });
 

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.ts
@@ -135,7 +135,9 @@ export class DeploymentMetadataService {
   /**
    * Map Prisma model to response DTO
    */
-  private mapToResponse(metadata: DeploymentMetadata): DeploymentMetadataResponseDto {
+  private mapToResponse(
+    metadata: DeploymentMetadata,
+  ): DeploymentMetadataResponseDto {
     return {
       id: metadata.id,
       contractName: metadata.contractName,
@@ -146,7 +148,8 @@ export class DeploymentMetadataService {
       commitSha: metadata.commitSha ?? undefined,
       deployer: metadata.deployer ?? undefined,
       transactionHash: metadata.transactionHash ?? undefined,
-      metadata: (metadata.metadata as Record<string, unknown> | null) ?? undefined,
+      metadata:
+        (metadata.metadata as Record<string, unknown> | null) ?? undefined,
       createdAt: metadata.createdAt,
       updatedAt: metadata.updatedAt,
     };

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { Prisma } from '@prisma/client';
+import { Prisma, DeploymentMetadata } from '@prisma/client';
 import {
   CreateDeploymentMetadataDto,
   UpdateDeploymentMetadataDto,
@@ -135,7 +135,7 @@ export class DeploymentMetadataService {
   /**
    * Map Prisma model to response DTO
    */
-  private mapToResponse(metadata: any): DeploymentMetadataResponseDto {
+  private mapToResponse(metadata: DeploymentMetadata): DeploymentMetadataResponseDto {
     return {
       id: metadata.id,
       contractName: metadata.contractName,
@@ -146,7 +146,7 @@ export class DeploymentMetadataService {
       commitSha: metadata.commitSha ?? undefined,
       deployer: metadata.deployer ?? undefined,
       transactionHash: metadata.transactionHash ?? undefined,
-      metadata: metadata.metadata ?? undefined,
+      metadata: (metadata.metadata as Record<string, unknown> | null) ?? undefined,
       createdAt: metadata.createdAt,
       updatedAt: metadata.updatedAt,
     };

--- a/app/backend/src/deployment-metadata/dto/deployment-metadata.dto.ts
+++ b/app/backend/src/deployment-metadata/dto/deployment-metadata.dto.ts
@@ -30,7 +30,7 @@ export class CreateDeploymentMetadataDto {
 
   @IsOptional()
   @IsObject()
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export class UpdateDeploymentMetadataDto {
@@ -52,7 +52,7 @@ export class UpdateDeploymentMetadataDto {
 
   @IsOptional()
   @IsObject()
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export class DeploymentMetadataResponseDto {
@@ -65,7 +65,7 @@ export class DeploymentMetadataResponseDto {
   commitSha?: string;
   deployer?: string;
   transactionHash?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/app/backend/src/onchain/aid-escrow.module.ts
+++ b/app/backend/src/onchain/aid-escrow.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { OnchainModule } from './onchain.module';
 import { AidEscrowService } from './aid-escrow.service';
 import { AidEscrowController } from './aid-escrow.controller';
@@ -6,7 +7,7 @@ import { CommonServicesModule } from '../common/services/common-services.module'
 import { BudgetService } from '../common/budget/budget.service';
 
 @Module({
-  imports: [OnchainModule, CommonServicesModule],
+  imports: [OnchainModule, CommonServicesModule, ConfigModule],
   providers: [AidEscrowService, BudgetService],
   controllers: [AidEscrowController],
   exports: [AidEscrowService],

--- a/app/backend/src/onchain/aid-escrow.service.ts
+++ b/app/backend/src/onchain/aid-escrow.service.ts
@@ -281,7 +281,7 @@ export class AidEscrowService {
    */
   async getTransactionStatus(
     hash: string,
-  ): Promise<GetTransactionStatusResult> {
+  ): Promise<GetTransactionStatusResult & { explorerUrl?: string }> {
     this.logger.debug('Getting transaction status:', { hash });
 
     const result = await this.onchainAdapter.getTransactionStatus({ hash });

--- a/app/backend/src/onchain/aid-escrow.service.ts
+++ b/app/backend/src/onchain/aid-escrow.service.ts
@@ -12,7 +12,7 @@ import {
 } from './dto/aid-escrow.dto';
 import { BudgetService } from '../common/budget/budget.service';
 import { GetTransactionStatusResult } from './onchain.adapter';
-import { explorerTxUrl, explorerContractUrl } from '../common/utils/explorer-url.util';
+import { explorerTxUrl } from '../common/utils/explorer-url.util';
 
 /**
  * AidEscrowService
@@ -33,9 +33,14 @@ export class AidEscrowService {
     this.network = this.configService.get<string>('SOROBAN_NETWORK', 'testnet');
   }
 
-  private withTxExplorerUrl<T extends { transactionHash?: string }>(result: T): T & { explorerUrl?: string } {
+  private withTxExplorerUrl<T extends { transactionHash?: string }>(
+    result: T,
+  ): T & { explorerUrl?: string } {
     if (!result.transactionHash) return result;
-    return { ...result, explorerUrl: explorerTxUrl(result.transactionHash, this.network) };
+    return {
+      ...result,
+      explorerUrl: explorerTxUrl(result.transactionHash, this.network),
+    };
   }
 
   /**

--- a/app/backend/src/onchain/aid-escrow.service.ts
+++ b/app/backend/src/onchain/aid-escrow.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { Inject } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OnchainAdapter, ONCHAIN_ADAPTER_TOKEN } from './onchain.adapter';
 import {
   CreateAidPackageDto,
@@ -11,6 +12,7 @@ import {
 } from './dto/aid-escrow.dto';
 import { BudgetService } from '../common/budget/budget.service';
 import { GetTransactionStatusResult } from './onchain.adapter';
+import { explorerTxUrl, explorerContractUrl } from '../common/utils/explorer-url.util';
 
 /**
  * AidEscrowService
@@ -20,12 +22,21 @@ import { GetTransactionStatusResult } from './onchain.adapter';
 @Injectable()
 export class AidEscrowService {
   private readonly logger = new Logger(AidEscrowService.name);
+  private readonly network: string;
 
   constructor(
     @Inject(ONCHAIN_ADAPTER_TOKEN)
     private readonly onchainAdapter: OnchainAdapter,
     private readonly budgetService: BudgetService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.network = this.configService.get<string>('SOROBAN_NETWORK', 'testnet');
+  }
+
+  private withTxExplorerUrl<T extends { transactionHash?: string }>(result: T): T & { explorerUrl?: string } {
+    if (!result.transactionHash) return result;
+    return { ...result, explorerUrl: explorerTxUrl(result.transactionHash, this.network) };
+  }
 
   /**
    * Check token balance before creating packages
@@ -115,7 +126,7 @@ export class AidEscrowService {
       tokenAddress: dto.tokenAddress,
     });
 
-    return result;
+    return this.withTxExplorerUrl(result);
   }
 
   /**
@@ -171,7 +182,7 @@ export class AidEscrowService {
       tokenAddress: dto.tokenAddress,
     });
 
-    return result;
+    return this.withTxExplorerUrl(result);
   }
 
   /**
@@ -193,7 +204,7 @@ export class AidEscrowService {
       amountClaimed: result.amountClaimed,
     });
 
-    return result;
+    return this.withTxExplorerUrl(result);
   }
 
   /**
@@ -218,7 +229,7 @@ export class AidEscrowService {
       amountDisbursed: result.amountDisbursed,
     });
 
-    return result;
+    return this.withTxExplorerUrl(result);
   }
 
   /**
@@ -275,6 +286,6 @@ export class AidEscrowService {
       status: result.status,
     });
 
-    return result;
+    return { ...result, explorerUrl: explorerTxUrl(result.hash, this.network) };
   }
 }

--- a/app/backend/src/onchain/soroban.adapter.ts
+++ b/app/backend/src/onchain/soroban.adapter.ts
@@ -211,7 +211,7 @@ export class SorobanAdapter implements OnchainAdapter {
         throw new Error(contractErr);
       }
 
-      const retval = receipt.returnValue
+      const retval: unknown = receipt.returnValue
         ? scValToNative(receipt.returnValue)
         : null;
 
@@ -227,7 +227,7 @@ export class SorobanAdapter implements OnchainAdapter {
     method: string,
     args: xdr.ScVal[],
     correlationId: string,
-  ): Promise<any> {
+  ): Promise<unknown> {
     const server = this.getServer();
     const kp = this.getKeypair();
     const contract = new Contract(this.contractId);
@@ -265,7 +265,7 @@ export class SorobanAdapter implements OnchainAdapter {
 
     if (SorobanRpc.Api.isSimulationSuccess(simulation)) {
       if (simulation.result?.retval) {
-        return scValToNative(simulation.result.retval);
+        return scValToNative(simulation.result.retval) as unknown;
       }
     }
 
@@ -275,7 +275,7 @@ export class SorobanAdapter implements OnchainAdapter {
   private extractContractError(receipt: any): string {
     if (receipt?.result?.retval) {
       try {
-        const val = scValToNative(receipt.result.retval);
+        const val: unknown = scValToNative(receipt.result.retval);
         if (typeof val === 'object' && val !== null) {
           return JSON.stringify(val);
         }
@@ -326,21 +326,31 @@ export class SorobanAdapter implements OnchainAdapter {
     return nativeToScVal(mapVal, { type: 'map' });
   }
 
-  private parsePackage(scv: any): AidPackage | null {
+  private parsePackage(scv: unknown): AidPackage | null {
     if (!scv || typeof scv !== 'object') return null;
+    const data = scv as {
+      id?: string | number;
+      recipient?: string;
+      amount?: string | number;
+      token?: string;
+      status?: number | string;
+      created_at?: number;
+      expires_at?: number;
+      metadata?: Record<string, string>;
+    };
     return {
-      id: String(scv.id ?? ''),
-      recipient: scv.recipient ?? '',
-      amount: String(scv.amount ?? '0'),
-      token: scv.token ?? '',
-      status: this.parseStatus(scv.status),
-      createdAt: Number(scv.created_at ?? 0),
-      expiresAt: Number(scv.expires_at ?? 0),
-      metadata: scv.metadata ?? undefined,
+      id: String(data.id ?? ''),
+      recipient: String(data.recipient ?? ''),
+      amount: String(data.amount ?? '0'),
+      token: String(data.token ?? ''),
+      status: this.parseStatus(data.status),
+      createdAt: Number(data.created_at ?? 0),
+      expiresAt: Number(data.expires_at ?? 0),
+      metadata: data.metadata,
     };
   }
 
-  private parseStatus(status: any): AidPackage['status'] {
+  private parseStatus(status: unknown): AidPackage['status'] {
     if (typeof status === 'number') {
       const map: Record<number, AidPackage['status']> = {
         0: 'Created',
@@ -559,11 +569,17 @@ export class SorobanAdapter implements OnchainAdapter {
       cid,
     );
 
+    const data =
+      (result as {
+        total_committed?: string | number;
+        total_claimed?: string | number;
+        total_expired_cancelled?: string | number;
+      }) || {};
     return {
       aggregates: {
-        totalCommitted: String(result?.total_committed ?? '0'),
-        totalClaimed: String(result?.total_claimed ?? '0'),
-        totalExpiredCancelled: String(result?.total_expired_cancelled ?? '0'),
+        totalCommitted: String(data.total_committed ?? '0'),
+        totalClaimed: String(data.total_claimed ?? '0'),
+        totalExpiredCancelled: String(data.total_expired_cancelled ?? '0'),
       },
       timestamp: new Date(),
     };
@@ -619,7 +635,7 @@ export class SorobanAdapter implements OnchainAdapter {
     const version = await this.simulateReadOnly('get_version', [], cid);
 
     return {
-      version: String(version ?? '0'),
+      version: String((version as string | number) ?? '0'),
       name: 'Soroban AidEscrow Contract',
       timestamp: new Date(),
     };

--- a/app/backend/src/orgs/invites.controller.ts
+++ b/app/backend/src/orgs/invites.controller.ts
@@ -31,7 +31,7 @@ export class InvitesController {
       orgId,
       email: body.email,
       role: body.role,
-      createdBy: req.user.id || req.user.apiKeyId || 'system',
+      createdBy: req.user?.id || req.user?.apiKeyId || 'system',
     });
   }
 
@@ -53,7 +53,7 @@ export class InvitesController {
   ) {
     return this.invitesService.revokeInvite(
       inviteId,
-      req.user.id || req.user.apiKeyId || 'system',
+      req.user?.id || req.user?.apiKeyId || 'system',
     );
   }
 

--- a/app/backend/src/orgs/invites.controller.ts
+++ b/app/backend/src/orgs/invites.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   Request,
 } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { InvitesService } from './invites.service';
 import { AppRole } from '@prisma/client';
 import { Roles } from '../auth/roles.decorator';
@@ -24,7 +25,7 @@ export class InvitesController {
   async createInvite(
     @Param('id') orgId: string,
     @Body() body: { email: string; role: AppRole },
-    @Request() req: any,
+    @Request() req: ExpressRequest,
   ) {
     return this.invitesService.createInvite({
       orgId,
@@ -38,7 +39,7 @@ export class InvitesController {
   async acceptInvite(
     @Param('id') inviteId: string,
     @Body('email') email: string,
-    @Request() req: any,
+    @Request() req: ExpressRequest,
   ) {
     const userEmail = req.user?.email || email;
     return this.invitesService.acceptInvite(inviteId, userEmail);
@@ -46,7 +47,10 @@ export class InvitesController {
 
   @Delete('invites/:id')
   @Roles(AppRole.admin)
-  async revokeInvite(@Param('id') inviteId: string, @Request() req: any) {
+  async revokeInvite(
+    @Param('id') inviteId: string,
+    @Request() req: ExpressRequest,
+  ) {
     return this.invitesService.revokeInvite(
       inviteId,
       req.user.id || req.user.apiKeyId || 'system',

--- a/app/backend/src/sandbox/seed.service.ts
+++ b/app/backend/src/sandbox/seed.service.ts
@@ -4,6 +4,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 import {
   DEMO_CAMPAIGN_SEEDS,
   DEMO_CLAIM_SEEDS,
@@ -76,7 +77,7 @@ export class SeedService {
           description: DEMO_TENANT_SEED.description,
           region: DEMO_TENANT_SEED.region,
           isTenantMarker: true,
-        } as Record<string, unknown>,
+        } as Prisma.InputJsonValue,
       },
     });
 
@@ -107,7 +108,7 @@ export class SeedService {
             status: seed.status,
             budget: seed.budget,
             ngoId: DEMO_TENANT_SEED.ngoId,
-            metadata: (seed.metadata ?? {}) as Record<string, unknown>,
+            metadata: (seed.metadata ?? {}) as Prisma.InputJsonValue,
           },
         });
         created++;

--- a/app/backend/src/sandbox/seed.service.ts
+++ b/app/backend/src/sandbox/seed.service.ts
@@ -72,13 +72,11 @@ export class SeedService {
         status: 'draft',
         budget: 0,
         ngoId: DEMO_TENANT_SEED.ngoId,
-        metadata: JSON.parse(
-          JSON.stringify({
-            description: DEMO_TENANT_SEED.description,
-            region: DEMO_TENANT_SEED.region,
-            isTenantMarker: true,
-          }),
-        ) as Record<string, unknown>,
+        metadata: {
+          description: DEMO_TENANT_SEED.description,
+          region: DEMO_TENANT_SEED.region,
+          isTenantMarker: true,
+        } as Record<string, unknown>,
       },
     });
 
@@ -109,7 +107,7 @@ export class SeedService {
             status: seed.status,
             budget: seed.budget,
             ngoId: DEMO_TENANT_SEED.ngoId,
-            metadata: JSON.parse(JSON.stringify(seed.metadata)) as Record<string, unknown>,
+            metadata: (seed.metadata ?? {}) as Record<string, unknown>,
           },
         });
         created++;

--- a/app/backend/src/sandbox/seed.service.ts
+++ b/app/backend/src/sandbox/seed.service.ts
@@ -78,7 +78,7 @@ export class SeedService {
             region: DEMO_TENANT_SEED.region,
             isTenantMarker: true,
           }),
-        ),
+        ) as Record<string, unknown>,
       },
     });
 
@@ -109,7 +109,7 @@ export class SeedService {
             status: seed.status,
             budget: seed.budget,
             ngoId: DEMO_TENANT_SEED.ngoId,
-            metadata: JSON.parse(JSON.stringify(seed.metadata)),
+            metadata: JSON.parse(JSON.stringify(seed.metadata)) as Record<string, unknown>,
           },
         });
         created++;

--- a/app/backend/src/sandbox/seed.service.ts
+++ b/app/backend/src/sandbox/seed.service.ts
@@ -4,6 +4,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
 import {
   DEMO_CAMPAIGN_SEEDS,
   DEMO_CLAIM_SEEDS,
@@ -78,7 +79,7 @@ export class SeedService {
             region: DEMO_TENANT_SEED.region,
             isTenantMarker: true,
           }),
-        ),
+        ) as Prisma.JsonObject,
       },
     });
 
@@ -109,7 +110,9 @@ export class SeedService {
             status: seed.status,
             budget: seed.budget,
             ngoId: DEMO_TENANT_SEED.ngoId,
-            metadata: JSON.parse(JSON.stringify(seed.metadata)),
+            metadata: JSON.parse(
+              JSON.stringify(seed.metadata),
+            ) as Prisma.JsonObject,
           },
         });
         created++;

--- a/app/backend/src/search/admin-search.controller.ts
+++ b/app/backend/src/search/admin-search.controller.ts
@@ -7,6 +7,11 @@ import { Roles } from '../auth/roles.decorator';
 import { AppRole } from '@prisma/client';
 import { AdaptiveRateLimitGuard } from '../common/guards/adaptive-rate-limit.guard';
 
+interface SearchUser {
+  orgId?: string | null;
+  ngoId?: string | null;
+}
+
 @Controller('admin')
 @UseGuards(ApiKeyGuard, RolesGuard, AdaptiveRateLimitGuard)
 export class AdminSearchController {
@@ -19,7 +24,8 @@ export class AdminSearchController {
     @Query('entity') entity: string,
     @Req() req: Request,
   ) {
-    const orgId = req.user?.orgId ?? req.user?.ngoId ?? '';
+    const user = req.user as SearchUser | undefined;
+    const orgId: string = user?.orgId ?? user?.ngoId ?? '';
     return this.searchService.search(query, entity, orgId);
   }
 }

--- a/app/backend/src/search/admin-search.controller.ts
+++ b/app/backend/src/search/admin-search.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, UseGuards, Request } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { AdminSearchService } from './admin-search.service';
 import { ApiKeyGuard } from '../common/guards/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -16,9 +17,9 @@ export class AdminSearchController {
   async search(
     @Query('q') query: string,
     @Query('entity') entity: string,
-    @Request() req: any,
+    @Request() req: ExpressRequest,
   ) {
-    const orgId = req.user.orgId || req.user.ngoId;
+    const orgId = req.user?.orgId || req.user?.ngoId;
     return this.searchService.search(query, entity, orgId);
   }
 }

--- a/app/backend/src/search/admin-search.controller.ts
+++ b/app/backend/src/search/admin-search.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Query, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { AdminSearchService } from './admin-search.service';
 import { ApiKeyGuard } from '../common/guards/api-key.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -16,9 +17,9 @@ export class AdminSearchController {
   async search(
     @Query('q') query: string,
     @Query('entity') entity: string,
-    @Request() req: any,
+    @Req() req: Request,
   ) {
-    const orgId = req.user.orgId || req.user.ngoId;
+    const orgId = req.user?.orgId ?? req.user?.ngoId ?? '';
     return this.searchService.search(query, entity, orgId);
   }
 }

--- a/app/backend/src/search/admin-search.service.ts
+++ b/app/backend/src/search/admin-search.service.ts
@@ -5,8 +5,19 @@ import { PrismaService } from '../prisma/prisma.service';
 export class AdminSearchService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async search(query: string, entity: string | undefined, orgId: string) {
-    const results: Array<{ type: string; label: string; status: string; id: string }> = [];
+  async search(
+    query: string,
+    entity: string | undefined,
+    orgId: string,
+  ): Promise<
+    Array<{ type: string; label: string; status: string; id: string }>
+  > {
+    const results: Array<{
+      type: string;
+      label: string;
+      status: string;
+      id: string;
+    }> = [];
     const q = query.toLowerCase();
 
     // 1. Search Campaigns

--- a/app/backend/src/search/admin-search.service.ts
+++ b/app/backend/src/search/admin-search.service.ts
@@ -1,12 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
+export interface SearchResult {
+  type: 'campaign' | 'claim' | 'recipient' | 'verification';
+  label: string;
+  status: string;
+  id: string;
+}
+
 @Injectable()
 export class AdminSearchService {
   constructor(private readonly prisma: PrismaService) {}
 
   async search(query: string, entity: string | undefined, orgId: string) {
-    const results: any[] = [];
+    const results: SearchResult[] = [];
     const q = query.toLowerCase();
 
     // 1. Search Campaigns

--- a/app/backend/src/search/admin-search.service.ts
+++ b/app/backend/src/search/admin-search.service.ts
@@ -6,7 +6,7 @@ export class AdminSearchService {
   constructor(private readonly prisma: PrismaService) {}
 
   async search(query: string, entity: string | undefined, orgId: string) {
-    const results: any[] = [];
+    const results: Array<{ type: string; label: string; status: string; id: string }> = [];
     const q = query.toLowerCase();
 
     // 1. Search Campaigns

--- a/app/backend/src/types/express.d.ts
+++ b/app/backend/src/types/express.d.ts
@@ -5,7 +5,9 @@ declare global {
     interface Request {
       user?: {
         role: AppRole;
+        id?: string;
         ngoId?: string | null;
+        orgId?: string | null;
         apiKeyId?: string;
         authType?: 'apiKey' | 'envApiKey';
       };

--- a/app/backend/src/types/express.d.ts
+++ b/app/backend/src/types/express.d.ts
@@ -6,6 +6,8 @@ declare global {
       user?: {
         role: AppRole;
         id?: string;
+        email?: string;
+        sub?: string;
         ngoId?: string | null;
         orgId?: string | null;
         apiKeyId?: string;

--- a/app/backend/src/types/express.d.ts
+++ b/app/backend/src/types/express.d.ts
@@ -4,6 +4,10 @@ declare global {
   namespace Express {
     interface Request {
       user?: {
+        id?: string;
+        email?: string;
+        sub?: string;
+        orgId?: string | null;
         role: AppRole;
         ngoId?: string | null;
         apiKeyId?: string;

--- a/app/backend/src/verification/verification-inbox.controller.ts
+++ b/app/backend/src/verification/verification-inbox.controller.ts
@@ -27,6 +27,11 @@ import { VerificationInboxService } from './verification-inbox.service';
 import { Roles } from 'src/auth/roles.decorator';
 import { AppRole } from 'src/auth/app-role.enum';
 
+interface InboxUser {
+  sub?: string;
+  apiKeyId?: string;
+}
+
 @ApiTags('Verification Inbox')
 @ApiBearerAuth('JWT-auth')
 @Controller('verification-inbox')
@@ -95,7 +100,8 @@ export class VerificationInboxController {
   ) {
     const pageNum = page ? parseInt(page, 10) : 1;
     const limitNum = limit ? parseInt(limit, 10) : 20;
-    const userId = req?.user?.apiKeyId;
+    const user = req?.user as InboxUser | undefined;
+    const userId: string | undefined = user?.apiKeyId;
 
     return this.verificationInboxService.getInbox(
       status,
@@ -169,8 +175,8 @@ export class VerificationInboxController {
     @Body() body: { nextStepMessage?: string; internalNote?: string },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      req.user?.apiKeyId ?? 'system';
+    const user = req.user as InboxUser | undefined;
+    const reviewerId: string = user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'approved',
@@ -222,8 +228,8 @@ export class VerificationInboxController {
     },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      req.user?.apiKeyId ?? 'system';
+    const user = req.user as InboxUser | undefined;
+    const reviewerId: string = user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'rejected',
@@ -275,8 +281,8 @@ export class VerificationInboxController {
     },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      req.user?.apiKeyId ?? 'system';
+    const user = req.user as InboxUser | undefined;
+    const reviewerId: string = user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'needs_resubmission',
@@ -358,8 +364,8 @@ export class VerificationInboxController {
     @Body() body: { content: string; category?: string },
     @Request() req: ExpressRequest,
   ) {
-    const authorId =
-      req.user?.apiKeyId ?? 'system';
+    const user = req.user as InboxUser | undefined;
+    const authorId: string = user?.apiKeyId ?? 'system';
     return this.verificationInboxService.addInternalNote(
       id,
       body.content,

--- a/app/backend/src/verification/verification-inbox.controller.ts
+++ b/app/backend/src/verification/verification-inbox.controller.ts
@@ -95,7 +95,7 @@ export class VerificationInboxController {
   ) {
     const pageNum = page ? parseInt(page, 10) : 1;
     const limitNum = limit ? parseInt(limit, 10) : 20;
-    const userId = (req?.user as any)?.sub || (req?.user as any)?.apiKeyId;
+    const userId = req?.user?.sub || req?.user?.apiKeyId;
 
     return this.verificationInboxService.getInbox(
       status,
@@ -169,8 +169,7 @@ export class VerificationInboxController {
     @Body() body: { nextStepMessage?: string; internalNote?: string },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+    const reviewerId = req.user?.sub || req.user?.apiKeyId || 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'approved',
@@ -222,8 +221,7 @@ export class VerificationInboxController {
     },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+    const reviewerId = req.user?.sub || req.user?.apiKeyId || 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'rejected',
@@ -275,8 +273,7 @@ export class VerificationInboxController {
     },
     @Request() req: ExpressRequest,
   ) {
-    const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+    const reviewerId = req.user?.sub || req.user?.apiKeyId || 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'needs_resubmission',
@@ -358,8 +355,7 @@ export class VerificationInboxController {
     @Body() body: { content: string; category?: string },
     @Request() req: ExpressRequest,
   ) {
-    const authorId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+    const authorId = req.user?.sub || req.user?.apiKeyId || 'system';
     return this.verificationInboxService.addInternalNote(
       id,
       body.content,

--- a/app/backend/src/verification/verification-inbox.controller.ts
+++ b/app/backend/src/verification/verification-inbox.controller.ts
@@ -95,7 +95,7 @@ export class VerificationInboxController {
   ) {
     const pageNum = page ? parseInt(page, 10) : 1;
     const limitNum = limit ? parseInt(limit, 10) : 20;
-    const userId = (req?.user as any)?.sub || (req?.user as any)?.apiKeyId;
+    const userId = req?.user?.apiKeyId;
 
     return this.verificationInboxService.getInbox(
       status,
@@ -170,7 +170,7 @@ export class VerificationInboxController {
     @Request() req: ExpressRequest,
   ) {
     const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+      req.user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'approved',
@@ -223,7 +223,7 @@ export class VerificationInboxController {
     @Request() req: ExpressRequest,
   ) {
     const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+      req.user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'rejected',
@@ -276,7 +276,7 @@ export class VerificationInboxController {
     @Request() req: ExpressRequest,
   ) {
     const reviewerId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+      req.user?.apiKeyId ?? 'system';
     return this.verificationInboxService.updateStatus(
       id,
       'needs_resubmission',
@@ -359,7 +359,7 @@ export class VerificationInboxController {
     @Request() req: ExpressRequest,
   ) {
     const authorId =
-      (req.user as any)?.sub || (req.user as any)?.apiKeyId || 'system';
+      req.user?.apiKeyId ?? 'system';
     return this.verificationInboxService.addInternalNote(
       id,
       body.content,

--- a/app/backend/src/verification/verification-inbox.service.ts
+++ b/app/backend/src/verification/verification-inbox.service.ts
@@ -149,9 +149,13 @@ export class VerificationInboxService {
       status,
       reviewedAt: new Date(),
       reviewedBy: reviewerId,
-      ...(nextStepMessage ? { nextStepMessage } : {}),
-      ...(rejectionReason ? { rejectionReason } : {}),
     };
+    if (nextStepMessage) {
+      updateData.nextStepMessage = nextStepMessage;
+    }
+    if (rejectionReason) {
+      updateData.rejectionReason = rejectionReason;
+    }
 
     const updated = await this.prisma.verificationRequest.update({
       where: { id },

--- a/app/backend/src/verification/verification-inbox.service.ts
+++ b/app/backend/src/verification/verification-inbox.service.ts
@@ -60,7 +60,7 @@ export class VerificationInboxService {
   ): Promise<InboxResponse> {
     const skip = (page - 1) * limit;
 
-    const where: any = {
+    const where: { deletedAt: null; status?: VerificationStatus } = {
       deletedAt: null,
     };
 
@@ -145,7 +145,13 @@ export class VerificationInboxService {
       throw new BadRequestException('Verification already processed');
     }
 
-    const updateData: any = {
+    const updateData: {
+      status: VerificationStatus;
+      reviewedAt: Date;
+      reviewedBy: string;
+      nextStepMessage?: string;
+      rejectionReason?: string;
+    } = {
       status,
       reviewedAt: new Date(),
       reviewedBy: reviewerId,

--- a/app/backend/src/verification/verification-inbox.service.ts
+++ b/app/backend/src/verification/verification-inbox.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
-import { VerificationStatus } from '@prisma/client';
+import { Prisma, VerificationStatus } from '@prisma/client';
 
 export interface InboxItem {
   id: string;
@@ -60,7 +60,7 @@ export class VerificationInboxService {
   ): Promise<InboxResponse> {
     const skip = (page - 1) * limit;
 
-    const where: any = {
+    const where: { deletedAt: null; status?: VerificationStatus } = {
       deletedAt: null,
     };
 
@@ -145,19 +145,13 @@ export class VerificationInboxService {
       throw new BadRequestException('Verification already processed');
     }
 
-    const updateData: any = {
+    const updateData: Prisma.VerificationRequestUpdateInput = {
       status,
       reviewedAt: new Date(),
       reviewedBy: reviewerId,
+      ...(nextStepMessage ? { nextStepMessage } : {}),
+      ...(rejectionReason ? { rejectionReason } : {}),
     };
-
-    if (nextStepMessage) {
-      updateData.nextStepMessage = nextStepMessage;
-    }
-
-    if (rejectionReason) {
-      updateData.rejectionReason = rejectionReason;
-    }
 
     const updated = await this.prisma.verificationRequest.update({
       where: { id },

--- a/app/backend/test/aid-escrow.integration.spec.ts
+++ b/app/backend/test/aid-escrow.integration.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { AidEscrowService } from '../src/onchain/aid-escrow.service';
 import { BudgetService } from '../src/common/budget/budget.service';
 import { PrismaService } from '../src/prisma/prisma.service';
@@ -32,6 +33,10 @@ describe('AidEscrow Integration Tests', () => {
         {
           provide: ONCHAIN_ADAPTER_TOKEN,
           useValue: mockAdapter,
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('testnet') },
         },
       ],
     }).compile();

--- a/app/backend/test/transaction-status.spec.ts
+++ b/app/backend/test/transaction-status.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { BadRequestException } from '@nestjs/common';
 import { AidEscrowService } from '../src/onchain/aid-escrow.service';
 import { AidEscrowController } from '../src/onchain/aid-escrow.controller';
@@ -22,6 +23,7 @@ describe('Transaction Status Polling', () => {
         BudgetService,
         { provide: PrismaService, useValue: {} },
         { provide: ONCHAIN_ADAPTER_TOKEN, useValue: mockAdapter },
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('testnet') } },
       ],
     }).compile();
 


### PR DESCRIPTION
1. Utility — src/common/utils/explorer-url.util.ts with explorerTxUrl,
  explorerContractUrl, and explorerBase (network-aware, defaults to testnet).
  2. API responses — AidEscrowService enriches every response that carries a
  transactionHash with an explorerUrl field (create, batch-create, claim, disburse,
  get-transaction-status).
  3. Tests — explorer-url.util.spec.ts with 11 passing tests covering formatting, network
  switching, case-insensitivity, and unknown-network fallback.
 
closes #425