### PR TITLE
Feat: theme

### DIFF
--- a/app/frontend/src/app/[locale]/campaigns/page.tsx
+++ b/app/frontend/src/app/[locale]/campaigns/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState, useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { AppEmptyState } from '@/components/empty-state/AppEmptyState';
 import { ExportControls } from '@/components/dashboard/ExportControls';
 import { useCampaigns, useCreateCampaign } from '@/hooks/useCampaigns';
-import { useCampaignAction, useCampaignActions } from '@/hooks/useOptimisticCampaignMutations';
+import { useCampaignAction } from '@/hooks/useOptimisticCampaignMutations';
 import { InlineFeedback, OptimisticStatusBadge } from '@/components/InlineFeedback';
 import {
   canManageCampaigns,
@@ -14,14 +14,6 @@ import {
   getUserRoleLabel,
 } from '@/lib/user-role';
 import type { CampaignStatus } from '@/types/campaign';
-
-const statusStyles: Record<CampaignStatus, string> = {
-  draft: 'bg-gray-100 text-gray-800',
-  active: 'bg-green-100 text-green-800',
-  paused: 'bg-yellow-100 text-yellow-800',
-  completed: 'bg-blue-100 text-blue-800',
-  archived: 'bg-red-100 text-red-800',
-};
 
 function toCampaignStatus(value: string): CampaignStatus | '' {
   const map: Record<string, CampaignStatus> = {
@@ -38,7 +30,6 @@ function toCampaignStatus(value: string): CampaignStatus | '' {
 }
 
 export default function CampaignsPage() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const urlStatus = searchParams.get('status') ?? '';
   const userRole = getUserRole();
@@ -52,22 +43,6 @@ export default function CampaignsPage() {
   const [token, setToken] = useState('USDC');
   const [expiry, setExpiry] = useState('');
   const [formMessage, setFormMessage] = useState<string | null>(null);
-
-  function updateParam(key: string, value: string) {
-    const params = new URLSearchParams(searchParams.toString());
-    if (value) params.set(key, value);
-    else params.delete(key);
-    router.replace(`?${params.toString()}`, { scroll: false });
-  }
-
-  const handleApplyPreset = useCallback(
-    (preset: { status?: string | '' }) => {
-      const params = new URLSearchParams();
-      if (preset.status) params.set('status', preset.status);
-      router.replace(params.size ? `?${params.toString()}` : '?', { scroll: false });
-    },
-    [router],
-  );
 
   const activeCampaignStatus = toCampaignStatus(urlStatus);
 
@@ -153,14 +128,14 @@ export default function CampaignsPage() {
       <main className="container mx-auto space-y-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-4xl font-bold">NGO Campaigns</h1>
-          <span className="text-sm text-gray-500">Role: {userRoleLabel}</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Role: {userRoleLabel}</span>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
             <h2 className="mb-4 text-xl font-semibold">Create New Campaign</h2>
             {formMessage && (
-              <div className="mb-4 rounded-md border bg-gray-50 p-3 text-sm text-gray-700 dark:bg-gray-800 dark:text-gray-200">
+              <div className="mb-4 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200">
                 {formMessage}
               </div>
             )}
@@ -170,7 +145,7 @@ export default function CampaignsPage() {
                 <input
                   value={name}
                   onChange={event => setName(event.target.value)}
-                  className="mt-1 w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
                   placeholder="e.g. Winter Relief 2026"
                   required
                 />
@@ -183,7 +158,7 @@ export default function CampaignsPage() {
                   min="0"
                   value={budget}
                   onChange={event => setBudget(event.target.value)}
-                  className="mt-1 w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
                   placeholder="e.g. 25000"
                   required
                 />
@@ -194,7 +169,7 @@ export default function CampaignsPage() {
                 <input
                   value={token}
                   onChange={event => setToken(event.target.value)}
-                  className="mt-1 w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500"
                   placeholder="e.g. USDC"
                 />
               </label>
@@ -205,7 +180,7 @@ export default function CampaignsPage() {
                   type="date"
                   value={expiry}
                   onChange={event => setExpiry(event.target.value)}
-                  className="mt-1 w-full rounded-lg border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100"
                 />
               </label>
 
@@ -268,17 +243,17 @@ export default function CampaignsPage() {
                     <div className="flex items-start justify-between gap-2">
                       <div>
                         <h3 className="text-lg font-semibold">{campaign.name}</h3>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           Budget:{' '}
                           {campaign.budget.toLocaleString('en-US', {
                             style: 'currency',
                             currency: 'USD',
                           })}
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           Token: {campaign.metadata?.token ?? 'N/A'}
                         </p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
                           Expiry:{' '}
                           {campaign.metadata?.expiry
                             ? new Date(campaign.metadata.expiry as string).toLocaleDateString()
@@ -301,7 +276,13 @@ export default function CampaignsPage() {
                       {campaignAction.isPending && campaignAction.variables?.id === campaign.id ? (
                         <InlineFeedback
                           isPending={true}
-                          action={campaignAction.variables?.action.type === 'pause' ? 'pausing' : campaignAction.variables?.action.type === 'resume' ? 'resuming' : 'archiving' as any}
+                          action={
+                            campaignAction.variables?.action.type === 'pause'
+                              ? 'pausing'
+                              : campaignAction.variables?.action.type === 'resume'
+                                ? 'resuming'
+                                : 'archiving'
+                          }
                         />
                       ) : (
                         <>
@@ -309,7 +290,7 @@ export default function CampaignsPage() {
                             type="button"
                             onClick={() => onPauseResume(campaign.id, campaign.name, campaign.status)}
                             disabled={campaignAction.isPending}
-                            className="rounded-md border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800"
+                            className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
                           >
                             {campaign.status === 'active' ? 'Pause' : 'Resume'}
                           </button>
@@ -317,7 +298,7 @@ export default function CampaignsPage() {
                             type="button"
                             onClick={() => onArchive(campaign.id, campaign.name)}
                             disabled={campaignAction.isPending || campaign.status === 'archived'}
-                            className="rounded-md border border-red-400 px-3 py-1 text-sm text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+                            className="rounded-md border border-red-400 px-3 py-1 text-sm text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-900/20"
                           >
                             Archive
                           </button>

--- a/app/frontend/src/app/[locale]/claim-receipt/page.tsx
+++ b/app/frontend/src/app/[locale]/claim-receipt/page.tsx
@@ -11,13 +11,13 @@ export default function ClaimReceiptPage() {
   const claimId = searchParams.get('claimId');
 
   const [claim, setClaim] = useState<ClaimReceiptData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(Boolean(claimId));
+  const [error, setError] = useState<string | null>(
+    claimId ? null : 'Claim ID not provided',
+  );
 
   useEffect(() => {
     if (!claimId) {
-      setError('Claim ID not provided');
-      setLoading(false);
       return;
     }
 
@@ -162,7 +162,7 @@ export default function ClaimReceiptPage() {
 
             {/* Support Information */}
             <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-              <h3 className="font-semibold text-blue-900 dark:text-blue-100 mb-2">
+              <h3 className="font-semibold text-slate-950 dark:text-blue-100 mb-2">
                 Need help?
               </h3>
               <p className="text-blue-800 dark:text-blue-200 text-sm">

--- a/app/frontend/src/app/[locale]/page.tsx
+++ b/app/frontend/src/app/[locale]/page.tsx
@@ -10,7 +10,7 @@ export default async function Home({ params }: PageProps) {
   return (
     <main className="container mx-auto px-4 py-16 grow">
       <div className="max-w-4xl mx-auto text-center space-y-8">
-        <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-blue-900 dark:text-white">
+        <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-slate-950 dark:text-white">
           Soter
         </h1>
         <p className="text-xl md:text-2xl text-gray-900 dark:text-gray-400">
@@ -41,13 +41,13 @@ export default async function Home({ params }: PageProps) {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-16">
           <div className="p-6 rounded-lg border border-gray-200 dark:border-gray-800 text-left">
-            <h3 className="text-lg font-semibold mb-2 text-blue-900 dark:text-white">Direct Aid Claims</h3>
+            <h3 className="text-lg font-semibold mb-2 text-slate-950 dark:text-white">Direct Aid Claims</h3>
             <p className="text-gray-600 dark:text-gray-400 text-sm">
               Wallet-based, passwordless claiming—no accounts required.
             </p>
           </div>
           <div className="p-6 rounded-lg border border-gray-200 dark:border-gray-800 text-left">
-            <h3 className="text-lg font-semibold mb-2 text-blue-900 dark:text-white">
+            <h3 className="text-lg font-semibold mb-2 text-slate-950 dark:text-white">
               AI Need Verification
             </h3>
             <p className="text-gray-600 dark:text-gray-400 text-sm">
@@ -55,7 +55,7 @@ export default async function Home({ params }: PageProps) {
             </p>
           </div>
           <div className="p-6 rounded-lg border border-gray-200 dark:border-gray-800 text-left">
-            <h3 className="text-lg font-semibold mb-2 text-blue-900 dark:text-white">
+            <h3 className="text-lg font-semibold mb-2 text-slate-950 dark:text-white">
               Immutable Transparency
             </h3>
             <p className="text-gray-600 dark:text-gray-400 text-sm">

--- a/app/frontend/src/app/globals.css
+++ b/app/frontend/src/app/globals.css
@@ -2,12 +2,15 @@
 
 @import "leaflet/dist/leaflet.css";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #111827;
   --nav-background: #ffffff;
-  --nav-foreground: #171717;
+  --nav-foreground: #111827;
   --nav-border: #e5e7eb;
+  color-scheme: light;
 }
 
 html.dark {
@@ -16,25 +19,16 @@ html.dark {
   --nav-background: #1e293b;
   --nav-foreground: #f1f5f9;
   --nav-border: #334155;
+  color-scheme: dark;
 }
 
 html.light {
   --background: #ffffff;
-  --foreground: #1e3a8a; /* Changed from blue-800 to blue-900 */
+  --foreground: #111827;
   --nav-background: #ffffff;
-  --nav-foreground: #1e3a8a; /* Changed from blue-800 to blue-900 */
+  --nav-foreground: #111827;
   --nav-border: #e5e7eb;
-}
-
-/* Force Navbar background to white in light theme, overriding any conflicts */
-html.light nav {
-  background-color: #ffffff !important;
-  color: var(--nav-foreground) !important;
-}
-
-/* Force body text color in light theme, overriding any conflicts */
-html.light body {
-  color: var(--foreground) !important;
+  color-scheme: light;
 }
 @theme inline {
   --color-background: var(--background);
@@ -47,6 +41,156 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+html.dark [class~="text-gray-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-gray-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-800"]:not([class*="dark:text-"]) {
+  color: #f8fafc;
+}
+
+html.dark [class~="text-gray-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-gray-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-gray-500"]:not([class*="dark:text-"]),
+html.dark [class~="text-gray-400"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-500"]:not([class*="dark:text-"]),
+html.dark [class~="text-slate-400"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-500"]:not([class*="dark:text-"]),
+html.dark [class~="text-neutral-400"]:not([class*="dark:text-"]) {
+  color: #cbd5e1;
+}
+
+html.dark [class~="text-blue-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-blue-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-blue-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-blue-600"]:not([class*="dark:text-"]) {
+  color: #93c5fd;
+}
+
+html.dark [class~="text-green-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-green-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-green-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-green-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-emerald-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-emerald-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-emerald-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-emerald-600"]:not([class*="dark:text-"]) {
+  color: #86efac;
+}
+
+html.dark [class~="text-yellow-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-yellow-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-yellow-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-yellow-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-amber-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-amber-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-amber-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-amber-600"]:not([class*="dark:text-"]) {
+  color: #fde68a;
+}
+
+html.dark [class~="text-red-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-red-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-red-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-red-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-red-500"]:not([class*="dark:text-"]),
+html.dark [class~="text-rose-900"]:not([class*="dark:text-"]),
+html.dark [class~="text-rose-800"]:not([class*="dark:text-"]),
+html.dark [class~="text-rose-700"]:not([class*="dark:text-"]),
+html.dark [class~="text-rose-600"]:not([class*="dark:text-"]),
+html.dark [class~="text-rose-500"]:not([class*="dark:text-"]) {
+  color: #fca5a5;
+}
+
+html.dark [class~="bg-white"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-gray-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-slate-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-neutral-50"]:not([class*="dark:bg-"]) {
+  background-color: #111827;
+}
+
+html.dark [class~="bg-gray-100"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-slate-100"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-neutral-100"]:not([class*="dark:bg-"]) {
+  background-color: #1f2937;
+}
+
+html.dark [class~="bg-blue-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-blue-100"]:not([class*="dark:bg-"]) {
+  background-color: rgba(30, 58, 138, 0.45);
+}
+
+html.dark [class~="bg-green-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-green-100"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-emerald-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-emerald-100"]:not([class*="dark:bg-"]) {
+  background-color: rgba(6, 78, 59, 0.45);
+}
+
+html.dark [class~="bg-yellow-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-yellow-100"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-amber-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-amber-100"]:not([class*="dark:bg-"]) {
+  background-color: rgba(120, 53, 15, 0.45);
+}
+
+html.dark [class~="bg-red-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-red-100"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-rose-50"]:not([class*="dark:bg-"]),
+html.dark [class~="bg-rose-100"]:not([class*="dark:bg-"]) {
+  background-color: rgba(127, 29, 29, 0.45);
+}
+
+html.dark [class~="border-gray-100"]:not([class*="dark:border-"]),
+html.dark [class~="border-gray-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-gray-300"]:not([class*="dark:border-"]),
+html.dark [class~="border-slate-100"]:not([class*="dark:border-"]),
+html.dark [class~="border-slate-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-slate-300"]:not([class*="dark:border-"]),
+html.dark [class~="border-neutral-100"]:not([class*="dark:border-"]),
+html.dark [class~="border-neutral-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-neutral-300"]:not([class*="dark:border-"]) {
+  border-color: #334155;
+}
+
+html.dark [class~="border-blue-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-blue-300"]:not([class*="dark:border-"]) {
+  border-color: #1d4ed8;
+}
+
+html.dark [class~="border-green-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-emerald-200"]:not([class*="dark:border-"]) {
+  border-color: #047857;
+}
+
+html.dark [class~="border-yellow-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-amber-200"]:not([class*="dark:border-"]) {
+  border-color: #92400e;
+}
+
+html.dark [class~="border-red-200"]:not([class*="dark:border-"]),
+html.dark [class~="border-red-400"]:not([class*="dark:border-"]),
+html.dark [class~="border-rose-200"]:not([class*="dark:border-"]) {
+  border-color: #b91c1c;
+}
+
+html.dark :where(input, textarea, select):not([class*="dark:text-"]) {
+  color: #f8fafc;
+}
+
+html.dark :where(input, textarea, select):not([class*="dark:bg-"]) {
+  background-color: #111827;
+}
+
+html.dark :where(input, textarea, select)::placeholder {
+  color: #94a3b8;
 }
 
 /* Global default focus-visible ring — ensures any interactive element that

--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import type { Metadata } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
-import { notFound } from 'next/navigation';
 import './globals.css';
 import { QueryProvider } from '@/lib/query-provider';
 import { Navbar } from '@/components/Navbar';
@@ -11,7 +10,6 @@ import { ThemeProvider } from '@/components/ThemeProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { MisconfiguredPage } from '@/components/MisconfiguredPage';
 import { validateEnv } from '@/lib/env';
-import { locales } from '@/i18n';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -58,7 +56,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen bg-white text-blue-900 dark:bg-slate-950 dark:text-slate-50`}
+        className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col bg-background text-foreground antialiased`}
       >
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider>

--- a/app/frontend/src/app/theme-contrast.test.ts
+++ b/app/frontend/src/app/theme-contrast.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('theme contrast CSS guardrails', () => {
+  const sourceRoot = path.join(process.cwd(), 'src');
+  const globalsCss = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/globals.css'),
+    'utf8',
+  );
+
+  it('sets color-scheme for both themes', () => {
+    expect(globalsCss).toContain('color-scheme: light');
+    expect(globalsCss).toContain('color-scheme: dark');
+  });
+
+  it('binds Tailwind dark variants to the theme class, not the OS preference', () => {
+    expect(globalsCss).toContain(
+      '@custom-variant dark (&:where(.dark, .dark *));',
+    );
+  });
+
+  it('provides dark-mode fallbacks for light-only text, background, and border utilities', () => {
+    expect(globalsCss).toContain('[class~="text-gray-500"]:not([class*="dark:text-"])');
+    expect(globalsCss).toContain('[class~="bg-white"]:not([class*="dark:bg-"])');
+    expect(globalsCss).toContain('[class~="border-gray-200"]:not([class*="dark:border-"])');
+  });
+
+  it('uses near-black foreground colors in light mode', () => {
+    expect(globalsCss).toContain('--foreground: #111827;');
+    expect(globalsCss).toContain('--nav-foreground: #111827;');
+  });
+
+  it('does not pair dark white text with blue light-mode text for headings/navigation', () => {
+    const source = readSourceFiles(sourceRoot).join('\n');
+
+    expect(source).not.toContain('text-blue-900 dark:text-white');
+    expect(source).not.toContain('text-blue-900 dark:text-slate-50');
+  });
+});
+
+function readSourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const absolute = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      return readSourceFiles(absolute);
+    }
+
+    if (!/\.(tsx?|css)$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) {
+      return [];
+    }
+
+    return fs.readFileSync(absolute, 'utf8');
+  });
+}

--- a/app/frontend/src/components/AidPackageList.tsx
+++ b/app/frontend/src/components/AidPackageList.tsx
@@ -12,12 +12,12 @@ const STATUS_STYLES: Record<AidPackageStatus, string> = {
 
 function PackageCard({ pkg }: { pkg: AidPackage }) {
   return (
-    <div className="p-4 border rounded-lg shadow-sm bg-white dark:bg-gray-800 dark:border-gray-700">
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="flex justify-between items-start">
         <div>
-          <h4 className="font-medium">{pkg.title}</h4>
-          <p className="text-sm text-gray-500">ID: {pkg.id}</p>
-          <p className="text-sm text-gray-500">{pkg.region}</p>
+          <h4 className="font-medium text-gray-900 dark:text-gray-100">{pkg.title}</h4>
+          <p className="text-sm text-gray-500 dark:text-gray-400">ID: {pkg.id}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{pkg.region}</p>
         </div>
         <span className={`px-2 py-1 text-xs rounded-full ${STATUS_STYLES[pkg.status]}`}>
           {pkg.status}
@@ -32,28 +32,28 @@ export const AidPackageList: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="p-4 border rounded-lg bg-gray-50 dark:bg-gray-900 animate-pulse">
-        <div className="h-4 bg-gray-200 rounded w-1/3 mb-2"></div>
-        <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+      <div className="animate-pulse rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-900">
+        <div className="mb-2 h-4 w-1/3 rounded bg-gray-200 dark:bg-gray-800" />
+        <div className="h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-800" />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-4 border border-red-200 rounded-lg bg-red-50 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
         Error loading packages: {error.message}
       </div>
     );
   }
 
   if (packages.length === 0) {
-    return <div className="text-gray-500">No aid packages found.</div>;
+    return <div className="text-gray-500 dark:text-gray-400">No aid packages found.</div>;
   }
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">Available Aid Packages</h3>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Available Aid Packages</h3>
       <div className="grid gap-4 md:grid-cols-2">
         {packages.map(pkg => (
           <PackageCard key={pkg.id} pkg={pkg} />

--- a/app/frontend/src/components/InlineFeedback.tsx
+++ b/app/frontend/src/components/InlineFeedback.tsx
@@ -30,7 +30,7 @@ export function InlineFeedback({
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-2 text-sm text-gray-500',
+        'inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400',
         className
       )}
       role="status"
@@ -62,11 +62,11 @@ export function OptimisticStatusBadge({
   isOptimistic?: boolean;
 }) {
   const statusStyles: Record<string, string> = {
-    draft: 'bg-gray-100 text-gray-800',
-    active: 'bg-green-100 text-green-800',
-    paused: 'bg-yellow-100 text-yellow-800',
-    completed: 'bg-blue-100 text-blue-800',
-    archived: 'bg-red-100 text-red-800',
+    draft: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+    active: 'bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-300',
+    paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-300',
+    completed: 'bg-blue-100 text-blue-800 dark:bg-blue-950/40 dark:text-blue-300',
+    archived: 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300',
   };
 
   return (

--- a/app/frontend/src/components/Navbar.tsx
+++ b/app/frontend/src/components/Navbar.tsx
@@ -43,10 +43,6 @@ export function Navbar() {
     ? `${publicKey.substring(0, 6)}...${publicKey.substring(publicKey.length - 6)}`
     : null;
 
-  useEffect(() => {
-    setIsOpen(false);
-  }, [pathname]);
-
   /** Return focus to the toggle button when the mobile menu closes. */
   useEffect(() => {
     if (!didMountRef.current) {
@@ -59,7 +55,7 @@ export function Navbar() {
   }, [isOpen]);
 
   return (
-    <nav className="border-b border-slate-200 bg-white p-4 text-blue-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50">
+    <nav className="border-b border-slate-200 bg-white p-4 text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-50">
       <div className="container mx-auto flex items-center justify-between gap-4">
         <div className="flex items-center gap-6">
           <Link href="/" className="text-xl font-bold">
@@ -77,8 +73,8 @@ export function Navbar() {
                   aria-current={isActive ? 'page' : undefined}
                   className={`${linkBaseClassName} ${
                     isActive
-                      ? 'bg-blue-100 text-blue-900 dark:bg-slate-800 dark:text-slate-50'
-                      : 'text-slate-600 hover:bg-slate-100 hover:text-blue-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50'
+                      ? 'bg-blue-100 text-slate-950 dark:bg-slate-800 dark:text-slate-50'
+                      : 'text-slate-700 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50'
                   }`}
                 >
                   {t(item.label)}
@@ -137,9 +133,10 @@ export function Navbar() {
                     key={item.href}
                     href={item.href}
                     aria-current={isActive ? 'page' : undefined}
+                    onClick={() => setIsOpen(false)}
                     className={`rounded-2xl border px-4 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
                       isActive
-                        ? 'border-blue-200 bg-blue-50 text-blue-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-50'
+                        ? 'border-blue-200 bg-blue-50 text-slate-950 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-50'
                         : 'border-slate-200 text-slate-700 dark:border-slate-700 dark:text-slate-200'
                     }`}
                   >

--- a/app/frontend/src/components/ThemeToggle.tsx
+++ b/app/frontend/src/components/ThemeToggle.tsx
@@ -2,10 +2,41 @@
 
 import * as React from 'react';
 import { useTheme } from 'next-themes';
-import { MoonIcon, SunIcon } from '@heroicons/react/24/solid'; // Example icons
+import {
+  ComputerDesktopIcon,
+  MoonIcon,
+  SunIcon,
+} from '@heroicons/react/24/solid';
+
+type ThemeMode = 'system' | 'light' | 'dark';
+
+const THEME_OPTIONS = [
+  {
+    value: 'system',
+    label: 'System',
+    ariaLabel: 'Use system theme preference',
+    Icon: ComputerDesktopIcon,
+  },
+  {
+    value: 'light',
+    label: 'Light',
+    ariaLabel: 'Use light theme',
+    Icon: SunIcon,
+  },
+  {
+    value: 'dark',
+    label: 'Dark',
+    ariaLabel: 'Use dark theme',
+    Icon: MoonIcon,
+  },
+] as const;
+
+function normalizeTheme(theme?: string): ThemeMode {
+  return theme === 'light' || theme === 'dark' ? theme : 'system';
+}
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = React.useState(false);
 
   // The mounted guard avoids a client/server theme mismatch during hydration.
@@ -19,31 +50,56 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <button
-        className="p-2 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950 focus-visible:ring-blue-500 dark:focus-visible:ring-blue-400"
-        aria-label="Toggle theme (loading)"
-        disabled
+      <div
+        className="inline-flex rounded-lg border border-slate-200 bg-white p-0.5 text-slate-500 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300"
+        aria-label="Theme preference loading"
+        aria-disabled="true"
       >
-        <div className="h-5 w-5 bg-slate-300 dark:bg-slate-600 rounded-full animate-pulse"></div>
-      </button>
+        {THEME_OPTIONS.map(option => (
+          <span
+            key={option.value}
+            className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs font-medium opacity-60"
+          >
+            <option.Icon className="h-4 w-4 animate-pulse" aria-hidden="true" />
+            <span>{option.label}</span>
+          </span>
+        ))}
+      </div>
     );
   }
 
-  const handleToggle = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
-  };
+  const currentTheme = normalizeTheme(theme);
 
   return (
-    <button
-      onClick={handleToggle}
-      className="p-2 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950 focus-visible:ring-blue-500 dark:focus-visible:ring-blue-400"
-      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    <div
+      role="group"
+      aria-label="Theme preference"
+      className="inline-flex rounded-lg border border-slate-200 bg-white p-0.5 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      data-theme={currentTheme}
+      data-resolved-theme={resolvedTheme}
     >
-      {theme === 'dark' ? (
-        <SunIcon className="h-5 w-5 text-yellow-400" />
-      ) : (
-        <MoonIcon className="h-5 w-5 text-blue-300" />
-      )}
-    </button>
+      {THEME_OPTIONS.map(option => {
+        const isActive = currentTheme === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setTheme(option.value)}
+            aria-label={option.ariaLabel}
+            aria-pressed={isActive}
+            title={option.ariaLabel}
+            className={`inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-slate-950 ${
+              isActive
+                ? 'bg-blue-600 text-white shadow-sm dark:bg-blue-500 dark:text-white'
+                : 'text-slate-600 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white'
+            }`}
+          >
+            <option.Icon className="h-4 w-4" aria-hidden="true" />
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/app/frontend/src/components/__tests__/ThemeProvider.test.tsx
+++ b/app/frontend/src/components/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../ThemeProvider';
+import { ThemeToggle } from '../ThemeToggle';
+
+let mockTheme = 'system';
+let mockResolvedTheme = 'dark';
+const mockSetTheme = jest.fn();
+
+jest.mock('next-themes', () => {
+  const actualReact = jest.requireActual<typeof import('react')>('react');
+
+  return {
+    ThemeProvider: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+      actualReact.createElement(
+        'div',
+        {
+          'data-testid': 'next-themes-provider',
+          'data-attribute': props.attribute,
+          'data-default-theme': props.defaultTheme,
+          'data-enable-system': String(props.enableSystem),
+          'data-enable-color-scheme': String(props.enableColorScheme),
+        },
+        children,
+      ),
+    useTheme: () => ({
+      theme: mockTheme,
+      resolvedTheme: mockResolvedTheme,
+      setTheme: mockSetTheme,
+    }),
+  };
+});
+
+describe('ThemeProvider', () => {
+  it('follows the system color scheme by default', () => {
+    render(
+      <ThemeProvider>
+        <span>content</span>
+      </ThemeProvider>,
+    );
+
+    const provider = screen.getByTestId('next-themes-provider');
+    expect(provider).toHaveAttribute('data-attribute', 'class');
+    expect(provider).toHaveAttribute('data-default-theme', 'system');
+    expect(provider).toHaveAttribute('data-enable-system', 'true');
+    expect(provider).toHaveAttribute('data-enable-color-scheme', 'true');
+  });
+});
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    mockTheme = 'system';
+    mockResolvedTheme = 'dark';
+    mockSetTheme.mockClear();
+
+    window.requestAnimationFrame = callback => {
+      callback(0);
+      return 1;
+    };
+    window.cancelAnimationFrame = jest.fn();
+  });
+
+  it('renders explicit system, light, and dark theme controls', async () => {
+    render(<ThemeToggle />);
+
+    expect(
+      await screen.findByRole('group', { name: 'Theme preference' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Use system theme preference' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: 'Use light theme' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Use dark theme' }),
+    ).toBeInTheDocument();
+  });
+
+  it('lets the user override the theme directly', async () => {
+    render(<ThemeToggle />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Use light theme' }),
+    );
+    expect(mockSetTheme).toHaveBeenLastCalledWith('light');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use dark theme' }));
+    expect(mockSetTheme).toHaveBeenLastCalledWith('dark');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Use system theme preference' }),
+    );
+    expect(mockSetTheme).toHaveBeenLastCalledWith('system');
+  });
+});


### PR DESCRIPTION
Closes #603 

## Summary

This PR fixes light/dark theme rendering issues, adds a usable theme switcher, and improves local development behavior so the backend no longer requires Redis unless Redis-backed features are explicitly enabled.

## Changes

- Added `System`, `Light`, and `Dark` theme controls.
- Fixed Tailwind dark mode so `dark:` styles follow the `.dark` class instead of the OS preference when the user overrides theme mode.
- Improved light-mode contrast so dark-theme white text does not remain white on light backgrounds.
- Added global dark-mode fallback styles for common text/background/border utilities.
