### PR TITLE
feat: claim receipt explorer links, per-field copy, and share URL

### DIFF
--- a/app/frontend/src/app/[locale]/claim-receipt/page.tsx
+++ b/app/frontend/src/app/[locale]/claim-receipt/page.tsx
@@ -61,13 +61,18 @@ export default function ClaimReceiptPage() {
   const handleShare = async () => {
     if (!claim) return;
 
+    const pageUrl = typeof window !== 'undefined' ? window.location.href : '';
+
     try {
-      // Try Web Share API first
       if (navigator.share) {
         await navigator.share({
           title: 'Claim Receipt',
           text: `Claim ${claim.claimId} - ${claim.status}`,
+          url: pageUrl,
         });
+      } else {
+        // Fallback: copy URL to clipboard
+        await navigator.clipboard.writeText(pageUrl);
       }
     } catch (err) {
       if (err instanceof Error && err.name !== 'AbortError') {

--- a/app/frontend/src/components/ClaimReceipt.tsx
+++ b/app/frontend/src/components/ClaimReceipt.tsx
@@ -24,6 +24,30 @@ interface ClaimReceiptProps {
   compact?: boolean;
 }
 
+/** Inline copy button with transient ✓ feedback for a single field value. */
+function FieldCopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = React.useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  };
+  return (
+    <button
+      onClick={copy}
+      aria-label={`Copy ${label}`}
+      title={`Copy ${label}`}
+      className="ml-1 inline-flex items-center opacity-60 hover:opacity-100 transition-opacity"
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
+  );
+}
+
 export const ClaimReceipt: React.FC<ClaimReceiptProps> = ({
   claim,
   onShare,
@@ -167,43 +191,52 @@ ${claim.transactionHash ? `Transaction Hash: ${claim.transactionHash}` : ''}`.tr
         {claim.tokenAddress && (
           <div className="col-span-2">
             <p className="text-xs font-semibold opacity-75 mb-1">TOKEN ADDRESS</p>
-            <a
-              href={buildExplorerUrl('address', claim.tokenAddress)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1 inline-flex"
-            >
-              {claim.tokenAddress}
-              <ExternalLink size={12} className="shrink-0" />
-            </a>
+            <div className="flex items-center gap-1">
+              <a
+                href={buildExplorerUrl('address', claim.tokenAddress)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1"
+              >
+                {claim.tokenAddress}
+                <ExternalLink size={12} className="shrink-0" />
+              </a>
+              <FieldCopyButton value={claim.tokenAddress} label="token address" />
+            </div>
           </div>
         )}
         {claim.contractAddress && (
           <div className="col-span-2">
             <p className="text-xs font-semibold opacity-75 mb-1">CONTRACT ADDRESS</p>
-            <a
-              href={buildExplorerUrl('contract', claim.contractAddress)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1 inline-flex"
-            >
-              {claim.contractAddress}
-              <ExternalLink size={12} className="shrink-0" />
-            </a>
+            <div className="flex items-center gap-1">
+              <a
+                href={buildExplorerUrl('contract', claim.contractAddress)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1"
+              >
+                {claim.contractAddress}
+                <ExternalLink size={12} className="shrink-0" />
+              </a>
+              <FieldCopyButton value={claim.contractAddress} label="contract address" />
+            </div>
           </div>
         )}
         {claim.transactionHash && (
           <div className="col-span-2">
             <p className="text-xs font-semibold opacity-75 mb-1">TRANSACTION HASH</p>
-            <a
-              href={buildExplorerUrl('tx', claim.transactionHash)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1 inline-flex"
-            >
-              {claim.transactionHash}
-              <ExternalLink size={12} className="shrink-0" />
-            </a>
+            <div className="flex items-center gap-1">
+              <a
+                href={buildExplorerUrl('tx', claim.transactionHash)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs break-all text-blue-600 hover:underline dark:text-blue-400 flex items-center gap-1"
+              >
+                {claim.transactionHash}
+                <ExternalLink size={12} className="shrink-0" />
+              </a>
+              <FieldCopyButton value={claim.transactionHash} label="transaction hash" />
+            </div>
           </div>
         )}
       </div>

--- a/app/frontend/src/components/__tests__/ClaimReceipt.test.tsx
+++ b/app/frontend/src/components/__tests__/ClaimReceipt.test.tsx
@@ -1,0 +1,195 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ClaimReceipt, ClaimReceiptData } from '../ClaimReceipt';
+
+// Mock dependencies
+jest.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}));
+
+jest.mock('@/lib/explorer', () => ({
+  buildExplorerUrl: (type: string, id: string) =>
+    `https://stellar.expert/explorer/testnet/${type}/${id}`,
+}));
+
+const baseClaim: ClaimReceiptData = {
+  claimId: 'claim-123',
+  packageId: 'pkg-abc',
+  status: 'disbursed',
+  amount: 100,
+  timestamp: '2024-01-15T10:30:00Z',
+};
+
+const fullClaim: ClaimReceiptData = {
+  ...baseClaim,
+  transactionHash: 'abc123txhash',
+  contractAddress: 'CCONTRACTADDRESS',
+  tokenAddress: 'GTOKENADDRESS',
+};
+
+beforeEach(() => {
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ClaimReceipt', () => {
+  describe('basic rendering', () => {
+    it('renders claim id and package id', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.getByText('claim-123')).toBeInTheDocument();
+      expect(screen.getByText('pkg-abc')).toBeInTheDocument();
+    });
+
+    it('renders status badge', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.getAllByText('disbursed').length).toBeGreaterThan(0);
+    });
+
+    it('renders amount', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.getByText(/100 tokens/)).toBeInTheDocument();
+    });
+
+    it('renders formatted timestamp', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+    });
+  });
+
+  describe('explorer links', () => {
+    it('shows transaction hash with explorer link', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      const txLink = screen.getByRole('link', { name: /abc123txhash/i });
+      expect(txLink).toHaveAttribute(
+        'href',
+        'https://stellar.expert/explorer/testnet/tx/abc123txhash'
+      );
+      expect(txLink).toHaveAttribute('target', '_blank');
+    });
+
+    it('shows contract address with explorer link', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      const contractLink = screen.getByRole('link', { name: /CCONTRACTADDRESS/i });
+      expect(contractLink).toHaveAttribute(
+        'href',
+        'https://stellar.expert/explorer/testnet/contract/CCONTRACTADDRESS'
+      );
+    });
+
+    it('shows token address with explorer link', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      const tokenLink = screen.getByRole('link', { name: /GTOKENADDRESS/i });
+      expect(tokenLink).toHaveAttribute(
+        'href',
+        'https://stellar.expert/explorer/testnet/address/GTOKENADDRESS'
+      );
+    });
+
+    it('does not render tx hash section when transactionHash is absent', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.queryByText(/TRANSACTION HASH/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render contract address section when contractAddress is absent', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.queryByText(/CONTRACT ADDRESS/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('per-field copy buttons', () => {
+    it('renders copy button for transaction hash', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      expect(
+        screen.getByRole('button', { name: /copy transaction hash/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders copy button for contract address', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      expect(
+        screen.getByRole('button', { name: /copy contract address/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders copy button for token address', () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      expect(
+        screen.getByRole('button', { name: /copy token address/i })
+      ).toBeInTheDocument();
+    });
+
+    it('copies transaction hash to clipboard on click', async () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      const btn = screen.getByRole('button', { name: /copy transaction hash/i });
+      fireEvent.click(btn);
+      await waitFor(() =>
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('abc123txhash')
+      );
+    });
+
+    it('copies contract address to clipboard on click', async () => {
+      render(<ClaimReceipt claim={fullClaim} />);
+      const btn = screen.getByRole('button', { name: /copy contract address/i });
+      fireEvent.click(btn);
+      await waitFor(() =>
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('CCONTRACTADDRESS')
+      );
+    });
+  });
+
+  describe('full receipt copy', () => {
+    it('copies full receipt text when Copy button is clicked', async () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      const copyBtn = screen.getByTitle('Copy to clipboard');
+      fireEvent.click(copyBtn);
+      await waitFor(() =>
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+          expect.stringContaining('claim-123')
+        )
+      );
+    });
+
+    it('shows "Copied" feedback after copying', async () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      const copyBtn = screen.getByTitle('Copy to clipboard');
+      fireEvent.click(copyBtn);
+      await waitFor(() => expect(screen.getByText('Copied')).toBeInTheDocument());
+    });
+  });
+
+  describe('compact mode', () => {
+    it('renders package id in compact mode', () => {
+      render(<ClaimReceipt claim={baseClaim} compact />);
+      expect(screen.getByText('pkg-abc')).toBeInTheDocument();
+    });
+
+    it('does not render action buttons in compact mode', () => {
+      render(<ClaimReceipt claim={baseClaim} compact />);
+      expect(screen.queryByTitle('Copy to clipboard')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('share callback', () => {
+    it('calls onShare when Share button is clicked', async () => {
+      const onShare = jest.fn().mockResolvedValue(undefined);
+      render(<ClaimReceipt claim={baseClaim} onShare={onShare} />);
+      const shareBtn = screen.getByTitle('Share receipt');
+      fireEvent.click(shareBtn);
+      await waitFor(() => expect(onShare).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe('download', () => {
+    it('renders Download button', () => {
+      render(<ClaimReceipt claim={baseClaim} />);
+      expect(screen.getByTitle('Download receipt')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #589

Improves the claim receipt page with direct Stellar explorer links and per-field copy controls as specified in the issue.

## Changes

### `ClaimReceipt.tsx`
- Added `FieldCopyButton` component: inline copy button with transient ✓ feedback for individual fields
- Token address, contract address, and transaction hash fields each have their own copy button alongside the explorer link
- Explorer links were already present — retained and tested

### `claim-receipt/page.tsx`
- Fixed `handleShare` to include `window.location.href` as the `url` field in the Web Share API call
- Added clipboard fallback when Web Share API is unavailable

## Tests
- 20 new tests in `ClaimReceipt.test.tsx` covering:
  - Basic rendering (claim id, package id, status, amount, timestamp)
  - Explorer links for tx hash, contract address, token address
  - Per-field copy buttons render and copy correct values
  - Full receipt copy with Copied feedback
  - Compact mode, share callback, download button
- Full suite: **106 tests passing** (was 86)
- Type-check: clean
- Lint: 0 new issues (24 pre-existing in other files)