### PR TITLE
✨ Add OpenAPI examples to speed up integration and contributor onboar…

### DIFF
--- a/app/ai-service/api/v1/proof_of_life.py
+++ b/app/ai-service/api/v1/proof_of_life.py
@@ -17,21 +17,55 @@ router = APIRouter(tags=["proof-of-life"])
 class ProofOfLifeRequest(BaseModel):
     """Request model for proof-of-life selfie and optional burst frames."""
 
-    selfie_image_base64: str
-    burst_images_base64: Optional[List[str]] = None
-    confidence_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    selfie_image_base64: str = Field(examples=["iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="])
+    burst_images_base64: Optional[List[str]] = Field(None, examples=[["iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="]])
+    confidence_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0, examples=[0.8])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "selfie_image_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                    "confidence_threshold": 0.8,
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                }
+            ]
+        }
+    }
 
 
 class ProofOfLifeResponse(BaseModel):
     """Response model for proof-of-life analysis."""
 
-    is_real_person: bool
-    confidence: float
-    threshold: float
-    checks: Dict[str, Any]
-    reason: str
+    is_real_person: bool = Field(examples=[True])
+    confidence: float = Field(examples=[0.95])
+    threshold: float = Field(examples=[0.8])
+    checks: Dict[str, Any] = Field(examples=[{"face_detected": True, "liveness_check": "passed"}])
+    reason: str = Field(examples=["Liveness verification passed"])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "is_real_person": True,
+                    "confidence": 0.95,
+                    "threshold": 0.8,
+                    "checks": {"face_detected": True, "liveness_check": "passed"},
+                    "reason": "Liveness verification passed",
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                },
+                {
+                    "is_real_person": False,
+                    "confidence": 0.2,
+                    "threshold": 0.8,
+                    "checks": {"face_detected": False},
+                    "reason": "No face detected in image"
+                }
+            ]
+        }
+    }
 
 
 @router.post("/ai/proof-of-life", response_model=ProofOfLifeResponse)

--- a/app/ai-service/schemas/anonymization.py
+++ b/app/ai-service/schemas/anonymization.py
@@ -5,21 +5,53 @@ from schemas.common import AnchorMetadata
 
 
 class AnonymizeRequest(BaseModel):
-    text: str = Field(min_length=1, description="Input text to anonymize before LLM processing")
+    text: str = Field(min_length=1, description="Input text to anonymize before LLM processing", examples=["John Doe from New York on 2024-01-01 requested aid"])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "text": "John Doe from New York on 2024-01-01 requested aid",
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                }
+            ]
+        }
+    }
 
 
 class PIISummary(BaseModel):
-    names: int
-    locations: int
-    dates: int
-    total: int
+    names: int = Field(examples=[1])
+    locations: int = Field(examples=[1])
+    dates: int = Field(examples=[1])
+    total: int = Field(examples=[3])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"names": 1, "locations": 1, "dates": 1, "total": 3}]
+        }
+    }
 
 
 class AnonymizeResponse(BaseModel):
-    success: bool
-    anonymized_text: str
-    original_length: int
+    success: bool = Field(examples=[True])
+    anonymized_text: str = Field(examples=["[NAME] from [LOCATION] on [DATE] requested aid"])
+    original_length: int = Field(examples=[50])
     pii_summary: PIISummary
-    token_counts: Dict[str, int] = Field(default_factory=dict)
+    token_counts: Dict[str, int] = Field(default_factory=dict, examples=[{"original": 10, "anonymized": 10}])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "success": True,
+                    "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
+                    "original_length": 50,
+                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                    "token_counts": {"original": 10, "anonymized": 10},
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                }
+            ]
+        }
+    }

--- a/app/ai-service/schemas/common.py
+++ b/app/ai-service/schemas/common.py
@@ -1,7 +1,18 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 class AnchorMetadata(BaseModel):
-    campaign_ref: Optional[str] = None
-    claim_id: Optional[str] = None
-    package_id: Optional[str] = None
+    campaign_ref: Optional[str] = Field(None, examples=["campaign-2024-001"])
+    claim_id: Optional[str] = Field(None, examples=["claim-abc123"])
+    package_id: Optional[str] = Field(None, examples=["package-x7y8z9"])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "campaign_ref": "campaign-2024-001",
+                    "claim_id": "claim-abc123"
+                }
+            ]
+        }
+    }

--- a/app/ai-service/schemas/errors.py
+++ b/app/ai-service/schemas/errors.py
@@ -1,12 +1,28 @@
 from typing import Any, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ErrorDetail(BaseModel):
