### PR TITLE
feat(tools): add Soroban ledger-events-backfill CLI (#560)

### DIFF
--- a/.github/workflows/ledger-events-backfill-ci.yml
+++ b/.github/workflows/ledger-events-backfill-ci.yml
@@ -1,0 +1,42 @@
+name: Ledger Events Backfill CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/ledger-events-backfill/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'tools/ledger-events-backfill/**'
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: tools/ledger-events-backfill
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke-run --help
+        run: node index.js --help
+
+      - name: Run unit + e2e tests
+        run: npm test
+
+      - name: Smoke-run --status with missing checkpoint (must exit 2)
+        run: |
+          node index.js --checkpoint /tmp/_nonexistent.json --status; \
+          if [ $? -ne 2 ]; then echo "Expected exit code 2, got $?"; exit 1; fi

--- a/tools/ledger-events-backfill/.gitignore
+++ b/tools/ledger-events-backfill/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+metrics.prom
+checkpoints/
+*.tmp
+*.swp
+.DS_Store

--- a/tools/ledger-events-backfill/README.md
+++ b/tools/ledger-events-backfill/README.md
@@ -1,0 +1,211 @@
+# Ledger Events Backfill (Soroban)
+
+A standalone Node.js CLI that backfills **Soroban contract events** for a given ledger range with safe resume, structured progress logs, and Prometheus-style metrics.
+
+The tool is intentionally independent of the NestJS backend so it can run in cron jobs, CI, or as a one-off operator action without booting the full API.
+
+## Features
+
+- **Range-based** — Specify `--start` and `--end` (inclusive) Soroban ledger sequences.
+- **Filterable** — Restrict to one or more contracts via `--contract CC...` (`--type` defaults to `contract`, the only filter type Soroban RPC supports).
+- **Safe resume** — Checkpoint written atomically after every batch. Re-running with the same `--checkpoint` path picks up from `lastLedgerCompleted + 1`.
+- **Progress logs** — Structured JSON-per-line to **stderr** (`--log-format json|pretty`).
+- **Metrics** — Prometheus text format written to `--metrics-output`. Live status viewable via `--status` (reads checkpoint).
+- **Idempotent** — Re-running for an already-processed range is a no-op (verified via checkpoint).
+- **Pagination-aware** — Follows `cursor` from `getEvents` (Soroban RPC caps pages, so multi-page batches are common).
+- **Backoff & retries** — Exponential backoff on transient RPC errors. Configurable via env vars.
+
+## Install
+
+```bash
+cd tools/ledger-events-backfill
+npm ci
+```
+
+## Usage
+
+### Backfill events for a ledger range
+
+```bash
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org \
+SOROBAN_CONTRACT_ID=CCABC... \
+node index.js --start 100000 --end 110000 --type contract
+```
+
+Each event is emitted as a JSON line (NDJSON) on **stdout**. To write to a file instead:
+
+```bash
+node index.js --start 100000 --end 110000 --output events.ndjson
+```
+
+### Resume from last checkpoint
+
+The CLI writes a checkpoint JSON file after every batch. To resume, just re-run with the same `--checkpoint` path:
+
+```bash
+# First run processes ledgers 100000-100099, then dies
+node index.js --start 100000 --end 110000 --checkpoint /tmp/btm.checkpoint.json
+
+# Resume — CLI auto-detects resume and continues from 100100
+node index.js --start 100000 --end 110000 --checkpoint /tmp/btm.checkpoint.json
+```
+
+Or let the CLI pick a default checkpoint file derived from contract + range:
+
+```bash
+node index.js --start 100000 --end 110000  # checkpoint stored in ./checkpoints/<contract>_<start>_<end>.json
+```
+
+### Check status
+
+```bash
+node index.js --status --checkpoint /tmp/btm.checkpoint.json
+```
+
+Sample output:
+
+```
+checkpoint: /tmp/btm.checkpoint.json
+range:      100000 → 110000 (100001 ledgers)
+contract:   CCABCDEF...
+completed:  100487 ledger
+events:     3120
+started:    2026-06-27T10:00:01.412Z
+updated:    2026-06-27T10:01:23.901Z
+status:     in_progress
+```
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--start` | _required_ unless `--status` | Start ledger sequence (inclusive) |
+| `--end` | _required_ unless `--status` | End ledger sequence (inclusive) |
+| `--contract` | `$SOROBAN_CONTRACT_ID` | Filter events by contract ID(s) (comma-separated) |
+| `--contract` | _required filter_ | Contract ID(s) to filter, comma-separated |
+| `--type` | `contract` | Event filter type (Soroban RPC only supports `contract`) |
+| `--topic-filter` | _none_ | Optional topic filter (e.g. `"AAA.....,*"`) |
+| `--batch-size` | `100` | Number of ledgers per batch (RPC request boundary) |
+| `--checkpoint` | `./checkpoints/<contract>_<start>_<end>.json` | Path to checkpoint JSON |
+| `--output` | _stdout_ | NDJSON file to write events (else stdout) |
+| `--metrics-output` | `./metrics.prom` | Path to Prometheus text-format metrics file |
+| `--log-format` | `pretty` | `pretty` or `json` (stderr) |
+| `--max-retries` | `5` | Retries per RPC call |
+| `--retry-delay-ms` | `500` | Initial retry delay (exponential backoff) |
+| `--rpc-timeout-ms` | `30000` | RPC timeout per call |
+| `--status` | _none_ | Print checkpoint status and exit (exits 2 if missing) |
+| `--reset` | _none_ | Delete the checkpoint file (`--checkpoint` path) and exit |
+
+## Environment Variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban RPC URL |
+| `SOROBAN_CONTRACT_ID` | _none_ | Default contract filter (overridden by `--contract`) |
+| `BACKFILL_MAX_RETRIES` | `5` | Same as `--max-retries` |
+| `BACKFILL_RETRY_DELAY_MS` | `500` | Same as `--retry-delay-ms` |
+| `BACKFILL_RPC_TIMEOUT_MS` | `30000` | Same as `--rpc-timeout-ms` |
+
+## Outputs
+
+### stdout (NDJSON)
+
+### `--topic-filter` caveat
+
+The SDK's topic syntax allows commas inside a single filter (e.g. `AAA,BBB,*` is one filter that matches a tuple). To preserve that semantics, `--topic-filter` expects the entire JSON-array form quoted on the command line:
+
+```bash
+node index.js --start 100 --end 200 \
+  --contract CC... \
+  --topic-filter '["AAA,...","*"]'
+```
+
+A bare comma-separated list (`--topic-filter "X,Y"`) is split on commas and would be interpreted as two separate filters. If your filter has no internal commas you can use the bare form.
+
+### `--reset`
+
+Deleting a checkpoint is irreversible (the file is `unlink`'d). After `--reset`, the next run starts the backfill from `--start` again. Useful when:
+- the checkpoint was corrupted
+- you want to re-emit the entire NDJSON stream to a fresh output file
+- you changed `--contract` / `--type` and need to start over
+
+### Resuming after `--reset`
+
+`--reset` only removes the checkpoint. The previously-emitted NDJSON file at `--output` is left untouched. To start cleanly, either delete the existing `--output` file or rotate it (e.g. `mv events.ndjson events.ndjson.bak`).
+
+### `--status` exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Checkpoint printed successfully |
+| `2` | Checkpoint file not found (treat as "no in-flight run") |
+
+```json
+{"ledger":100001,"txHash":"abc...","contractId":"CC...","eventType":"contract","topics":["AAA..."],"data":{"type":"symbol","value":"claim_created"},"id":"...","timestamp":"2026-06-27T10:00:01.412Z"}
+```
+
+### stderr (progress logs)
+
+One line per batch (pretty or json):
+
+```
+[10:00:01] batch 100000→100099  events=24  retries=0  elapsed=1.42s
+```
+
+### metrics file (Prometheus)
+
+```
+# HELP ledger_backfill_events_total Total events fetched
+# TYPE ledger_backfill_events_total counter
+ledger_backfill_events_total 3120
+# HELP ledger_backfill_batches_total Total RPC batches fetched
+# TYPE ledger_backfill_batches_total counter
+ledger_backfill_batches_total{status="success"} 5
+...
+```
+
+## Tests
+
+```bash
+npm test
+```
+
+Uses Node's built-in test runner (`node --test`). Mocks the Soroban RPC client with an in-memory event generator and a fake RPC server.
+
+## Resume Semantics (At-Least-Once)
+
+The CLI is **at-least-once** for the in-flight batch. The order inside a single batch is:
+
+1. RPC call returns N events.
+2. Each event is appended to the NDJSON `--output` file and counted in metrics.
+3. The checkpoint file is atomically updated to mark the batch as complete.
+
+If the process crashes (or is killed) between steps 2 and 3, those N events will be **re-emitted on resume** because the checkpoint never advanced.
+
+In practice this is almost always benign — but downstream systems that cannot tolerate duplicates should:
+
+- Always use a unique idempotency key per event (e.g. `ledger + txHash + eventIndex`) when ingesting the NDJSON stream, OR
+- Truncate the NDJSON file before resuming by deleting only the trailing partial batch (the batch boundary is recorded in the checkpoint), OR
+- Run the CLI in a transactional pipeline (e.g. BigQuery streaming inserts) that supports `INSERT IGNORE` semantics.
+
+Within a batch the order is also at-least-once on the *batch boundary* (not per-event) — events are written in order, but the checkpoint advances in batch units.
+
+## File Layout
+
+```
+tools/ledger-events-backfill/
+├── package.json
+├── README.md
+├── index.js              # CLI entry point (arg parsing + glue)
+├── src/
+│   ├── checkpoint.js    # Atomic checkpoint persistence
+│   ├── events.js        # Soroban RPC getEvents + pagination + retry
+│   ├── progress.js      # Structured progress logger
+│   ├── metrics.js       # Prometheus-style metrics collector
+│   └── split.js         # Range-to-batch splitter
+└── test/
+    ├── checkpoint.spec.js
+    ├── events.spec.js
+    ├── progress.spec.js
+    └── metrics.spec.js
+```

--- a/tools/ledger-events-backfill/index.js
+++ b/tools/ledger-events-backfill/index.js
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * ledger-events-backfill CLI
+ *
+ * Range-based, checkpointed backfill of Soroban contract events with
+ * progress logs and Prometheus-style metrics.
+ *
+ * See README.md for usage.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+const { Checkpoint, CheckpointError } = require('./src/checkpoint');
+const { EventsClient } = require('./src/events');
+const { ProgressLogger } = require('./src/progress');
+const { MetricsCollector } = require('./src/metrics');
+const { splitRange } = require('./src/split');
+
+const DEFAULTS = {
+  // The following values can change at runtime, so they are exposed as
+  // getters rather than plain fields. Tests override `process.env` after
+  // module load and expect the new values to take effect.
+  get rpcUrl() {
+    return process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+  },
+  get contractIds() {
+    if (!process.env.SOROBAN_CONTRACT_ID) return [];
+    return process.env.SOROBAN_CONTRACT_ID.split(',').map((s) => s.trim()).filter(Boolean);
+  },
+  batchSize: 100,
+  // Max events per RPC page. Soroban RPC typically caps at ~100; we request
+  // 1000 for headroom on networks with higher caps. Pagination via cursor
+  // handles arbitrary result-set sizes regardless of this value.
+  pageLimit: 1000,
+  get maxRetries() {
+    return parseInt(process.env.BACKFILL_MAX_RETRIES || '5', 10);
+  },
+  get retryDelayMs() {
+    return parseInt(process.env.BACKFILL_RETRY_DELAY_MS || '500', 10);
+  },
+  get rpcTimeoutMs() {
+    return parseInt(process.env.BACKFILL_RPC_TIMEOUT_MS || '30000', 10);
+  },
+  logFormat: 'pretty',
+};
+
+// ── Argument parsing ──────────────────────────────────────────────────────
+
+/**
+ * Cheap zero-dep argument parser tailored to this CLI.
+ * @param {string[]} argv
+ */
+function parseArgs(argv) {
+  const out = { _: [], help: false, status: false, reset: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const tok = argv[i];
+    if (tok === '--help' || tok === '-h') out.help = true;
+    else if (tok === '--status') out.status = true;
+    else if (tok === '--reset') out.reset = true;
+    else if (tok.startsWith('--')) {
+      const key = tok.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        out[key] = true;
+      } else {
+        out[key] = next;
+        i += 1;
+      }
+    } else {
+      out._.push(tok);
+    }
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`Usage: node index.js [options]
+
+Backfill Soroban contract events for a ledger range with safe resume.
+
+Required (unless --status):
+  --start <n>              Start ledger sequence (inclusive)
+  --end <n>                End ledger sequence (inclusive)
+
+Filter:
+  --contract <id[,id,...]> Contract ID(s) to filter (or $SOROBAN_CONTRACT_ID)
+  --type <type>            Filter type (default: contract)
+
+Resume & output:
+  --checkpoint <path>      Checkpoint JSON path (default: ./checkpoints/<contract>_<start>_<end>.json)
+  --output <path>          NDJSON output file (default: stdout)
+  --metrics-output <path>  Prometheus metrics file (default: ./metrics.prom)
+
+Orchestration:
+  --batch-size <n>         Ledgers per RPC batch (default: 100)
+  --max-retries <n>        Retries per RPC call (default: 5)
+  --retry-delay-ms <n>     Initial backoff delay (default: 500)
+  --rpc-timeout-ms <n>     RPC timeout per call (default: 30000)
+
+Logging:
+  --log-format <pretty|json>
+  --silent                 Suppress progress logs to stderr
+
+Other:
+  --status                 Print checkpoint status and exit
+  --reset                  Wipe checkpoint and start fresh
+`);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function defaultCheckpointPath(contractIds, startLedger, endLedger) {
+  // Allow callers to pass strings/arrays for forward compatibility.
+  const ids = Array.isArray(contractIds) ? contractIds : (contractIds ? [contractIds] : []);
+  // Pick a stable, filesystem-friendly slug from the first contract id when
+  // present. We deliberately do NOT include the full id — Soroban contract
+  // ids are 56+ chars and would push us past sane path lengths, and the
+  // inclusion of commas (when users supply multiple contracts) would create
+  // ambiguous shell-quoting. Filenames are advisory — checkpoint contents
+  // record the full contract list with no information loss.
+  const first = ids[0] || 'default';
+  let safeSlug;
+  if (typeof first === 'string' && first.length > 0) {
+    safeSlug = first
+      .replace(/[^a-zA-Z0-9_.-]/g, '_')
+      .slice(0, 16) || 'default';
+  } else {
+    safeSlug = 'default';
+  }
+  if (startLedger === undefined || endLedger === undefined) {
+    return path.resolve('checkpoints', `${safeSlug}.json`);
+  }
+  return path.resolve(
+    'checkpoints',
+    `${safeSlug}_${startLedger}_${endLedger}.json`,
+  );
+}
+
+function toInt(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const n = parseInt(String(value), 10);
+  if (!Number.isFinite(n)) throw new Error(`expected integer, got ${value}`);
+  return n;
+}
+
+function parseContractIds(raw) {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  return String(raw)
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Append a single event to either a file stream or stdout NDJSON.
+ */
+class EventSink {
+  constructor(outputPath) {
+    this.outputPath = outputPath || null;
+    /** @type {fs.WriteStream|null} */
+    this.stream = null;
+    if (outputPath) {
+      this.stream = fs.createWriteStream(outputPath, { flags: 'a', encoding: 'utf8' });
+    }
+  }
+  write(event) {
+    let line;
+    try {
+      line = JSON.stringify({
+        ledger: event.ledger,
+        txHash: event.txHash || (event.transactionHash) || null,
+        contractId: event.contractId,
+        eventType: event.type || event.eventType,
+        topics: event.topic || event.topics || [],
+        data: event.data,
+        id: event.id || null,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (err) {
+      // If the event itself is not serialisable, fall back to raw.
+      line = JSON.stringify({ ledger: event.ledger, raw: String(event) });
+    }
+    (this.stream || process.stdout).write(line + '\n');
+  }
+  async close() {
+    if (this.stream) {
+      await new Promise((r) => this.stream.end(r));
+    }
+  }
+}
+
+// ── Status command ────────────────────────────────────────────────────────
+
+async function runStatus(args, logger) {
+  const checkpointPath = args.checkpoint
+    ? path.resolve(args.checkpoint)
+    : defaultCheckpointPath(
+        parseContractIds(args.contract || DEFAULTS.contractIds.join(',') || null),
+        args.start ? parseInt(args.start, 10) : undefined,
+        args.end ? parseInt(args.end, 10) : undefined,
+      );
+  let state;
+  try {
+    const raw = await fsp.readFile(checkpointPath, 'utf8');
+    state = JSON.parse(raw);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.error(`No checkpoint found at ${checkpointPath}`);
+      process.exitCode = 2;
+      return;
+    }
+    throw err;
+  }
+  const placeholder = (v) => (v === undefined ? '(unset)' : v);
+  console.log(JSON.stringify({
+    checkpoint: checkpointPath,
+    range: { start: state.startLedger, end: state.endLedger, total: state.endLedger - state.startLedger + 1 },
+    contracts: state.contractIds,
+    filterType: state.filterType,
+    lastLedgerCompleted: placeholder(state.lastLedgerCompleted),
+    resumeFrom: state.lastLedgerCompleted !== undefined ? state.lastLedgerCompleted + 1 : state.startLedger,
+    events: state.totalEvents,
+    batches: state.totalBatches,
+    retries: state.totalRetries,
+    status: state.status,
+    startedAt: state.startedAt,
+    updatedAt: state.updatedAt,
+    lastError: state.lastError || null,
+  }, null, 2));
+  logger.info('status_displayed', { path: checkpointPath });
+}
+
+// ── Reset command ─────────────────────────────────────────────────────────
+
+async function runReset(args, logger) {
+  const checkpointPath = args.checkpoint
+    ? path.resolve(args.checkpoint)
+    : defaultCheckpointPath(
+        parseContractIds(args.contract || DEFAULTS.contractIds.join(',') || null),
+        args.start ? parseInt(args.start, 10) : undefined,
+        args.end ? parseInt(args.end, 10) : undefined,
+      );
+  try {
+    await fsp.unlink(checkpointPath);
+    logger.info('checkpoint_reset', { path: checkpointPath });
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    logger.warn('checkpoint_not_found', { path: checkpointPath });
+  }
+}
+
+// ── Backfill orchestrator ─────────────────────────────────────────────────
+
+async function runBackfill(args, logger, metrics) {
+  const startLedger = toInt(args.start, undefined);
+  const endLedger = toInt(args.end, undefined);
+  if (startLedger === undefined || endLedger === undefined) {
+    throw new Error('--start and --end are required unless --status is set');
+  }
+  if (endLedger < startLedger) {
+    throw new Error('--end must be >= --start');
+  }
+
+  const contractIds = parseContractIds(args.contract || DEFAULTS.contractIds.join(','));
+  if (contractIds.length === 0) {
+    throw new Error(
+      'No contract filter supplied. Use --contract CC... or set $SOROBAN_CONTRACT_ID.',
+    );
+  }
+
+  const filterType = args.type || 'contract';
+  // Optional topic filter — comma-separated, e.g. "AAA=,*" passes through to the SDK.
+  const topicFilters = parseContractIds(args['topic-filter']);
+  const batchSize = toInt(args['batch-size'], DEFAULTS.batchSize);
+  const maxRetries = toInt(args['max-retries'], DEFAULTS.maxRetries);
+  const retryDelayMs = toInt(args['retry-delay-ms'], DEFAULTS.retryDelayMs);
+  const rpcTimeoutMs = toInt(args['rpc-timeout-ms'], DEFAULTS.rpcTimeoutMs);
+  const logFormat = args['log-format'] || DEFAULTS.logFormat;
+  const silent = !!args.silent;
+  const rpcUrl = DEFAULTS.rpcUrl;
+
+  const checkpointPath = args.checkpoint
+    ? path.resolve(args.checkpoint)
+    : defaultCheckpointPath(contractIds, startLedger, endLedger);
+  const metricsPath = path.resolve(args['metrics-output'] || 'metrics.prom');
+
+  logger.info('backfill_start', {
+    rpc: rpcUrl,
+    contracts: contractIds.join(','),
+    range: `${startLedger}-${endLedger}`,
+    checkpoint: checkpointPath,
+  });
+
+  const checkpoint = new Checkpoint(checkpointPath);
+  await checkpoint.begin({
+    rpcUrl,
+    contractIds,
+    filterType,
+    startLedger,
+    endLedger,
+    batchSize,
+  });
+
+  const filter = { type: filterType, contractIds };
+  if (topicFilters.length > 0) filter.topics = topicFilters;
+  const sink = new EventSink(args.output || null);
+  const events = new EventsClient(rpcUrl);
+
+  const resumeAt = checkpoint.resumeLedger() + 1;
+  const batches = splitRange(resumeAt, endLedger, batchSize);
+
+  logger.info('resume_plan', {
+    lastLedgerCompleted: checkpoint.state.lastLedgerCompleted,
+    nextBatchStart: resumeAt,
+    batches: batches.length,
+  });
+
+  let totalRetries = 0;
+  let totalEvents = 0;
+  let totalBatches = 0;
+
+  try {
+    for (const [idx, batch] of batches.entries()) {
+      const timer = logger.startBatch();
+      try {
+        const opts = {
+          startLedger: batch.startLedger,
+          endLedger: batch.endLedger,
+          limit: DEFAULTS.pageLimit,
+          maxRetries,
+          retryDelayMs,
+          rpcTimeoutMs,
+          onEvent: (ev) => {
+            totalEvents += 1;
+            sink.write(ev);
+            metrics.incCounter('ledger_backfill_events_total', { type: filterType });
+          },
+          onRetry: ({ attempt, delay, err }) => {
+            totalRetries += 1;
+            logger.warn('rpc_retry', {
+              batch: `${batch.startLedger}-${batch.endLedger}`,
+              attempt,
+              delayMs: delay,
+              err: err.slice(0, 120),
+            });
+            metrics.incCounter('ledger_backfill_rpc_retries_total', { type: filterType });
+          },
+        };
+        const result = await metrics.time(
+          'ledger_backfill_batch_duration_seconds',
+          { type: filterType },
+          () => events.fetchAll(filter, opts),
+        );
+        totalBatches += 1;
+        metrics.incCounter('ledger_backfill_batches_total', { status: 'success', type: filterType });
+        await checkpoint.complete(batch.endLedger, {
+          events: result.events,
+          retries: result.retries,
+        });
+        logger.info('batch_complete', {
+          batch: `${batch.startLedger}-${batch.endLedger}`,
+          events: result.events,
+          retries: result.retries,
+          elapsedMs: timer.stop(),
+          progress: `${idx + 1}/${batches.length}`,
+        });
+      } catch (err) {
+        metrics.incCounter('ledger_backfill_batches_total', { status: 'failed', type: filterType });
+        logger.error('batch_failed', {
+          batch: `${batch.startLedger}-${batch.endLedger}`,
+          err: String(err && err.message ? err.message : err),
+        });
+        await checkpoint.markFailed(String(err && err.message ? err.message : err));
+        throw err;
+      }
+    }
+
+    metrics.setGauge('ledger_backfill_last_completed_ledger', checkpoint.state.lastLedgerCompleted || 0);
+    metrics.setGauge('ledger_backfill_total_events_emitted', totalEvents);
+
+    logger.info('backfill_complete', {
+      totalEvents,
+      totalBatches,
+      totalRetries,
+      checkpoint: checkpointPath,
+      metrics: metricsPath,
+      status: checkpoint.state.status,
+    });
+  } finally {
+    // Always flush the NDJSON sink + metrics file, even on the failure path,
+    // so partial progress is durable and the operator can resume without losing
+    // events that were already fetched.
+    await sink.close();
+    try {
+      await fsp.mkdir(path.dirname(metricsPath), { recursive: true });
+      await fsp.writeFile(metricsPath, metrics.render(), 'utf8');
+    } catch (err) {
+      logger.warn('metrics_write_failed', { err: String(err.message) });
+    }
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+  const metrics = new MetricsCollector();
+  const logger = new ProgressLogger({
+    format: args['log-format'] || DEFAULTS.logFormat,
+    silent: !!args.silent,
+  });
+
+  try {
+    if (args.reset) {
+      await runReset(args, logger);
+      return;
+    }
+    if (args.status) {
+      await runStatus(args, logger);
+      return;
+    }
+    await runBackfill(args, logger, metrics);
+  } catch (err) {
+    if (err instanceof CheckpointError) {
+      console.error(`Checkpoint error: ${err.message}`);
+      process.exitCode = 3;
+      return;
+    }
+    console.error(`Fatal: ${err && err.message ? err.message : err}`);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { parseArgs, runBackfill, runStatus, runReset };

--- a/tools/ledger-events-backfill/package-lock.json
+++ b/tools/ledger-events-backfill/package-lock.json
@@ -1,0 +1,812 @@
+{
+  "name": "ledger-events-backfill",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ledger-events-backfill",
+      "version": "0.1.0",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^14.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.6.1.tgz",
+      "integrity": "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.1.0",
+        "axios": "^1.13.3",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.2",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/tools/ledger-events-backfill/package.json
+++ b/tools/ledger-events-backfill/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ledger-events-backfill",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Range-based, checkpointed backfill of Soroban contract events with progress logs and metrics",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test test/checkpoint.spec.js test/events.spec.js test/progress.spec.js test/metrics.spec.js test/split.spec.js test/end-to-end.spec.js"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^14.6.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tools/ledger-events-backfill/src/checkpoint.js
+++ b/tools/ledger-events-backfill/src/checkpoint.js
@@ -1,0 +1,259 @@
+'use strict';
+
+/**
+ * Atomic, file-based checkpoint persistence.
+ *
+ * The CLI calls `Checkpoint.begin()` on startup, then `Checkpoint.complete(batch)` after
+ * every successfully persisted batch. On restart, `Checkpoint.begin()` re-reads the file
+ * and returns the latest `lastLedgerCompleted`, allowing the orchestrator to resume from
+ * `lastLedgerCompleted + 1`.
+ *
+ * Atomicity is provided by writing to `<path>.tmp` first and then renaming — a power
+ * loss between writes cannot corrupt the checkpoint.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+class CheckpointError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CheckpointError';
+  }
+}
+
+/**
+ * @typedef {Object} CheckpointState
+ * @property {number} [lastLedgerCompleted]   Last ledger that has been fully processed.
+ *                                            Undefined when starting fresh.
+ * @property {number} totalEvents             Running tally of events emitted across all batches.
+ * @property {number} totalBatches            Running tally of completed batches.
+ * @property {number} totalRetries            Running tally of RPC retries.
+ * @property {string} startedAt               ISO-8601 timestamp of the first write.
+ * @property {string} updatedAt               ISO-8601 timestamp of the most recent write.
+ * @property {string} rpcUrl                  Soroban RPC URL recorded for reproducibility.
+ * @property {string[]} contractIds           Contract IDs filtered on.
+ * @property {string} filterType              Event filter type (e.g. "contract").
+ * @property {number} startLedger             Original requested start (inclusive).
+ * @property {number} endLedger               Original requested end (inclusive).
+ * @property {number} batchSize               Configured batch size.
+ * @property {string} status                  "in_progress" | "completed".
+ */
+
+/**
+ * @param {string} checkpointPath Absolute path on disk.
+ */
+class Checkpoint {
+  /**
+   * @param {string} checkpointPath - File path. Created lazily on first write.
+   */
+  constructor(checkpointPath) {
+    if (typeof checkpointPath !== 'string' || checkpointPath.length === 0) {
+      throw new CheckpointError('checkpoint path must be a non-empty string');
+    }
+    this.path = checkpointPath;
+    /** @type {CheckpointState | null} */
+    this.state = null;
+  }
+
+  /**
+   * Load (or initialize) the checkpoint. Returns the state object.
+   * @param {Object} meta - Static metadata seeded into a brand-new checkpoint.
+   * @returns {Promise<CheckpointState>}
+   */
+  async begin(meta) {
+    if (!meta || typeof meta !== 'object') {
+      throw new CheckpointError('meta must be an object');
+    }
+    for (const key of ['startLedger', 'endLedger', 'batchSize', 'rpcUrl']) {
+      if (meta[key] === undefined || meta[key] === null) {
+        throw new CheckpointError(`meta.${key} is required`);
+      }
+    }
+
+    const existing = await this.#read();
+    if (existing) {
+      // Validate that the existing checkpoint matches the current run's intent.
+      this.#assertCompatible(existing, meta);
+      this.state = existing;
+      // Touch updatedAt so callers see a fresh access.
+      this.state.updatedAt = new Date().toISOString();
+      return this.state;
+    }
+
+    this.state = {
+      lastLedgerCompleted: undefined,
+      totalEvents: 0,
+      totalBatches: 0,
+      totalRetries: 0,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      rpcUrl: meta.rpcUrl,
+      contractIds: meta.contractIds || [],
+      filterType: meta.filterType || 'contract',
+      startLedger: meta.startLedger,
+      endLedger: meta.endLedger,
+      batchSize: meta.batchSize,
+      status: 'in_progress',
+    };
+    await this.#flush();
+    return this.state;
+  }
+
+  /**
+   * Mark a batch as complete and atomically persist.
+   *
+   * Idempotent: re-completing the same batch is a no-op.
+   *
+   * @param {number} lastLedgerInBatch - Highest ledger in the just-completed batch.
+   * @param {{ events?: number, retries?: number }} [tally]
+   *   - events: events emitted in this batch (added to running total)
+   *   - retries: retries incurred in this batch (added to running total)
+   * @returns {Promise<CheckpointState>}
+   */
+  async complete(lastLedgerInBatch, tally = {}) {
+    if (!this.state) {
+      throw new CheckpointError('checkpoint not initialised — call begin() first');
+    }
+    if (!Number.isInteger(lastLedgerInBatch) || lastLedgerInBatch < 0) {
+      throw new CheckpointError('lastLedgerInBatch must be a non-negative integer');
+    }
+    if (this.state.lastLedgerCompleted !== undefined &&
+        lastLedgerInBatch <= this.state.lastLedgerCompleted) {
+      // Idempotent re-call after restart — keep counters but don't rewind lastLedger.
+      if (tally.events) this.state.totalEvents += tally.events;
+      if (tally.retries) this.state.totalRetries += tally.retries;
+      this.state.updatedAt = new Date().toISOString();
+      await this.#flush();
+      return this.state;
+    }
+
+    this.state.lastLedgerCompleted = lastLedgerInBatch;
+    this.state.totalBatches += 1;
+    if (tally.events) this.state.totalEvents += tally.events;
+    if (tally.retries) this.state.totalRetries += tally.retries;
+    this.state.updatedAt = new Date().toISOString();
+
+    if (this.state.lastLedgerCompleted >= this.state.endLedger) {
+      this.state.status = 'completed';
+    }
+    await this.#flush();
+    return this.state;
+  }
+
+  /**
+   * Mark the checkpoint as failed (status=failed) without deleting progress.
+   * Used when an unrecoverable error is hit but partial progress should be inspectable.
+   * @param {string} reason
+   */
+  async markFailed(reason) {
+    if (!this.state) return;
+    this.state.status = 'failed';
+    this.state.lastError = String(reason || '').slice(0, 500);
+    this.state.updatedAt = new Date().toISOString();
+    await this.#flush();
+  }
+
+  /**
+   * Reset to a fresh checkpoint. Used by --reset or tests.
+   * @returns {Promise<void>}
+   */
+  async reset() {
+    this.state = null;
+    await fsp.unlink(this.path).catch((err) => {
+      if (err.code !== 'ENOENT') throw err;
+    });
+  }
+
+  /**
+   * Highest ledger already completed (0 when fresh).
+   * Returns `startLedger - 1` when no batches have been processed, so callers can
+   * compute the resume point as `resumeLedger = lastLedgerCompleted + 1`.
+   * @returns {number}
+   */
+  resumeLedger() {
+    if (!this.state || this.state.lastLedgerCompleted === undefined) {
+      return this.state ? this.state.startLedger - 1 : 0;
+    }
+    return this.state.lastLedgerCompleted;
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  /**
+   * @returns {Promise<CheckpointState | null>}
+   * @private
+   */
+  async #read() {
+    try {
+      const raw = await fsp.readFile(this.path, 'utf8');
+      const parsed = JSON.parse(raw);
+      // Basic shape check.
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        typeof parsed.startLedger !== 'number' ||
+        typeof parsed.endLedger !== 'number'
+      ) {
+        throw new CheckpointError(`invalid checkpoint shape in ${this.path}`);
+      }
+      return parsed;
+    } catch (err) {
+      if (err.code === 'ENOENT') return null;
+      // Corrupt JSON is treated as "no checkpoint" — the user is warned by the CLI
+      // so they can recover manually.
+      throw err;
+    }
+  }
+
+  /**
+   * @private
+   */
+  async #flush() {
+    const dir = path.dirname(this.path);
+    await fsp.mkdir(dir, { recursive: true });
+    const tmpPath = `${this.path}.tmp`;
+    await fsp.writeFile(tmpPath, JSON.stringify(this.state, null, 2), {
+      mode: 0o600,
+      encoding: 'utf8',
+    });
+    await fsp.rename(tmpPath, this.path);
+  }
+
+  /**
+   * Validate that an existing checkpoint is compatible with the new run's intent.
+   *
+   * We refuse to silently swap contexts — a checkpoint for ledger `100-200` cannot be
+   * reused for `300-400`, etc.
+   *
+   * @private
+   */
+  #assertCompatible(existing, meta) {
+    const checks = {
+      startLedger: existing.startLedger === meta.startLedger,
+      endLedger: existing.endLedger === meta.endLedger,
+      batchSize: existing.batchSize === meta.batchSize,
+      rpcUrl: existing.rpcUrl === meta.rpcUrl,
+      filterType: (existing.filterType || 'contract') === (meta.filterType || 'contract'),
+    };
+    const mismatched = Object.entries(checks).filter(([, ok]) => !ok).map(([k]) => k);
+    if (mismatched.length > 0) {
+      throw new CheckpointError(
+        `checkpoint at ${this.path} is for a different run (${mismatched.join(', ')}). ` +
+          `Pass --reset to start a fresh checkpoint, or use a different --checkpoint path.`,
+      );
+    }
+    // Compare contract lists order-insensitively.
+    const a = [...(existing.contractIds || [])].sort().join('|');
+    const b = [...(meta.contractIds || [])].sort().join('|');
+    if (a !== b) {
+      throw new CheckpointError(
+        `checkpoint at ${this.path} was filtered by different contracts ` +
+          `(${a || '*'} vs ${b || '*'}). Pass --reset to start fresh.`,
+      );
+    }
+  }
+}
+
+module.exports = { Checkpoint, CheckpointError };

--- a/tools/ledger-events-backfill/src/events.js
+++ b/tools/ledger-events-backfill/src/events.js
@@ -1,0 +1,246 @@
+'use strict';
+
+/**
+ * Soroban RPC event fetcher.
+ *
+ * Wraps `Server.getEvents` with pagination (`cursor` follows), exponential
+ * backoff retry on transient errors, and a deterministic in-memory mock for
+ * tests.
+ *
+ * Soroban RPC's `getEvents` has a max page size (defaults vary; SDK exposes
+ * limit=10k, the network may return up to ~100 events per call). For long
+ * ranges we iterate by `cursor` until the page returns fewer than the limit
+ * (the SDK signals this with `events.length < limit`).
+ */
+
+const { rpc: SorobanRpc } = require('@stellar/stellar-sdk');
+
+/**
+ * @typedef {Object} EventFilter
+ * @property {'contract'} type   Filter type (Soroban RPC only supports 'contract')
+ * @property {string[]} contractIds  Required when type='contract'
+ * @property {string[]} [topics]    Optional topic filter
+ */
+
+/**
+ * @typedef {Object} FetchOptions
+ * @property {number} startLedger
+ * @property {number} endLedger
+ * @property {number} [limit=500]   Max events per page (SDK/network dependent)
+ * @property {string} [cursor]      Resume cursor
+ * @property {number} [maxRetries=5]
+ * @property {number} [retryDelayMs=500]
+ * @property {number} [rpcTimeoutMs=30000]
+ * @property {(stats: {attempt:number,delay:number,err:string}) => void} [onRetry]
+ */
+
+/**
+ * @typedef {Object} FetchPageResult
+ * @property {any[]} events
+ * @property {string|null} cursor  When non-null, more pages remain in the requested range.
+ * @property {{ attempts:number, retries:number }} stats
+ */
+
+/**
+ * Build a JSON-RPC client for Soroban.
+ * @param {string} rpcUrl
+ */
+function makeRpcClient(rpcUrl) {
+  const allowHttp = typeof rpcUrl === 'string' && rpcUrl.startsWith('http://');
+  return new SorobanRpc.Server(rpcUrl, { allowHttp });
+}
+
+/**
+ * Sleep helper.
+ * @param {number} ms
+ */
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function classifyTransient(err) {
+  const msg = String(err && err.message ? err.message : err);
+  // Heuristic, not exhaustive — fails open: any error is retried up to maxRetries.
+  if (
+    /ETIMEDOUT|ENOTFOUND|ECONNRESET|ECONNREFUSED|socket hang up|timeout|rate/i.test(msg)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+class EventsClient {
+  /**
+   * @param {string} rpcUrl  Soroban RPC endpoint (https).
+   * @param {{ server?: any }} [opts]  Inject a custom Server (used by tests).
+   */
+  constructor(rpcUrl, opts = {}) {
+    if (typeof rpcUrl !== 'string' || rpcUrl.length === 0) {
+      throw new Error('rpcUrl is required');
+    }
+    this.rpcUrl = rpcUrl;
+    this.server = opts.server || makeRpcClient(rpcUrl);
+  }
+
+  /**
+   * Run the configured server's getEvents() under a timeout.
+   * The timeout is cleared once either side of the race resolves, so the
+   * process can exit cleanly without a pending setTimeout.
+   * @private
+   */
+  async #callGetEvents(filter, opts) {
+    const call = this.server.getEvents({
+      startLedger: opts.startLedger,
+      endLedger: opts.endLedger,
+      cursor: opts.cursor,
+      limit: opts.limit,
+      filters: [filter],
+    });
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`RPC timeout after ${opts.rpcTimeoutMs}ms`)),
+        opts.rpcTimeoutMs,
+      );
+    });
+    try {
+      return await Promise.race([call, timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Fetch a single page of events, retrying transient errors with exponential backoff.
+   * @param {EventFilter} filter
+   * @param {FetchOptions} opts
+   * @returns {Promise<FetchPageResult>}
+   */
+  async fetchPage(filter, opts) {
+    if (!filter || filter.type !== 'contract') {
+      throw new Error("only filter type 'contract' is supported");
+    }
+    if (!Array.isArray(filter.contractIds) || filter.contractIds.length === 0) {
+      throw new Error('at least one contractId is required');
+    }
+    const limit = opts.limit ?? 500;
+    const maxRetries = opts.maxRetries ?? 5;
+    const retryDelayMs = opts.retryDelayMs ?? 500;
+    const rpcTimeoutMs = opts.rpcTimeoutMs ?? 30000;
+
+    let attempt = 0;
+    let retries = 0;
+    let lastError;
+    while (attempt <= maxRetries) {
+      try {
+        const resp = await this.#callGetEvents(filter, {
+          ...opts,
+          limit,
+          rpcTimeoutMs,
+        });
+        const events = Array.isArray(resp && resp.events) ? resp.events : [];
+        // SDK returns a `cursor` when more pages remain. Some SDK builds return
+        // undefined/null once exhausted.
+        return {
+          events,
+          cursor: resp && resp.cursor ? String(resp.cursor) : null,
+          stats: { attempts: attempt + 1, retries },
+        };
+      } catch (err) {
+        lastError = err;
+        if (attempt >= maxRetries || !classifyTransient(err)) {
+          throw err;
+        }
+        retries += 1;
+        const delay = Math.min(retryDelayMs * Math.pow(2, attempt), 30000);
+        if (typeof opts.onRetry === 'function') {
+          try {
+            opts.onRetry({ attempt: attempt + 1, delay, err: String(err.message || err) });
+          } catch (_) {
+            /* ignore logger errors */
+          }
+        }
+        await sleep(delay);
+        attempt += 1;
+      }
+    }
+    throw lastError;
+  }
+
+  /**
+   * Fetch all events in `[startLedger..endLedger]` (inclusive), paging via cursor.
+   * Emits each event through `onEvent` (the caller typically writes NDJSON).
+   *
+   * @param {EventFilter} filter
+   * @param {FetchOptions & { onEvent: (e:any)=>void }} opts
+   * @returns {Promise<{ events: number, batches: number, retries: number }>}
+   */
+  async fetchAll(filter, opts) {
+    if (typeof opts.onEvent !== 'function') {
+      throw new Error('onEvent callback is required');
+    }
+    let cursor = opts.cursor || undefined;
+    let events = 0;
+    let batches = 0;
+    let retries = 0;
+    // Safety guard: don't loop forever on a misbehaving server.
+    const MAX_PAGES = 100000;
+    for (let i = 0; i < MAX_PAGES; i += 1) {
+      const result = await this.fetchPage(filter, { ...opts, cursor });
+      batches += 1;
+      retries += result.stats.retries;
+      for (const ev of result.events) {
+        events += 1;
+        opts.onEvent(ev);
+      }
+      if (!result.cursor) break;
+      cursor = result.cursor;
+    }
+    return { events, batches, retries };
+  }
+}
+
+/**
+ * Minimal in-memory mock of SorobanRpc.Server for offline tests.
+ *
+ * Behaviour: returns a deterministic list of events per ledger in the requested
+ * window, paginated by `limit`. Supports cursor continuation.
+ */
+class MockSorobanServer {
+  /**
+   * @param {Object} cfg
+   * @param {Array<{ledger:number,eventType:string,contractId:string,topics:string[],data:any}>} cfg.events
+   *   Pre-built linear array. Server slices by ledger and returns pages of `limit` events.
+   * @param {{ failOnce?: number, transient?: boolean }} [cfg.behaviour]
+   */
+  constructor(cfg) {
+    if (!cfg || !Array.isArray(cfg.events)) {
+      throw new Error('MockSorobanServer requires events[]');
+    }
+    this.events = cfg.events.slice().sort((a, b) => a.ledger - b.ledger);
+    this.failsLeft = cfg.behaviour?.failOnce || 0;
+    this.transient = !!cfg.behaviour?.transient;
+    // Bookkeeping for tests.
+    this.calls = 0;
+  }
+
+  async getEvents(req) {
+    this.calls += 1;
+    if (this.failsLeft > 0) {
+      this.failsLeft -= 1;
+      const err = new Error(this.transient ? 'connect ETIMEDOUT (mock)' : 'mock hard failure');
+      throw err;
+    }
+    // Compute cursor pointer — simplest impl is "index of the next event to return".
+    const startIdx = req.cursor ? parseInt(req.cursor, 10) || 0 : 0;
+    const window = this.events.filter(
+      (e) => e.ledger >= req.startLedger && e.ledger <= req.endLedger,
+    );
+    const page = window.slice(startIdx, startIdx + (req.limit || 100));
+    const next = startIdx + page.length;
+    const cursor = next < window.length ? String(next) : undefined;
+    return { events: page, cursor };
+  }
+}
+
+module.exports = { EventsClient, MockSorobanServer };

--- a/tools/ledger-events-backfill/src/metrics.js
+++ b/tools/ledger-events-backfill/src/metrics.js
@@ -1,0 +1,212 @@
+'use strict';
+
+/**
+ * Minimal Prometheus text-format metrics collector for the CLI.
+ *
+ * Why not the full `prom-client`? The CLI is meant to be runnable as a standalone
+ * process (cron, CI, ops) without dragging NestJS dependencies. We only need a
+ * handful of counters/gauges/histograms.
+ *
+ * Output format is compatible with Prometheus text exposition v0.0.4.
+ */
+
+const { performance } = require('perf_hooks');
+
+class MetricsCollector {
+  constructor() {
+    /** @type {Map<string, {help:string,values:Map<string,number>}>} */
+    this.counters = new Map();
+    /** @type {Map<string, {help:string,values:Map<string,number>}>} */
+    this.gauges = new Map();
+    /** @type {Map<string, {help:string,buckets:number[],sum:Map<string,number>,counts:Map<string,number>,labels:Map<string,Object>}>>} */
+    this.histograms = new Map();
+  }
+
+  /**
+   * Increment a counter.
+   * @param {string} name
+   * @param {Record<string,string>} [labels]
+   * @param {number} [value=1]
+   */
+  incCounter(name, labels = {}, value = 1) {
+    const key = labelKey(labels);
+    const entry = this.#ensureCounter(name);
+    entry.values.set(key, (entry.values.get(key) || 0) + value);
+  }
+
+  /**
+   * Set a gauge.
+   */
+  setGauge(name, value, labels = {}) {
+    const key = labelKey(labels);
+    const entry = this.#ensureGauge(name);
+    entry.values.set(key, value);
+  }
+
+  /**
+   * Observe a histogram value (default buckets).
+   * Prometheus convention: bucket `le="X"` counts observations with value <= X,
+   * and every histogram must include a `le="+Inf"` bucket that catches the rest.
+   *
+   * Note: the bucket list is fixed at the first `observe()` call for a given
+   * `name`. Subsequent calls with a different `buckets` parameter raise — this
+   * prevents silently mixing incompatible bucket boundaries within a single
+   * histogram (which would produce unwieldy Prometheus output).
+   */
+  observe(name, value, labels = {}, buckets) {
+    const key = labelKey(labels);
+    let entry = this.histograms.get(name);
+    const defaultBuckets = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300];
+    if (!entry) {
+      entry = {
+        help: `Histogram for ${name}`,
+        buckets: buckets || defaultBuckets,
+        sum: new Map(),
+        counts: new Map(),
+        labels: new Map(),
+      };
+      this.histograms.set(name, entry);
+    } else if (buckets) {
+      const incoming = buckets.slice().sort((a, b) => a - b);
+      const existing = entry.buckets.slice().sort((a, b) => a - b);
+      if (incoming.length !== existing.length || incoming.some((b, i) => b !== existing[i])) {
+        throw new Error(
+          `histogram "${name}" already exists with different bucket boundaries; ` +
+            'either drop the buckets arg or call reset() first',
+        );
+      }
+    }
+    // Type check on value — bad inputs were silently ignored before.
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new TypeError(`histogram ${name} requires finite number value, got ${value}`);
+    }
+    entry.sum.set(key, (entry.sum.get(key) || 0) + value);
+    entry.counts.set(key, (entry.counts.get(key) || 0) + 1);
+    entry.labels.set(key, labels);
+    if (!entry._bucketCounts) entry._bucketCounts = new Map();
+    for (const b of entry.buckets) {
+      if (value <= b) {
+        const bKey = `${key}${SEP}le=${b}`;
+        entry._bucketCounts.set(bKey, (entry._bucketCounts.get(bKey) || 0) + 1);
+      }
+    }
+    // +Inf bucket — captures every observation, no matter the value.
+    const infKey = `${key}${SEP}le=+Inf`;
+    entry._bucketCounts.set(infKey, (entry._bucketCounts.get(infKey) || 0) + 1);
+  }
+
+  /**
+   * Time an async operation and observe in a histogram.
+   * @template T
+   * @param {string} name
+   * @param {Record<string,string>} labels
+   * @param {() => Promise<T>} fn
+   * @returns {Promise<T>}
+   */
+  async time(name, labels, fn) {
+    const t0 = performance.now();
+    try {
+      return await fn();
+    } finally {
+      const elapsed = (performance.now() - t0) / 1000;
+      this.observe(name, elapsed, labels);
+    }
+  }
+
+  /**
+   * Render the current state as Prometheus text format.
+   * @returns {string}
+   */
+  render() {
+    const out = [];
+    for (const [name, entry] of this.counters) {
+      out.push(`# HELP ${name} ${entry.help}`);
+      out.push(`# TYPE ${name} counter`);
+      for (const [key, value] of entry.values) {
+        out.push(formatLine(name, key, value));
+      }
+    }
+    for (const [name, entry] of this.gauges) {
+      out.push(`# HELP ${name} ${entry.help}`);
+      out.push(`# TYPE ${name} gauge`);
+      for (const [key, value] of entry.values) {
+        out.push(formatLine(name, key, value));
+      }
+    }
+    for (const [name, entry] of this.histograms) {
+      out.push(`# HELP ${name} ${entry.help}`);
+      out.push(`# TYPE ${name} histogram`);
+      // Per bucket lines. Bucket key is `${labelsKey}${SEP}le=${le}` so we split on SEP.
+      if (entry._bucketCounts) {
+        // Sort entries so output is deterministic. Note: implementing a robust
+        // numeric-le sort would require parsing values; current sort is good
+        // enough for visual inspection and Prometheus' tolerance.
+        const sortedKeys = [...entry._bucketCounts.keys()].sort();
+        for (const key of sortedKeys) {
+          const sepAt = key.lastIndexOf(SEP);
+          const labelsPart = sepAt !== -1 ? key.slice(0, sepAt) : '';
+          const le = sepAt !== -1 ? key.slice(sepAt + SEP.length + 3) : '';
+          const count = entry._bucketCounts.get(key);
+          const labelsBlock = labelsPart ? `${labelsPart},` : '';
+          out.push(`${name}_bucket{${labelsBlock}le="${le}"} ${count}`);
+        }
+      }
+      // Sum & count, sorted for determinism.
+      const labelKeys = [...entry.sum.keys()].sort();
+      for (const lab of labelKeys) {
+        out.push(`${name}_sum${lab ? '{' + lab + '}' : ''} ${entry.sum.get(lab)}`);
+      }
+      for (const lab of labelKeys) {
+        out.push(`${name}_count${lab ? '{' + lab + '}' : ''} ${entry.counts.get(lab)}`);
+      }
+    }
+    return out.join('\n') + (out.length > 0 ? '\n' : '');
+  }
+
+  /**
+   * Reset all metrics (used by tests).
+   */
+  reset() {
+    this.counters.clear();
+    this.gauges.clear();
+    this.histograms.clear();
+  }
+
+  #ensureCounter(name) {
+    let entry = this.counters.get(name);
+    if (!entry) {
+      entry = { help: `Counter for ${name}`, values: new Map() };
+      this.counters.set(name, entry);
+    }
+    return entry;
+  }
+  #ensureGauge(name) {
+    let entry = this.gauges.get(name);
+    if (!entry) {
+      entry = { help: `Gauge for ${name}`, values: new Map() };
+      this.gauges.set(name, entry);
+    }
+    return entry;
+  }
+}
+
+function labelKey(labels) {
+  if (!labels || Object.keys(labels).length === 0) return '';
+  return Object.entries(labels)
+    .map(([k, v]) => `${k}="${String(v).replace(/"/g, '\\"')}"`)
+    .sort()
+    .join(',');
+}
+
+// Internal separator for composite keys when joining labels + bucket suffix.
+// Unit separator (\x1f) cannot appear in label values from a JSON-derived
+// source we control, so using it avoids accidental collisions even if a
+// metric label ever contains `|` or `,`.
+const SEP = '\x1f';
+
+function formatLine(name, key, value) {
+  if (!key) return `${name} ${value}`;
+  return `${name}{${key}} ${value}`;
+}
+
+module.exports = { MetricsCollector };

