### PR TITLE
fix(#596): Block claim submission on network mismatch

### DIFF
--- a/app/frontend/src/components/EnhancedVerificationFlow.tsx
+++ b/app/frontend/src/components/EnhancedVerificationFlow.tsx
@@ -20,6 +20,8 @@ import type {
     RedactionLevel,
     ViewingPermission,
 } from '@/types/evidence-artifact';
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
+import { NetworkMismatchBanner } from '@/components/NetworkMismatchBanner';
 
 /* ─── Accepted image MIME types ─────────────────────────────────────────── */
 
@@ -118,6 +120,7 @@ function createMockEvidenceArtifact(
 export const EnhancedVerificationFlow: React.FC = () => {
     const uid = useId();
     const role = getAppUserRole();
+    const { isMismatch } = useNetworkGuard();
     const [restoredDraft] = useState<EnhancedVerificationDraft | null>(() =>
         readEnhancedVerificationDraftFromStorage(),
     );
@@ -391,6 +394,10 @@ export const EnhancedVerificationFlow: React.FC = () => {
                 <div>
                     <h2 className="text-lg font-semibold mb-4">Submit Evidence for Verification</h2>
 
+                    <div className="mb-6">
+                        <NetworkMismatchBanner />
+                    </div>
+
                     {!flowState.imageFile && flowState.textInput.trim().length === 0 && (
                         <div className="mb-6">
                             <AppEmptyState
@@ -518,8 +525,8 @@ export const EnhancedVerificationFlow: React.FC = () => {
                         <div className="flex flex-wrap items-center gap-3">
                             <button
                                 type="submit"
-                                disabled={!flowState.imageFile && flowState.textInput.trim().length === 0}
-                                aria-disabled={!flowState.imageFile && flowState.textInput.trim().length === 0}
+                                disabled={(!flowState.imageFile && flowState.textInput.trim().length === 0) || isMismatch}
+                                aria-disabled={(!flowState.imageFile && flowState.textInput.trim().length === 0) || isMismatch}
                                 className="px-6 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                             >
                                 Submit for Verification

--- a/app/frontend/src/components/VerificationFlow.tsx
+++ b/app/frontend/src/components/VerificationFlow.tsx
@@ -13,6 +13,8 @@ import type {
     VerificationStep,
 } from '@/types/verification';
 import { useActivity } from '@/hooks/useActivity';
+import { useNetworkGuard } from '@/hooks/useNetworkGuard';
+import { NetworkMismatchBanner } from '@/components/NetworkMismatchBanner';
 
 /* ─── Accepted image MIME types ─────────────────────────────────────────── */
 
@@ -290,6 +292,7 @@ function readVerificationDraftFromStorage(): VerificationDraft | null {
 export const VerificationFlow: React.FC = () => {
     const uid = useId();
     const { trackJob } = useActivity();
+    const { isMismatch } = useNetworkGuard();
     const [restoredDraft] = useState<VerificationDraft | null>(() =>
         readVerificationDraftFromStorage(),
     );
@@ -522,7 +525,7 @@ export const VerificationFlow: React.FC = () => {
 
     /* ── Submit button disabled state ───────────────────────────────────────── */
 
-    const canSubmit = imageFile !== null || textInput.trim().length > 0;
+    const canSubmit = (imageFile !== null || textInput.trim().length > 0) && !isMismatch;
 
     /* ── Render ──────────────────────────────────────────────────────────────── */
 
@@ -634,6 +637,10 @@ function StepUpload({
             aria-describedby={errors.form ? formErrorId : undefined}
         >
             <h2 className="text-lg font-semibold mb-4">Submit Evidence for Verification</h2>
+
+            <div className="mb-6">
+                <NetworkMismatchBanner />
+            </div>
 
             {!imageFile && textInput.trim().length === 0 && (
                 <div className="mb-6">

--- a/app/frontend/src/components/__tests__/EnhancedVerificationFlow.ui.test.tsx
+++ b/app/frontend/src/components/__tests__/EnhancedVerificationFlow.ui.test.tsx
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { EnhancedVerificationFlow } from '../EnhancedVerificationFlow';
+import * as networkGuard from '@/hooks/useNetworkGuard';
+
+// Mocking the hooks that are used in EnhancedVerificationFlow to prevent errors
+jest.mock('@/hooks/useNetworkGuard');
+jest.mock('@/hooks/useActivity', () => ({
+    useActivity: () => ({ trackJob: jest.fn() })
+}));
+jest.mock('@/lib/app-role', () => ({
+    getAppUserRole: () => 'recipient',
+    getSampleVerificationText: () => 'sample',
+    isOperationsRole: () => false
+}));
+
+describe('EnhancedVerificationFlow UI Network Guard', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('disables submit button and shows mismatch banner when network is mismatched', () => {
+        jest.spyOn(networkGuard, 'useNetworkGuard').mockReturnValue({
+            isCorrectNetwork: false,
+            isMismatch: true,
+            walletNetwork: 'testnet',
+            expectedNetwork: 'mainnet'
+        });
+
+        render(<EnhancedVerificationFlow />);
+
+        // The banner should be rendered
+        expect(screen.getByText(/Network mismatch/i)).toBeInTheDocument();
+        
+        // The submit button should be disabled
+        const submitButton = screen.getByRole('button', { name: /Submit for Verification/i });
+        expect(submitButton).toBeDisabled();
+    });
+
+    it('hides mismatch banner when network is correct', () => {
+        jest.spyOn(networkGuard, 'useNetworkGuard').mockReturnValue({
+            isCorrectNetwork: true,
+            isMismatch: false,
+            walletNetwork: 'mainnet',
+            expectedNetwork: 'mainnet'
+        });
+
+        render(<EnhancedVerificationFlow />);
+
+        // The banner should NOT be rendered
+        expect(screen.queryByText(/Network mismatch/i)).not.toBeInTheDocument();
+    });
+});

--- a/app/frontend/src/components/__tests__/VerificationFlow.ui.test.tsx
+++ b/app/frontend/src/components/__tests__/VerificationFlow.ui.test.tsx
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { VerificationFlow } from '../VerificationFlow';
+import * as networkGuard from '@/hooks/useNetworkGuard';
+
+// Mocking the hooks that are used in VerificationFlow to prevent errors
+jest.mock('@/hooks/useNetworkGuard');
+jest.mock('@/hooks/useActivity', () => ({
+    useActivity: () => ({ trackJob: jest.fn() })
+}));
+jest.mock('@/lib/app-role', () => ({
+    getAppUserRole: () => 'recipient',
+    getSampleVerificationText: () => 'sample',
+    isOperationsRole: () => false
+}));
+
+describe('VerificationFlow UI Network Guard', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('disables submit button and shows mismatch banner when network is mismatched', () => {
+        jest.spyOn(networkGuard, 'useNetworkGuard').mockReturnValue({
+            isCorrectNetwork: false,
+            isMismatch: true,
+            walletNetwork: 'testnet',
+            expectedNetwork: 'mainnet'
+        });
+
+        render(<VerificationFlow />);
+
+        // The banner should be rendered
+        expect(screen.getByText(/Network mismatch/i)).toBeInTheDocument();
+        
+        // The submit button should be disabled
+        const submitButton = screen.getByRole('button', { name: /Submit for Verification/i });
+        expect(submitButton).toBeDisabled();
+    });
+
+    it('hides mismatch banner when network is correct', () => {
+        jest.spyOn(networkGuard, 'useNetworkGuard').mockReturnValue({
+            isCorrectNetwork: true,
+            isMismatch: false,
+            walletNetwork: 'mainnet',
+            expectedNetwork: 'mainnet'
+        });
+
+        render(<VerificationFlow />);
+
+        // The banner should NOT be rendered
+        expect(screen.queryByText(/Network mismatch/i)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Closes #596

  ## Summary

  This PR implements a network mismatch guard during the evidence claim
  submission process. It prevents users from submitting forms if their
  connected wallet is on an unexpected Stellar network and provides a clear
  troubleshooting banner to guide them to switch to the correct network.
  ## What Changed
  •  app/frontend/src/components/VerificationFlow.tsx : Integrated 
  useNetworkGuard  to evaluate network mismatch state, added the 
  NetworkMismatchBanner  to the UI above the inputs, and updated the submit
  button to become disabled ( aria-disabled ) when a mismatch occurs.
  •  app/frontend/src/components/EnhancedVerificationFlow.tsx : Mirrored the
  exact same updates as above to maintain parity across both verification
  forms.
  •  app/frontend/src/components/__tests__/VerificationFlow.ui.test.tsx :
  Added new UI tests ensuring the banner appears and the submit button is
  locked when a mismatch is simulated.
  •  app/frontend/src/components/__tests__/EnhancedVerificationFlow.ui.test.
  tsx : Added parallel UI tests for the enhanced flow.

  ## Key Design Decisions
  • Reusing Existing Architecture: While investigating the codebase for this
  issue, we noticed that both the  useNetworkGuard  hook and the 
  NetworkMismatchBanner  UI component were already implemented and available
  in the frontend repository but had not been wired into these specific forms.
  Rather than reinventing the wheel, we cleanly dropped these existing modules
  into the  VerificationFlow  and  EnhancedVerificationFlow  components.
  • Client-Side Blocking: The validation directly leverages React state. The
  submit button is hard-disabled dynamically rather than relying on form-
  validation throw errors, guaranteeing a smooth and immediate visual feedback
  loop for the user.

  ## Acceptance Criteria

  [✓] Blocks claim submission on mismatch.
  [✓] Shows clear banner and troubleshooting step.

  ## Test Output & Coverage

  All UI logic was covered successfully using Jest + React Testing Library:

    PASS src/components/__tests__/EnhancedVerificationFlow.ui.test.tsx
    PASS src/components/__tests__/VerificationFlow.ui.test.tsx

    Test Suites: 2 passed, 2 total
    Tests:       4 passed, 4 total
    Snapshots:   0 total
    Time:        3.848 s

  Coverage Note: While Jest was invoked with coverage collection flags, the
  repository's current  jest.config.ts  prevents text-summary output tables
  from printing to the console. However, all new logical branches added (the
  conditional rendering of the banner and the boolean  disabled  state on the
  button based on  isMismatch ) were explicitly asserted on in our new tests.

  ## Follow-Ups

  • Jest configuration in the frontend ( jest.config.ts ) currently relies on
  a pure node environment out of the box and disables text-summary coverage
  outputs. A future PR could configure UI-based test coverage reporting to
  output cleanly to the CI/CD pipeline logs.

  ## Security Note

  This PR introduces frontend validation to guide users, but as a best
  practice, any authoritative on-chain submissions should still be cross-
  verified and protected at the backend/contract level to prevent
  sophisticated actors from bypassing client-side guards.