-    code: str
-    message: str
-    details: Optional[Any] = None
+    code: str = Field(examples=["VALIDATION_ERROR", "HTTP_400"])
+    message: str = Field(examples=["Request validation failed"])
+    details: Optional[Any] = Field(None, examples=[{"field": "text", "msg": "field required"}])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"code": "VALIDATION_ERROR", "message": "Request validation failed", "details": [{"loc": ["body", "text"], "msg": "field required", "type": "value_error.missing"}]}
+            ]
+        }
+    }
 
 
 class ErrorEnvelope(BaseModel):
     error: ErrorDetail
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"error": {"code": "VALIDATION_ERROR", "message": "Request validation failed", "details": [{"loc": ["body", "text"], "msg": "field required", "type": "value_error.missing"}]}}
+            ]
+        }
+    }

--- a/app/ai-service/schemas/fraud.py
+++ b/app/ai-service/schemas/fraud.py
@@ -4,27 +4,78 @@ from schemas.common import AnchorMetadata
 
 
 class ClaimMetadata(BaseModel):
-    claim_id: str
-    ip_address: Optional[str] = None
-    evidence_hash: Optional[str] = None
-    amount: Optional[float] = None
-    location: Optional[str] = None
-    extra: Dict[str, Any] = Field(default_factory=dict)
+    claim_id: str = Field(examples=["claim-abc123"])
+    ip_address: Optional[str] = Field(None, examples=["192.168.1.1"])
+    evidence_hash: Optional[str] = Field(None, examples=["abc123def456"])
+    amount: Optional[float] = Field(None, examples=[100.0])
+    location: Optional[str] = Field(None, examples=["Kano, Nigeria"])
+    extra: Dict[str, Any] = Field(default_factory=dict, examples=[{"source": "mobile_app"}])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "claim_id": "claim-abc123",
+                    "ip_address": "192.168.1.1",
+                    "amount": 100.0,
+                    "location": "Kano, Nigeria"
+                }
+            ]
+        }
+    }
 
 
 class FraudDetectionRequest(BaseModel):
     claims: List[ClaimMetadata] = Field(min_length=1)
     anchor_metadata: Optional[AnchorMetadata] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "claims": [
+                        {"claim_id": "claim-abc123", "ip_address": "192.168.1.1", "amount": 100.0, "location": "Kano, Nigeria"},
+                        {"claim_id": "claim-def456", "ip_address": "192.168.1.2", "amount": 100.0, "location": "Kano, Nigeria"}
+                    ],
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001"}
+                }
+            ]
+        }
+    }
+
 
 class ClaimFraudResult(BaseModel):
-    claim_id: str
-    fraud_risk_score: float = Field(ge=0.0, le=1.0)
-    is_flagged: bool
-    reason: Optional[str] = None
+    claim_id: str = Field(examples=["claim-abc123"])
+    fraud_risk_score: float = Field(ge=0.0, le=1.0, examples=[0.15, 0.95])
+    is_flagged: bool = Field(examples=[False, True])
+    reason: Optional[str] = Field(None, examples=["Statistical outlier in amount"])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"claim_id": "claim-abc123", "fraud_risk_score": 0.15, "is_flagged": False},
+                {"claim_id": "claim-def456", "fraud_risk_score": 0.95, "is_flagged": True, "reason": "Statistical outlier in amount"}
+            ]
+        }
+    }
 
 
 class FraudDetectionResponse(BaseModel):
     results: List[ClaimFraudResult]
-    flagged_count: int
+    flagged_count: int = Field(examples=[1])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "results": [
+                        {"claim_id": "claim-abc123", "fraud_risk_score": 0.15, "is_flagged": False},
+                        {"claim_id": "claim-def456", "fraud_risk_score": 0.95, "is_flagged": True, "reason": "Statistical outlier in amount"}
+                    ],
+                    "flagged_count": 1,
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001"}
+                }
+            ]
+        }
+    }

--- a/app/ai-service/schemas/humanitarian.py
+++ b/app/ai-service/schemas/humanitarian.py
@@ -4,19 +4,53 @@ from schemas.common import AnchorMetadata
 
 
 class HumanitarianVerificationRequest(BaseModel):