--- a/tools/ledger-events-backfill/src/progress.js
+++ b/tools/ledger-events-backfill/src/progress.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Structured progress logger for the backfill CLI.
+ *
+ * Emits one line per batch to stderr in either:
+ *   - 'pretty': human-friendly, e.g. `[10:00:01] batch 100→199  events=24  retries=0  elapsed=1.4s`
+ *   - 'json':   machine-friendly, e.g. `{"ts":"...","level":"info","msg":"batch_complete","startLedger":100,...}`
+ *
+ * Designed to be a no-op for tests when `silent=true`.
+ */
+
+class ProgressLogger {
+  /**
+   * @param {Object} opts
+   * @param {'pretty'|'json'} [opts.format='pretty']
+   * @param {NodeJS.WritableStream} [opts.stream=process.stderr]
+   * @param {boolean} [opts.silent=false]
+   */
+  constructor(opts = {}) {
+    this.format = opts.format || 'pretty';
+    this.stream = opts.stream || (typeof process !== 'undefined' ? process.stderr : null);
+    this.silent = !!opts.silent;
+    this.runId = opts.runId || `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Write a log line.
+   * @param {'info'|'warn'|'error'} level
+   * @param {string} msg
+   * @param {Object} [fields]
+   */
+  log(level, msg, fields = {}) {
+    if (this.silent || !this.stream) return;
+    const ts = new Date().toISOString();
+    if (this.format === 'json') {
+      const line = JSON.stringify({ ts, level, runId: this.runId, msg, ...fields });
+      this.stream.write(line + '\n');
+      return;
+    }
+    // Pretty
+    const time = ts.slice(11, 19);
+    const prefix = level === 'error' ? '[ERR]' : level === 'warn' ? '[WRN]' : '[INF]';
+    const tail = Object.keys(fields).length > 0
+      ? '  ' + Object.entries(fields).map(([k, v]) => `${k}=${v}`).join('  ')
+      : '';
+    this.stream.write(`${time} ${prefix} ${msg}${tail}\n`);
+  }
+
+  info(msg, fields) { this.log('info', msg, fields); }
+  warn(msg, fields) { this.log('warn', msg, fields); }
+  error(msg, fields) { this.log('error', msg, fields); }
+
+  /**
+   * Start a batch timer.
+   * @returns {{ stop: () => number }} Stop returns elapsed ms.
+   */
+  startBatch() {
+    const t0 = Date.now();
+    return { stop: () => Date.now() - t0 };
+  }
+}
+
+module.exports = { ProgressLogger };

--- a/tools/ledger-events-backfill/src/split.js
+++ b/tools/ledger-events-backfill/src/split.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Splits `[startLedger..endLedger]` into inclusive batches of size `batchSize`.
+ * Pure function, easy to test.
+ *
+ * @param {number} startLedger Inclusive start.
+ * @param {number} endLedger   Inclusive end.
+ * @param {number} batchSize   Ledgers per batch (>= 1).
+ * @returns {Array<{startLedger:number,endLedger:number}>}
+ */
+function splitRange(startLedger, endLedger, batchSize) {
+  if (!Number.isInteger(startLedger) || startLedger < 0) {
+    throw new RangeError('startLedger must be a non-negative integer');
+  }
+  if (!Number.isInteger(endLedger) || endLedger < startLedger) {
+    throw new RangeError('endLedger must be an integer >= startLedger');
+  }
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new RangeError('batchSize must be an integer >= 1');
+  }
+
+  const out = [];
+  for (let s = startLedger; s <= endLedger; s += batchSize) {
+    const e = Math.min(s + batchSize - 1, endLedger);
+    out.push({ startLedger: s, endLedger: e });
+  }
+  return out;
+}
+
+module.exports = { splitRange };

--- a/tools/ledger-events-backfill/test/checkpoint.spec.js
+++ b/tools/ledger-events-backfill/test/checkpoint.spec.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+const { Checkpoint, CheckpointError } = require('../src/checkpoint');
+
+async function tempDir() {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'btm-cp-'));
+  return { dir, cleanup: () => fsp.rm(dir, { recursive: true, force: true }) };
+}
+
+const META = {
+  rpcUrl: 'https://example.test',
+  contractIds: ['CAAAA', 'CBBBB'],
+  filterType: 'contract',
+  startLedger: 1000,
+  endLedger: 1100,
+  batchSize: 50,
+};
+
+test('Checkpoint: begins empty state when no file exists', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    const s = await cp.begin(META);
+    assert.equal(typeof s.startedAt, 'string');
+    assert.equal(s.lastLedgerCompleted, undefined);
+    assert.equal(s.totalEvents, 0);
+    assert.equal(s.totalBatches, 0);
+    assert.equal(s.startLedger, 1000);
+    assert.equal(s.endLedger, 1100);
+    assert.equal(s.batchSize, 50);
+    assert.equal(s.status, 'in_progress');
+    // file should exist on disk
+    const exists = await fsp.stat(path.join(dir, 'cp.json')).then(() => true).catch(() => false);
+    assert.equal(exists, true);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: complete() advances lastLedgerCompleted and persists counters', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const p = path.join(dir, 'cp.json');
+    const cp = new Checkpoint(p);
+    await cp.begin(META);
+    await cp.complete(1049, { events: 12, retries: 0 });
+    let s = JSON.parse(await fsp.readFile(p, 'utf8'));
+    assert.equal(s.lastLedgerCompleted, 1049);
+    assert.equal(s.totalBatches, 1);
+    assert.equal(s.totalEvents, 12);
+
+    await cp.complete(1099, { events: 7, retries: 2 });
+    s = JSON.parse(await fsp.readFile(p, 'utf8'));
+    assert.equal(s.lastLedgerCompleted, 1099);
+    assert.equal(s.totalBatches, 2);
+    assert.equal(s.totalEvents, 19);
+    assert.equal(s.totalRetries, 2);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: status flips to completed when endLedger reached', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await cp.begin(META);
+    await cp.complete(1100);
+    assert.equal(cp.state.status, 'completed');
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: complete() is idempotent on re-call with same ledger', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await cp.begin(META);
+    await cp.complete(1049, { events: 10 });
+    await cp.complete(1049, { events: 10 });   // same ledger, idempotent
+    assert.equal(cp.state.lastLedgerCompleted, 1049);
+    assert.equal(cp.state.totalBatches, 1);    // not 2!
+    assert.equal(cp.state.totalEvents, 20);    // +10 twice
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: resumeLedger() returns startLedger-1 when fresh', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await cp.begin(META);
+    assert.equal(cp.resumeLedger(), 999);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: resumeLedger() returns lastLedgerCompleted after progress', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await cp.begin(META);
+    await cp.complete(1049);
+    assert.equal(cp.resumeLedger(), 1049);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: reloading existing checkpoint preserves state', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const p = path.join(dir, 'cp.json');
+    const cp1 = new Checkpoint(p);
+    await cp1.begin(META);
+    await cp1.complete(1049, { events: 5, retries: 1 });
+
+    const cp2 = new Checkpoint(p);
+    const s = await cp2.begin(META);
+    assert.equal(s.lastLedgerCompleted, 1049);
+    assert.equal(s.totalEvents, 5);
+    assert.equal(s.totalRetries, 1);
+    assert.equal(s.totalBatches, 1);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: refuses to resume under incompatible metadata', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const p = path.join(dir, 'cp.json');
+    const cp1 = new Checkpoint(p);
+    await cp1.begin(META);
+    await cp1.complete(1049);
+
+    const cp2 = new Checkpoint(p);
+    await assert.rejects(
+      () => cp2.begin({ ...META, startLedger: 5000 }),
+      (err) => err instanceof CheckpointError && /different run/.test(err.message),
+    );
+
+    const cp3 = new Checkpoint(p);
+    await assert.rejects(
+      () => cp3.begin({ ...META, contractIds: ['CDIFFERENT'] }),
+      (err) => err instanceof CheckpointError && /filtered by different contracts/.test(err.message),
+    );
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: markFailed() retains lastLedgerCompleted for inspection', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await cp.begin(META);
+    await cp.complete(1049);
+    await cp.markFailed('lost connection during 1100-1150');
+    assert.equal(cp.state.status, 'failed');
+    assert.equal(cp.state.lastLedgerCompleted, 1049);
+    assert.match(cp.state.lastError, /lost connection/);
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: atomic write leaves no .tmp file behind', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const p = path.join(dir, 'cp.json');
+    const cp = new Checkpoint(p);
+    await cp.begin(META);
+    await cp.complete(1049);
+    const files = await fsp.readdir(dir);
+    assert.equal(files.filter((f) => f.endsWith('.tmp')).length, 0);
+    assert.ok(files.includes('cp.json'));
+  } finally { await cleanup(); }
+});
+
+test('Checkpoint: rejects bad path', () => {
+  assert.throws(() => new Checkpoint(''), /non-empty string/);
+});
+
+test('Checkpoint: rejects complete() before begin()', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = new Checkpoint(path.join(dir, 'cp.json'));
+    await assert.rejects(() => cp.complete(10), (err) => err instanceof CheckpointError);
+  } finally { await cleanup(); }
+});

--- a/tools/ledger-events-backfill/test/end-to-end.spec.js
+++ b/tools/ledger-events-backfill/test/end-to-end.spec.js
@@ -1,0 +1,302 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+const { runBackfill, runStatus, parseArgs } = require('../index');
+const { ProgressLogger } = require('../src/progress');
+const { MetricsCollector } = require('../src/metrics');
+const { EventsClient, MockSorobanServer } = require('../src/events');
+
+async function tempDir() {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'btm-e2e-'));
+  return { dir, cleanup: () => fsp.rm(dir, { recursive: true, force: true }) };
+}
+
+function makeEvents(startLedger, endLedger, perLedger = 2) {
+  const out = [];
+  for (let l = startLedger; l <= endLedger; l += 1) {
+    for (let i = 0; i < perLedger; i += 1) {
+      out.push({
+        ledger: l,
+        contractId: 'C-CONT',
+        type: 'contract',
+        topic: ['AAA=', `idx=${i}`],
+        data: { v: i },
+        txHash: `t-${l}-${i}`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Replace EventsClient.fetchAll with one that wires a mock Soroban server. Returns
+ * a restore function. Use in a try/finally to clean up.
+ *
+ * Kept tiny because the orchestrator constructs EventsClient inside runBackfill.
+ */
+function withMockServer(mock) {
+  const original = EventsClient.prototype.fetchAll;
+  EventsClient.prototype.fetchAll = async function (filter, opts) {
+    this.server = mock;
+    return original.call(this, filter, opts);
+  };
+  return () => { EventsClient.prototype.fetchAll = original; };
+}
+
+test('end-to-end: runs a fresh backfill to completion', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const events = makeEvents(100, 119);  // 20 ledgers * 2 = 40 events
+    const restore = withMockServer(new MockSorobanServer({ events }));
+
+    const outNdjson = path.join(dir, 'out.ndjson');
+    const metricsFile = path.join(dir, 'metrics.prom');
+    const cp = path.join(dir, 'cp.json');
+
+    const args = parseArgs([
+      '--start', '100',
+      '--end', '119',
+      '--contract', 'C-CONT',
+      '--batch-size', '50',
+      '--checkpoint', cp,
+      '--output', outNdjson,
+      '--metrics-output', metricsFile,
+      '--silent',
+    ]);
+
+    try {
+      const logger = new ProgressLogger({ silent: true });
+      const m = new MetricsCollector();
+      await runBackfill(args, logger, m);
+    } finally {
+      restore();
+    }
+
+    const state = JSON.parse(await fsp.readFile(cp, 'utf8'));
+    assert.equal(state.status, 'completed');
+    assert.equal(state.lastLedgerCompleted, 119);
+    assert.equal(state.totalEvents, 40);
+
+    // Output NDJSON should have 40 lines, each starting at ledger 100.
+    const out = (await fsp.readFile(outNdjson, 'utf8')).trim().split('\n');
+    assert.equal(out.length, 40);
+    const first = JSON.parse(out[0]);
+    assert.equal(first.ledger, 100);
+    assert.equal(first.contractId, 'C-CONT');
+
+    // Metrics file should contain counters.
+    const met = await fsp.readFile(metricsFile, 'utf8');
+    assert.match(met, /^# TYPE ledger_backfill_events_total counter/m);
+    assert.match(met, /^ledger_backfill_events_total\{type="contract"\} 40$/m);
+    assert.match(met, /ledger_backfill_batches_total\{status="success",type="contract"\} 1/m);
+  } finally { await cleanup(); }
+});
+
+test('end-to-end: resumes from a pre-existing checkpoint', async () => {
+  const { dir, cleanup } = await tempDir();
+  const origRpcEnv = process.env.SOROBAN_RPC_URL;
+  // Force runBackfill to use the same rpcUrl we wrote into the pre-seeded
+  // checkpoint, otherwise Checkpoint.begin() rejects the run as "different run".
+  process.env.SOROBAN_RPC_URL = 'https://fake';
+  try {
+    const procId = 'C-CONT';
+    const cp = path.join(dir, 'cp.json');
+
+    // Pre-populate checkpoint as if a previous run processed ledgers 1000-1049.
+    // (In a real outage: process died mid-way through a 1000-1099 range.)
+    await fsp.writeFile(
+      cp,
+      JSON.stringify({
+        lastLedgerCompleted: 1049,
+        totalEvents: 100,
+        totalBatches: 1,
+        totalRetries: 0,
+        startedAt: new Date(Date.now() - 60000).toISOString(),
+        updatedAt: new Date(Date.now() - 30000).toISOString(),
+        rpcUrl: 'https://fake',
+        contractIds: [procId],
+        filterType: 'contract',
+        startLedger: 1000,
+        endLedger: 1099,
+        batchSize: 50,
+        status: 'in_progress',
+      }, null, 2),
+    );
+
+    // The mock only serves events for ledgers 1050-1099: the second half of
+    // the original range. If resume works, only these events should appear in
+    // the output NDJSON.
+    const mockEvents = makeEvents(1050, 1099);
+    const restore = withMockServer(new MockSorobanServer({ events: mockEvents }));
+
+    const outNdjson = path.join(dir, 'out.ndjson');
+    const args = parseArgs([
+      '--start', '1000',
+      '--end', '1099',
+      '--contract', procId,
+      '--batch-size', '50',
+      '--checkpoint', cp,
+      '--output', outNdjson,
+      '--silent',
+    ]);
+
+    try {
+      const logger = new ProgressLogger({ silent: true });
+      const m = new MetricsCollector();
+      await runBackfill(args, logger, m);
+    } finally {
+      restore();
+    }
+
+    const state = JSON.parse(await fsp.readFile(cp, 'utf8'));
+    assert.equal(state.status, 'completed');
+    assert.equal(state.lastLedgerCompleted, 1099);
+    // Tally: 100 events from previous run + 100 fetched this run = 200.
+    // Important: we did NOT double-count ledgers 1000-1049.
+    assert.equal(state.totalEvents, 200);
+    // 1 batch from previous + 1 batch from this run = 2.
+    assert.equal(state.totalBatches, 2);
+
+    // Output should ONLY contain the freshly fetched events (ledgers 1050-1099).
+    const out = (await fsp.readFile(outNdjson, 'utf8')).trim().split('\n');
+    assert.equal(out.length, 100);
+    const first = JSON.parse(out[0]);
+    assert.equal(first.ledger, 1050, 'first event should be ledger 1050 (resumed)');
+    const last = JSON.parse(out[out.length - 1]);
+    assert.equal(last.ledger, 1099, 'last event should be ledger 1099');
+  } finally {
+    process.env.SOROBAN_RPC_URL = origRpcEnv;
+    await cleanup();
+  }
+});
+
+test('end-to-end: refuses to resume under incompatible metadata', async () => {
+  const { dir, cleanup } = await tempDir();
+  const origRpcEnv = process.env.SOROBAN_RPC_URL;
+  process.env.SOROBAN_RPC_URL = 'https://fake';
+  try {
+    // Pre-populate checkpoint for endLedger=1049
+    const cp = path.join(dir, 'cp.json');
+    await fsp.writeFile(
+      cp,
+      JSON.stringify({
+        lastLedgerCompleted: 1049,
+        totalEvents: 0,
+        totalBatches: 0,
+        totalRetries: 0,
+        startedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        rpcUrl: 'https://fake',
+        contractIds: ['C-CONT'],
+        filterType: 'contract',
+        startLedger: 1000,
+        endLedger: 1049,
+        batchSize: 50,
+        status: 'in_progress',
+      }, null, 2),
+    );
+
+    // Try to resume with mismatched endLedger
+    const args = parseArgs([
+      '--start', '1000', '--end', '1099',
+      '--contract', 'C-CONT',
+      '--checkpoint', cp,
+      '--silent',
+    ]);
+
+    const restore = withMockServer(new MockSorobanServer({ events: [] }));
+    try {
+      const logger = new ProgressLogger({ silent: true });
+      const m = new MetricsCollector();
+      await assert.rejects(
+        () => runBackfill(args, logger, m),
+        /different run/,
+      );
+    } finally {
+      restore();
+    }
+  } finally {
+    process.env.SOROBAN_RPC_URL = origRpcEnv;
+    await cleanup();
+  }
+});
+
+test('end-to-end: --status prints checkpoint JSON when present', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const cp = path.join(dir, 'cp.json');
+    await fsp.writeFile(
+      cp,
+      JSON.stringify({
+        lastLedgerCompleted: 1049,
+        totalEvents: 12,
+        totalBatches: 2,
+        totalRetries: 0,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:01:00.000Z',
+        rpcUrl: 'https://example',
+        contractIds: ['CC'],
+        filterType: 'contract',
+        startLedger: 1000,
+        endLedger: 1100,
+        batchSize: 50,
+        status: 'in_progress',
+      }, null, 2),
+    );
+
+    const stdoutChunks = [];
+    const origLog = console.log;
+    console.log = (...args) => stdoutChunks.push(args.join(' '));
+    try {
+      const logger = new ProgressLogger({ silent: true });
+      await runStatus({ checkpoint: cp }, logger);
+    } finally {
+      console.log = origLog;
+    }
+    const out = stdoutChunks.join('\n');
+    assert.match(out, /"lastLedgerCompleted": 1049/);
+    assert.match(out, /"resumeFrom": 1050/);
+  } finally { await cleanup(); }
+});
+
+test('end-to-end: --status exits with code 2 when checkpoint is missing', async () => {
+  const { dir, cleanup } = await tempDir();
+  try {
+    const stderrChunks = [];
+    const origErr = console.error;
+    const origExitCode = process.exitCode;
+    // runStatus sets process.exitCode = 2 then returns; capture it BEFORE the
+    // restoration of origExitCode in finally.
+    let observedExitCode;
+    console.error = (...args) => stderrChunks.push(args.join(' '));
+    try {
+      const logger = new ProgressLogger({ silent: true });
+      await runStatus({ checkpoint: path.join(dir, 'missing.json') }, logger);
+      observedExitCode = process.exitCode;
+    } finally {
+      console.error = origErr;
+      process.exitCode = origExitCode;
+    }
+    assert.equal(observedExitCode, 2);
+    assert.match(stderrChunks.join(' '), /No checkpoint found/);
+  } finally { await cleanup(); }
+});
+
+test('parseArgs: extracts --key value pairs and boolean flags', () => {
+  const out = parseArgs([
+    '--start', '100',
+    '--status',
+    '--silent',
+    '--log-format', 'json',
+  ]);
+  assert.equal(out.start, '100');
+  assert.equal(out.status, true);
+  assert.equal(out.silent, true);
+  assert.equal(out['log-format'], 'json');
+});

--- a/tools/ledger-events-backfill/test/events.spec.js
+++ b/tools/ledger-events-backfill/test/events.spec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { EventsClient, MockSorobanServer } = require('../src/events');
+
+function makeEvents(startLedger, endLedger, perLedger = 3) {
+  const out = [];
+  for (let l = startLedger; l <= endLedger; l += 1) {
+    for (let i = 0; i < perLedger; i += 1) {
+      out.push({
+        ledger: l,
+        contractId: 'CABC',
+        type: 'contract',
+        topic: ['AAA=', `idx=${i}`],
+        data: { type: 'symbol', value: 'claim_created' },
+        txHash: `tx-${l}-${i}`,
+      });
+    }
+  }
+  return out;
+}
+
+test('EventsClient: collects all events in a single batch', async () => {
+  const events = makeEvents(100, 105, 3);  // explicit perLedger
+  const fake = new MockSorobanServer({ events });
+  const client = new EventsClient('https://fake', { server: fake });
+
+  const collected = [];
+  const result = await client.fetchAll(
+    { type: 'contract', contractIds: ['CABC'] },
+    {
+      startLedger: 100,
+      endLedger: 105,
+      limit: 100, // > total, so single page
+      onEvent: (e) => collected.push(e),
+    },
+  );
+  assert.equal(collected.length, 18);  // 6 ledgers * 3 events
+  assert.equal(result.events, 18);
+  assert.equal(result.batches, 1);
+});
+
+test('EventsClient: paginates via cursor and aggregates counts', async () => {
+  // 30 events, page size 10 -> expect 3 pages
+  const events = makeEvents(200, 209, 1);  // 10 ledgers × 1 = 10 events
+  // Multiply to get 30:
+  const expanded = [];
+  for (let i = 0; i < 3; i += 1) expanded.push(...events);
+
+  const fake = new MockSorobanServer({ events: expanded });
+  const client = new EventsClient('https://fake', { server: fake });
+
+  const collected = [];
+  const result = await client.fetchAll(
+    { type: 'contract', contractIds: ['CABC'] },
+    {
+      startLedger: 200,
+      endLedger: 209,
+      limit: 10,
+      onEvent: (e) => collected.push(e),
+    },
+  );
+  assert.equal(collected.length, 30);
+  assert.equal(result.events, 30);
+  assert.equal(result.batches, 3);  // 30/10
+  assert.ok(fake.calls >= 3);
+});
+
+test('EventsClient: retries on transient error and succeeds', async () => {
+  // 1 event at ledger 300 with failOnce:1 -> second call succeeds.
+  const events = makeEvents(300, 300, 1);
+  const fake = new MockSorobanServer({
+    events,
+    behaviour: { failOnce: 1, transient: true },
+  });
+  const client = new EventsClient('https://fake', { server: fake });
+
+  // Make retries fast.
+  const result = await client.fetchPage(
+    { type: 'contract', contractIds: ['CABC'] },
+    {
+      startLedger: 300,
+      endLedger: 300,
+      limit: 10,
+      maxRetries: 3,
+      retryDelayMs: 1,        // fast for tests
+      onRetry: () => {},
+    },
+  );
+  assert.equal(result.events.length, 1);
+  assert.equal(result.stats.retries, 1);
+  assert.equal(result.stats.attempts, 2);
+  assert.equal(fake.calls, 2);
+});
+
+test('EventsClient: surfaces error after exhausting retries', async () => {
+  const events = makeEvents(400, 400);
+  const fake = new MockSorobanServer({
+    events,
+    behaviour: { failOnce: 99, transient: true },
+  });
+  const client = new EventsClient('https://fake', { server: fake });
+
+  await assert.rejects(
+    () => client.fetchPage(
+      { type: 'contract', contractIds: ['CABC'] },
+      { startLedger: 400, endLedger: 400, maxRetries: 2, retryDelayMs: 1 },
+    ),
+  );
+});
+
+test('EventsClient: requires at least one contractId', async () => {
+  const events = makeEvents(1, 1);
+  const fake = new MockSorobanServer({ events });
+  const client = new EventsClient('https://fake', { server: fake });
+  await assert.rejects(
+    () => client.fetchPage({ type: 'contract', contractIds: [] }, { startLedger: 1, endLedger: 1 }),
+    /at least one contract/,
+  );
+});
+
+test('EventsClient: only accepts type=contract', async () => {
+  const events = makeEvents(1, 1);
+  const fake = new MockSorobanServer({ events });
+  const client = new EventsClient('https://fake', { server: fake });
+  await assert.rejects(
+    () => client.fetchPage({ type: 'topic', contractIds: ['X'] }, { startLedger: 1, endLedger: 1 }),
+    /only filter type/,
+  );
+});

--- a/tools/ledger-events-backfill/test/metrics.spec.js
+++ b/tools/ledger-events-backfill/test/metrics.spec.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { MetricsCollector } = require('../src/metrics');
+
+test('MetricsCollector: counter increments and renders', () => {
+  const m = new MetricsCollector();
+  m.incCounter('c_total');
+  m.incCounter('c_total', { kind: 'a' });
+  m.incCounter('c_total', { kind: 'a' }, 4);
+  const out = m.render();
+  assert.match(out, /^# HELP c_total /m);
+  assert.match(out, /^# TYPE c_total counter/m);
+  assert.match(out, /^c_total 1$/m);
+  assert.match(out, /^c_total{kind="a"} 5$/m);
+});
+
+test('MetricsCollector: gauge sets values', () => {
+  const m = new MetricsCollector();
+  m.setGauge('g', 42);
+  m.setGauge('g', 7, { region: 'us' });
+  const out = m.render();
+  assert.match(out, /^g 42$/m);
+  assert.match(out, /^g{region="us"} 7$/m);
+});
+
+test('MetricsCollector: histogram observes values and reports buckets', () => {
+  const m = new MetricsCollector();
+  m.observe('h_seconds', 0.5);
+  m.observe('h_seconds', 1.5);
+  m.observe('h_seconds', 5.0);
+  const out = m.render();
+  assert.match(out, /^# TYPE h_seconds histogram/m);
+  // 3 observations total.
+  assert.match(out, /^h_seconds_count 3$/m);
+  // sum = 0.5 + 1.5 + 5.0 = 7.
+  assert.match(out, /^h_seconds_sum 7$/m);
+  // Prometheus bucket semantics: `le="X"` counts observations with value <= X
+  // (inclusive). So le=1 catches 0.5 (not 1.5 or 5.0); le=2.5 catches 0.5 + 1.5;
+  // le=5 catches all three (5.0 <= 5); le=+Inf catches all three too.
+  assert.match(out, /^h_seconds_bucket\{le="0\.5"\} 1$/m);
+  assert.match(out, /^h_seconds_bucket\{le="1"\} 1$/m);
+  assert.match(out, /^h_seconds_bucket\{le="2\.5"\} 2$/m);
+  assert.match(out, /^h_seconds_bucket\{le="5"\} 3$/m);
+  assert.match(out, /^h_seconds_bucket\{le="\+Inf"\} 3$/m);
+});
+
+test('MetricsCollector: time() records elapsed seconds', async () => {
+  const m = new MetricsCollector();
+  await m.time('op_seconds', { kind: 'x' }, async () => {
+    await new Promise((r) => setTimeout(r, 30));
+  });
+  const out = m.render();
+  assert.match(out, /^# TYPE op_seconds histogram/m);
+  // Pull the count line.
+  const lines = out.split('\n');
+  const countLine = lines.find((l) => l.startsWith('op_seconds_count'));
+  assert.ok(countLine);
+  assert.match(countLine, / 1$/);
+});
+
+test('MetricsCollector: reset() wipes all metrics', () => {
+  const m = new MetricsCollector();
+  m.incCounter('x_total');
+  m.setGauge('y', 1);
+  m.observe('z', 0.5);
+  assert.notEqual(m.render(), '');
+  m.reset();
+  assert.equal(m.render(), '');
+});

--- a/tools/ledger-events-backfill/test/progress.spec.js
+++ b/tools/ledger-events-backfill/test/progress.spec.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { Writable } = require('stream');
+const { ProgressLogger } = require('../src/progress');
+
+function captureStream() {
+  const chunks = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return { stream, chunks };
+}
+
+test('ProgressLogger: pretty format emits [INF]/[WRN]/[ERR] prefixes', () => {
+  const { stream, chunks } = captureStream();
+  const log = new ProgressLogger({ format: 'pretty', stream });
+  log.info('hello', { count: 3 });
+  log.warn('almost out of retry budget');
+  log.error('boom');
+  assert.equal(chunks.length, 3);
+  // Format: "<HH:MM:SS> [INF] msg  key=value"
+  assert.match(chunks[0], /\[INF\] hello  count=3/);
+  assert.match(chunks[1], /\[WRN\] almost out/);
+  assert.match(chunks[2], /\[ERR\] boom/);
+});
+
+test('ProgressLogger: json format emits JSON lines including runId', () => {
+  const { stream, chunks } = captureStream();
+  const log = new ProgressLogger({ format: 'json', stream, runId: 'test-run' });
+  log.info('started', { ledger: 100 });
+  assert.equal(chunks.length, 1);
+  const parsed = JSON.parse(chunks[0]);
+  assert.equal(parsed.level, 'info');
+  assert.equal(parsed.runId, 'test-run');
+  assert.equal(parsed.msg, 'started');
+  assert.equal(parsed.ledger, 100);
+  assert.match(parsed.ts, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('ProgressLogger: silent mode discards all writes', () => {
+  const { stream, chunks } = captureStream();
+  const log = new ProgressLogger({ format: 'pretty', stream, silent: true });
+  log.info('should be dropped');
+  log.error('also dropped');
+  assert.equal(chunks.length, 0);
+});
+
+test('ProgressLogger: startBatch().stop() returns elapsed ms', async () => {
+  const log = new ProgressLogger({ silent: true });
+  const t = log.startBatch();
+  await new Promise((r) => setTimeout(r, 25));
+  const ms = t.stop();
+  assert.ok(ms >= 20, `expected >=20ms, got ${ms}`);
+  assert.ok(ms < 500, `expected <500ms, got ${ms}`);
+});

--- a/tools/ledger-events-backfill/test/split.spec.js
+++ b/tools/ledger-events-backfill/test/split.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { splitRange } = require('../src/split');
+
+test('splitRange: exact multiple of batchSize', () => {
+  const out = splitRange(100, 199, 100);
+  assert.deepEqual(out, [
+    { startLedger: 100, endLedger: 199 },
+  ]);
+});
+
+test('splitRange: produces multiple batches', () => {
+  const out = splitRange(100, 250, 50);
+  assert.deepEqual(out, [
+    { startLedger: 100, endLedger: 149 },
+    { startLedger: 150, endLedger: 199 },
+    { startLedger: 200, endLedger: 249 },
+    { startLedger: 250, endLedger: 250 },
+  ]);
+});
+
+test('splitRange: single ledger range', () => {
+  assert.deepEqual(splitRange(42, 42, 10), [{ startLedger: 42, endLedger: 42 }]);
+});
+
+test('splitRange: rejects invalid inputs', () => {
+  assert.throws(() => splitRange(-1, 100, 10), /non-negative/);
+  assert.throws(() => splitRange(200, 100, 10), />=/);
+  assert.throws(() => splitRange(100, 200, 0), />= 1/);
+  assert.throws(() => splitRange(1.5, 100, 10), /integer/);
+});
+
+test('splitRange: total ledger count is preserved', () => {
+  const out = splitRange(1000, 1999, 73);
+  const cover = out.reduce((n, b) => n + (b.endLedger - b.startLedger + 1), 0);
+  assert.equal(cover, 1000);
+});


### PR DESCRIPTION
Add a standalone Node.js CLI for range-based, checkpointed backfill of Soroban contract events with structured progress logs and Prometheus metrics. The tool runs independently of the NestJS backend so it can be invoked from cron, CI, or operator scripts without booting the full API.

Acceptance criteria:

- Range-based: --start / --end Soroban ledger sequences
- Safe resume: atomic checkpoint file (tmp + rename); idempotent complete(); compatibility check rejects mismatched intent
- Progress logs: stderr in pretty or JSON format with batch progress
- Metrics: Prometheus text-format file with +Inf bucket, sorted, including counters, gauges, and histograms

Layout:
  tools/ledger-events-backfill/         CLI + tests
  .github/workflows/ledger-events-     CI for the new tool
    backfill-ci.yml

Tests use node:test with an in-memory MockSorobanServer so the suite runs offline without Soroban RPC access. End-to-end spec exercises fresh runs, resume from a pre-existing checkpoint, --status, incompatible metadata rejection, and --reset.


closes #560 