-    aid_claim: str = Field(min_length=10, description="Aid claim to verify")
-    supporting_evidence: List[str] = Field(default_factory=list)
-    context_factors: Dict[str, Any] = Field(default_factory=dict)
-    provider_preference: Literal["auto", "test", "openai", "groq"] = "auto"
-    timeout: Optional[float] = Field(default=None, description="Request-level timeout in seconds for provider call")
+    aid_claim: str = Field(min_length=10, description="Aid claim to verify", examples=["Family of 5 displaced by flood needs food and shelter"])
+    supporting_evidence: List[str] = Field(default_factory=list, examples=[["photo of damaged home", "local report"]])
+    context_factors: Dict[str, Any] = Field(default_factory=dict, examples=[{"location": "Kano, Nigeria", "disaster_type": "flood"}])
+    provider_preference: Literal["auto", "test", "openai", "groq"] = Field("auto", examples=["auto"])
+    timeout: Optional[float] = Field(default=None, description="Request-level timeout in seconds for provider call", examples=[30.0])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "aid_claim": "Family of 5 displaced by flood needs food and shelter",
+                    "supporting_evidence": ["photo of damaged home"],
+                    "context_factors": {"location": "Kano, Nigeria", "disaster_type": "flood"},
+                    "provider_preference": "auto",
+                    "timeout": 30.0,
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                }
+            ]
+        }
+    }
 
 
 class HumanitarianVerificationResponse(BaseModel):
-    success: bool
-    provider: Optional[str] = None
-    model: Optional[str] = None
-    prompt_variant: Optional[str] = None
-    verification: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
+    success: bool = Field(examples=[True])
+    provider: Optional[str] = Field(None, examples=["test"])
+    model: Optional[str] = Field(None, examples=["gpt-4o"])
+    prompt_variant: Optional[str] = Field(None, examples=["v1"])
+    verification: Optional[Dict[str, Any]] = Field(None, examples=[{"eligible": True, "confidence": 0.9, "reasoning": "Claim meets humanitarian criteria"}])
+    error: Optional[str] = Field(None, examples=["Provider timed out"])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "success": True,
+                    "provider": "test",
+                    "model": "gpt-4o",
+                    "prompt_variant": "v1",
+                    "verification": {"eligible": True, "confidence": 0.9, "reasoning": "Claim meets humanitarian criteria"},
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                },
+                {
+                    "success": False,
+                    "error": "Provider timed out"
+                }
+            ]
+        }
+    }

--- a/app/ai-service/schemas/ocr.py
+++ b/app/ai-service/schemas/ocr.py
@@ -4,19 +4,61 @@ from schemas.common import AnchorMetadata
 
 
 class OCRFieldResult(BaseModel):
-    value: str
-    confidence: float = 0.0
+    value: str = Field(examples=["John Doe"])
+    confidence: float = Field(0.0, examples=[0.95])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"value": "John Doe", "confidence": 0.95}]
+        }
+    }
 
 
 class OCRData(BaseModel):
-    fields: dict[str, OCRFieldResult]
-    raw_text: str
-    processing_time_ms: int
+    fields: dict[str, OCRFieldResult] = Field(
+        examples=[{"full_name": {"value": "John Doe", "confidence": 0.95}, "id_number": {"value": "123456789", "confidence": 0.90}}]
+    )
+    raw_text: str = Field(examples=["John Doe\nID: 123456789"])
+    processing_time_ms: int = Field(examples=[1500])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "fields": {"full_name": {"value": "John Doe", "confidence": 0.95}, "id_number": {"value": "123456789", "confidence": 0.90}},
+                    "raw_text": "John Doe\nID: 123456789",
+                    "processing_time_ms": 1500
+                }
+            ]
+        }
+    }
 
 
 class OCRResponse(BaseModel):
-    success: bool
+    success: bool = Field(examples=[True])
     data: OCRData | None = None
-    error: dict[str, str] | None = None
-    processing_time_ms: int
+    error: dict[str, str] | None = Field(None, examples=[{"code": "invalid_image", "message": "Could not decode image"}])
+    processing_time_ms: int = Field(examples=[1500])
     anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "success": True,
+                    "data": {
+                        "fields": {"full_name": {"value": "John Doe", "confidence": 0.95}, "id_number": {"value": "123456789", "confidence": 0.90}},
+                        "raw_text": "John Doe\nID: 123456789",
+                        "processing_time_ms": 1500
+                    },
+                    "processing_time_ms": 1500,
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"}
+                },
+                {
+                    "success": False,
+                    "error": {"code": "invalid_image", "message": "Could not decode image"},
+                    "processing_time_ms": 500
+                }
+            ]
+        }
+    }

--- a/app/ai-service/schemas/uploads.py
+++ b/app/ai-service/schemas/uploads.py
@@ -10,43 +10,103 @@ from pydantic import BaseModel, Field
 class CreateUploadSessionRequest(BaseModel):
     """Request body for starting a new resumable upload session."""
 
-    filename: str = Field(..., min_length=1, max_length=255)
-    content_type: str = Field(..., min_length=1)
-    total_size: int = Field(..., gt=0, description="Total file size in bytes")
-    total_chunks: int = Field(..., gt=0, description="Number of chunks to be sent")
+    filename: str = Field(..., min_length=1, max_length=255, examples=["evidence_photo.jpg"])
+    content_type: str = Field(..., min_length=1, examples=["image/jpeg"])
+    total_size: int = Field(..., gt=0, description="Total file size in bytes", examples=[1048576])
+    total_chunks: int = Field(..., gt=0, description="Number of chunks to be sent", examples=[10])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "filename": "evidence_photo.jpg",
+                    "content_type": "image/jpeg",
+                    "total_size": 1048576,
+                    "total_chunks": 10
+                }
+            ]
+        }
+    }
 
 
 class UploadSessionResponse(BaseModel):
     """Current state of an upload session."""
 
-    session_id: str
-    filename: str
-    content_type: str
-    total_size: int
-    total_chunks: int
-    received_chunks: List[int]
-    status: str
-    expires_at: float
-    completed: bool = False
-    artifact_id: Optional[str] = None
+    session_id: str = Field(examples=["sess_abc123def456"])
+    filename: str = Field(examples=["evidence_photo.jpg"])
+    content_type: str = Field(examples=["image/jpeg"])
+    total_size: int = Field(examples=[1048576])
+    total_chunks: int = Field(examples=[10])
+    received_chunks: List[int] = Field(examples=[[0, 1, 2]])
+    status: str = Field(examples=["in_progress"])
+    expires_at: float = Field(examples=[1719784800.0])
+    completed: bool = Field(False, examples=[False])
+    artifact_id: Optional[str] = Field(None, examples=["art_xyz789"])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "session_id": "sess_abc123def456",
+                    "filename": "evidence_photo.jpg",
+                    "content_type": "image/jpeg",
+                    "total_size": 1048576,
+                    "total_chunks": 10,
+                    "received_chunks": [0, 1, 2],
+                    "status": "in_progress",
+                    "expires_at": 1719784800.0,
+                    "completed": False
+                }
+            ]
+        }
+    }
 
 
 class ChunkUploadResponse(BaseModel):
     """Result of uploading a single chunk."""
 
-    session_id: str
-    chunk_index: int
-    received_chunks: List[int]
-    remaining_chunks: int
-    status: str
+    session_id: str = Field(examples=["sess_abc123def456"])
+    chunk_index: int = Field(examples=[3])
+    received_chunks: List[int] = Field(examples=[[0, 1, 2, 3]])
+    remaining_chunks: int = Field(examples=[6])
+    status: str = Field(examples=["in_progress"])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "session_id": "sess_abc123def456",
+                    "chunk_index": 3,
+                    "received_chunks": [0, 1, 2, 3],
+                    "remaining_chunks": 6,
+                    "status": "in_progress"
+                }
+            ]
+        }
+    }
 
 
 class FinalizeUploadResponse(BaseModel):
     """Result of finalizing an assembled upload."""
 
-    session_id: str
-    artifact_id: str
-    filename: str
-    content_type: str
-    total_size: int
-    status: str
+    session_id: str = Field(examples=["sess_abc123def456"])
+    artifact_id: str = Field(examples=["art_xyz789"])
+    filename: str = Field(examples=["evidence_photo.jpg"])
+    content_type: str = Field(examples=["image/jpeg"])
+    total_size: int = Field(examples=[1048576])
+    status: str = Field(examples=["completed"])
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "session_id": "sess_abc123def456",
+                    "artifact_id": "art_xyz789",
+                    "filename": "evidence_photo.jpg",
+                    "content_type": "image/jpeg",
+                    "total_size": 1048576,
+                    "status": "completed"
+                }
+            ]
+        }
+    }


### PR DESCRIPTION
his PR adds comprehensive OpenAPI examples to all API schemas including:

- AnchorMetadata examples in all requests/responses
- Success case examples
- Error case examples (like 422 validation errors)
  This will make Swagger UI much more user-friendly for contributors and integrators! 🎉
Changes made :

- Added model_config with json_schema_extra.examples to all schemas
- Added Field(examples=[...]) to individual fields

closes #620