### PR TITLE
feat: add TTL cache for contract IDs/config snapshots with admin refresh endpoint

### DIFF
--- a/app/backend/src/deployment-metadata/contract-config-cache.service.spec.ts
+++ b/app/backend/src/deployment-metadata/contract-config-cache.service.spec.ts
@@ -5,8 +5,8 @@ import { PrismaService } from '../prisma/prisma.service';
 
 describe('ContractConfigCacheService', () => {
   let service: ContractConfigCacheService;
-  let redis: jest.Mocked<RedisService>;
-  let prisma: jest.Mocked<PrismaService>;
+  let _redis: jest.Mocked<RedisService>;
+  let _prisma: jest.Mocked<PrismaService>;
 
   const record = {
     id: 'id-1',
@@ -50,8 +50,8 @@ describe('ContractConfigCacheService', () => {
     service = module.get<ContractConfigCacheService>(
       ContractConfigCacheService,
     );
-    redis = module.get(RedisService);
-    prisma = module.get(PrismaService);
+    _redis = module.get(RedisService);
+    _prisma = module.get(PrismaService);
 
     jest.clearAllMocks();
     // Redis set/del always succeeds by default

--- a/app/backend/src/deployment-metadata/contract-config-cache.service.spec.ts
+++ b/app/backend/src/deployment-metadata/contract-config-cache.service.spec.ts
@@ -1,0 +1,362 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContractConfigCacheService } from './contract-config-cache.service';
+import { RedisService } from '../../cache/redis.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ContractConfigCacheService', () => {
+  let service: ContractConfigCacheService;
+  let redis: jest.Mocked<RedisService>;
+  let prisma: jest.Mocked<PrismaService>;
+
+  const record = {
+    id: 'id-1',
+    contractName: 'AidEscrow',
+    network: 'testnet',
+    contractId: 'CABC123',
+    wasmHash: 'hash-abc',
+    deployedAt: new Date('2026-01-01T00:00:00Z'),
+    commitSha: 'sha-1',
+    deployer: 'GDEPLOY',
+    transactionHash: 'tx-hash-1',
+    metadata: { version: '1.0' },
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  };
+
+  const mockRedis = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    delByPattern: jest.fn(),
+  };
+
+  const mockPrisma = {
+    deploymentMetadata: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractConfigCacheService,
+        { provide: RedisService, useValue: mockRedis },
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<ContractConfigCacheService>(
+      ContractConfigCacheService,
+    );
+    redis = module.get(RedisService);
+    prisma = module.get(PrismaService);
+
+    jest.clearAllMocks();
+    // Redis set/del always succeeds by default
+    mockRedis.set.mockResolvedValue(undefined);
+    mockRedis.del.mockResolvedValue(undefined);
+    mockRedis.delByPattern.mockResolvedValue(0);
+  });
+
+  // ─── getAll ────────────────────────────────────────────────────────────────
+
+  describe('getAll', () => {
+    it('returns cached value on cache hit', async () => {
+      mockRedis.get.mockResolvedValue([record]);
+
+      const result = await service.getAll();
+
+      expect(result).toEqual([record]);
+      expect(mockPrisma.deploymentMetadata.findMany).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+
+    it('queries DB and populates cache on cache miss', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([record]);
+
+      const result = await service.getAll();
+
+      expect(mockPrisma.deploymentMetadata.findMany).toHaveBeenCalledTimes(1);
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:all',
+        [expect.objectContaining({ id: record.id })],
+        expect.any(Number),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(record.id);
+    });
+
+    it('returns empty array (and caches it) when DB has no records', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([]);
+
+      const result = await service.getAll();
+
+      expect(result).toEqual([]);
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:all',
+        [],
+        expect.any(Number),
+      );
+    });
+
+    it('falls back to DB silently when Redis returns null (Redis unavailable)', async () => {
+      // RedisService.get swallows errors and returns null – simulate that
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([record]);
+
+      const result = await service.getAll();
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ─── getByNetwork ──────────────────────────────────────────────────────────
+
+  describe('getByNetwork', () => {
+    it('returns cached value on cache hit', async () => {
+      mockRedis.get.mockResolvedValue([record]);
+
+      const result = await service.getByNetwork('testnet');
+
+      expect(result).toEqual([record]);
+      expect(mockPrisma.deploymentMetadata.findMany).not.toHaveBeenCalled();
+    });
+
+    it('queries DB and caches on miss', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([record]);
+
+      const result = await service.getByNetwork('testnet');
+
+      expect(mockPrisma.deploymentMetadata.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { network: 'testnet' } }),
+      );
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:network:testnet',
+        expect.any(Array),
+        expect.any(Number),
+      );
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ─── getByNetworkAndContractName ───────────────────────────────────────────
+
+  describe('getByNetworkAndContractName', () => {
+    it('returns cached value on hit', async () => {
+      mockRedis.get.mockResolvedValue(record);
+
+      const result = await service.getByNetworkAndContractName(
+        'testnet',
+        'AidEscrow',
+      );
+
+      expect(result).toEqual(record);
+      expect(mockPrisma.deploymentMetadata.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('queries DB on miss and caches the result', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findUnique.mockResolvedValue(record);
+
+      const result = await service.getByNetworkAndContractName(
+        'testnet',
+        'AidEscrow',
+      );
+
+      expect(mockPrisma.deploymentMetadata.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            network_contractName: {
+              network: 'testnet',
+              contractName: 'AidEscrow',
+            },
+          },
+        }),
+      );
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:contract:testnet:AidEscrow',
+        expect.objectContaining({ id: record.id }),
+        expect.any(Number),
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('caches null and returns null when DB has no match', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findUnique.mockResolvedValue(null);
+
+      const result = await service.getByNetworkAndContractName(
+        'testnet',
+        'Missing',
+      );
+
+      expect(result).toBeNull();
+      // null result is cached to prevent repeated DB misses
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:contract:testnet:Missing',
+        null,
+        expect.any(Number),
+      );
+    });
+  });
+
+  // ─── getByContractId ───────────────────────────────────────────────────────
+
+  describe('getByContractId', () => {
+    it('returns cached value on hit', async () => {
+      mockRedis.get.mockResolvedValue(record);
+
+      const result = await service.getByContractId('CABC123');
+
+      expect(result).toEqual(record);
+      expect(mockPrisma.deploymentMetadata.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('queries DB on miss and caches the result', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findFirst.mockResolvedValue(record);
+
+      const result = await service.getByContractId('CABC123');
+
+      expect(mockPrisma.deploymentMetadata.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { contractId: 'CABC123' } }),
+      );
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'contract-config:id:CABC123',
+        expect.objectContaining({ id: record.id }),
+        expect.any(Number),
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('returns null when not found in DB', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockPrisma.deploymentMetadata.findFirst.mockResolvedValue(null);
+
+      const result = await service.getByContractId('NONEXISTENT');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── invalidateAll ─────────────────────────────────────────────────────────
+
+  describe('invalidateAll', () => {
+    it('deletes all contract-config:* keys via pattern', async () => {
+      mockRedis.delByPattern.mockResolvedValue(5);
+
+      const count = await service.invalidateAll();
+
+      expect(mockRedis.delByPattern).toHaveBeenCalledWith('contract-config:*');
+      expect(count).toBe(5);
+    });
+
+    it('returns 0 when no keys exist', async () => {
+      mockRedis.delByPattern.mockResolvedValue(0);
+
+      const count = await service.invalidateAll();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // ─── refreshAll ────────────────────────────────────────────────────────────
+
+  describe('refreshAll', () => {
+    it('invalidates then re-warms all cache keys and returns stats', async () => {
+      mockRedis.delByPattern.mockResolvedValue(3);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([record]);
+
+      const result = await service.refreshAll();
+
+      // Invalidation happened first
+      expect(mockRedis.delByPattern).toHaveBeenCalledWith('contract-config:*');
+
+      // All four key types populated: all, byNetwork, byNetworkAndName, byContractId
+      const setCalls = mockRedis.set.mock.calls.map(([k]) => k as string);
+      expect(setCalls).toContain('contract-config:all');
+      expect(setCalls).toContain('contract-config:network:testnet');
+      expect(setCalls).toContain(
+        'contract-config:contract:testnet:AidEscrow',
+      );
+      expect(setCalls).toContain('contract-config:id:CABC123');
+
+      // Stats
+      expect(result.contractCount).toBe(1);
+      expect(result.networkCount).toBe(1);
+      expect(result.refreshedAt).toBeInstanceOf(Date);
+    });
+
+    it('handles empty DB gracefully – 0 contracts, 0 networks', async () => {
+      mockRedis.delByPattern.mockResolvedValue(0);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([]);
+
+      const result = await service.refreshAll();
+
+      expect(result.contractCount).toBe(0);
+      expect(result.networkCount).toBe(0);
+      // Only the "all" key is written (empty array)
+      const setCalls = mockRedis.set.mock.calls.map(([k]) => k as string);
+      expect(setCalls).toContain('contract-config:all');
+    });
+
+    it('groups multiple contracts by network correctly', async () => {
+      const recordB = {
+        ...record,
+        id: 'id-2',
+        contractName: 'TokenVault',
+        contractId: 'CDEF456',
+        network: 'mainnet',
+      };
+      mockRedis.delByPattern.mockResolvedValue(0);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([
+        record,
+        recordB,
+      ]);
+
+      const result = await service.refreshAll();
+
+      expect(result.contractCount).toBe(2);
+      expect(result.networkCount).toBe(2);
+
+      const setCalls = mockRedis.set.mock.calls.map(([k]) => k as string);
+      expect(setCalls).toContain('contract-config:network:testnet');
+      expect(setCalls).toContain('contract-config:network:mainnet');
+      expect(setCalls).toContain(
+        'contract-config:contract:mainnet:TokenVault',
+      );
+      expect(setCalls).toContain('contract-config:id:CDEF456');
+    });
+  });
+
+  // ─── safe behavior when Redis is unavailable ───────────────────────────────
+
+  describe('safe fallback when Redis is unavailable', () => {
+    it('getAll still returns DB data if Redis.get returns null', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      // Redis.set silently swallows errors in the real impl – simulate no-op
+      mockRedis.set.mockResolvedValue(undefined);
+      mockPrisma.deploymentMetadata.findMany.mockResolvedValue([record]);
+
+      const result = await service.getAll();
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('getByContractId still returns DB data if Redis.get returns null', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      mockRedis.set.mockResolvedValue(undefined);
+      mockPrisma.deploymentMetadata.findFirst.mockResolvedValue(record);
+
+      const result = await service.getByContractId('CABC123');
+
+      expect(result).not.toBeNull();
+      expect(result!.contractId).toBe('CABC123');
+    });
+  });
+});

--- a/app/backend/src/deployment-metadata/contract-config-cache.service.ts
+++ b/app/backend/src/deployment-metadata/contract-config-cache.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import { RedisService } from '../../cache/redis.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { DeploymentMetadataResponseDto } from './dto/deployment-metadata.dto';
-import { Prisma } from '@prisma/client';
 
 /**
  * TTL for cached contract ID / config snapshots (5 minutes).

--- a/app/backend/src/deployment-metadata/contract-config-cache.service.ts
+++ b/app/backend/src/deployment-metadata/contract-config-cache.service.ts
@@ -1,0 +1,247 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../../cache/redis.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { DeploymentMetadataResponseDto } from './dto/deployment-metadata.dto';
+import { Prisma } from '@prisma/client';
+
+/**
+ * TTL for cached contract ID / config snapshots (5 minutes).
+ * Adjust via CONTRACT_CONFIG_CACHE_TTL_SECONDS env var.
+ */
+const DEFAULT_TTL_SECONDS = 300;
+
+/**
+ * Key helpers – all keys live under the `contract-config:` namespace.
+ */
+const KEYS = {
+  all: () => 'contract-config:all',
+  byNetwork: (network: string) => `contract-config:network:${network}`,
+  byNetworkAndName: (network: string, contractName: string) =>
+    `contract-config:contract:${network}:${contractName}`,
+  byContractId: (contractId: string) =>
+    `contract-config:id:${contractId}`,
+  pattern: () => 'contract-config:*',
+};
+
+/**
+ * ContractConfigCacheService
+ *
+ * Provides TTL-based Redis caching for contract deployment metadata
+ * (contract IDs, wasm hashes, network config snapshots).
+ *
+ * All read helpers fall back to a direct DB query if the cache is cold
+ * or Redis is unavailable, so the system is safe to run without Redis.
+ *
+ * Admin-triggered full refresh is available via `refreshAll()`.
+ */
+@Injectable()
+export class ContractConfigCacheService {
+  private readonly logger = new Logger(ContractConfigCacheService.name);
+  private readonly ttl: number;
+
+  constructor(
+    private readonly redis: RedisService,
+    private readonly prisma: PrismaService,
+  ) {
+    this.ttl =
+      parseInt(process.env.CONTRACT_CONFIG_CACHE_TTL_SECONDS ?? '', 10) ||
+      DEFAULT_TTL_SECONDS;
+  }
+
+  // ─── Public read helpers ────────────────────────────────────────────────────
+
+  /**
+   * Return all deployment metadata records.
+   * Cache hit → Redis; miss → Prisma, then populate cache.
+   */
+  async getAll(): Promise<DeploymentMetadataResponseDto[]> {
+    const key = KEYS.all();
+    const cached = await this.redis.get<DeploymentMetadataResponseDto[]>(key);
+    if (cached !== null) {
+      this.logger.debug('cache hit: getAll');
+      return cached;
+    }
+
+    this.logger.debug('cache miss: getAll – loading from DB');
+    const rows = await this.prisma.deploymentMetadata.findMany({
+      orderBy: { deployedAt: 'desc' },
+    });
+    const result = rows.map(r => this.mapToResponse(r));
+    await this.redis.set(key, result, this.ttl);
+    return result;
+  }
+
+  /**
+   * Return all deployment metadata records for a given network.
+   */
+  async getByNetwork(
+    network: string,
+  ): Promise<DeploymentMetadataResponseDto[]> {
+    const key = KEYS.byNetwork(network);
+    const cached =
+      await this.redis.get<DeploymentMetadataResponseDto[]>(key);
+    if (cached !== null) {
+      this.logger.debug(`cache hit: getByNetwork(${network})`);
+      return cached;
+    }
+
+    this.logger.debug(`cache miss: getByNetwork(${network}) – loading from DB`);
+    const rows = await this.prisma.deploymentMetadata.findMany({
+      where: { network },
+      orderBy: { deployedAt: 'desc' },
+    });
+    const result = rows.map(r => this.mapToResponse(r));
+    await this.redis.set(key, result, this.ttl);
+    return result;
+  }
+
+  /**
+   * Return a single record by network + contract name.
+   * Returns null (and does NOT throw) when not found – callers decide.
+   */
+  async getByNetworkAndContractName(
+    network: string,
+    contractName: string,
+  ): Promise<DeploymentMetadataResponseDto | null> {
+    const key = KEYS.byNetworkAndName(network, contractName);
+    const cached =
+      await this.redis.get<DeploymentMetadataResponseDto | null>(key);
+    if (cached !== undefined && cached !== null) {
+      this.logger.debug(
+        `cache hit: getByNetworkAndContractName(${network}, ${contractName})`,
+      );
+      return cached;
+    }
+
+    this.logger.debug(
+      `cache miss: getByNetworkAndContractName(${network}, ${contractName}) – loading from DB`,
+    );
+    const row = await this.prisma.deploymentMetadata.findUnique({
+      where: { network_contractName: { network, contractName } },
+    });
+    const result = row ? this.mapToResponse(row) : null;
+    // Cache the result even when null so we don't hammer the DB on repeated
+    // lookups for a contract that hasn't been deployed yet.
+    await this.redis.set(key, result, this.ttl);
+    return result;
+  }
+
+  /**
+   * Return a single record by on-chain contract ID (address).
+   */
+  async getByContractId(
+    contractId: string,
+  ): Promise<DeploymentMetadataResponseDto | null> {
+    const key = KEYS.byContractId(contractId);
+    const cached =
+      await this.redis.get<DeploymentMetadataResponseDto | null>(key);
+    if (cached !== undefined && cached !== null) {
+      this.logger.debug(`cache hit: getByContractId(${contractId})`);
+      return cached;
+    }
+
+    this.logger.debug(
+      `cache miss: getByContractId(${contractId}) – loading from DB`,
+    );
+    const row = await this.prisma.deploymentMetadata.findFirst({
+      where: { contractId },
+    });
+    const result = row ? this.mapToResponse(row) : null;
+    await this.redis.set(key, result, this.ttl);
+    return result;
+  }
+
+  // ─── Cache management ───────────────────────────────────────────────────────
+
+  /**
+   * Invalidate all contract-config cache keys.
+   * Called automatically after write operations (create / update / delete).
+   */
+  async invalidateAll(): Promise<number> {
+    const deleted = await this.redis.delByPattern(KEYS.pattern());
+    this.logger.log(
+      `contract-config cache invalidated: ${deleted} key(s) removed`,
+    );
+    return deleted;
+  }
+
+  /**
+   * Warm the cache by loading all records from the DB.
+   * Drops existing keys first so stale entries are never served.
+   *
+   * Used by the admin refresh endpoint.
+   */
+  async refreshAll(): Promise<{
+    refreshedAt: Date;
+    contractCount: number;
+    networkCount: number;
+  }> {
+    this.logger.log('contract-config cache refresh requested');
+
+    // 1. Wipe existing snapshot
+    await this.invalidateAll();
+
+    // 2. Load everything from Prisma
+    const rows = await this.prisma.deploymentMetadata.findMany({
+      orderBy: { deployedAt: 'desc' },
+    });
+    const all = rows.map(r => this.mapToResponse(r));
+
+    // 3. Populate the "all" key
+    await this.redis.set(KEYS.all(), all, this.ttl);
+
+    // 4. Populate per-network keys
+    const byNetwork = new Map<string, DeploymentMetadataResponseDto[]>();
+    for (const item of all) {
+      const list = byNetwork.get(item.network) ?? [];
+      list.push(item);
+      byNetwork.set(item.network, list);
+    }
+    for (const [network, list] of byNetwork.entries()) {
+      await this.redis.set(KEYS.byNetwork(network), list, this.ttl);
+    }
+
+    // 5. Populate per-contract keys
+    for (const item of all) {
+      await this.redis.set(
+        KEYS.byNetworkAndName(item.network, item.contractName),
+        item,
+        this.ttl,
+      );
+      await this.redis.set(
+        KEYS.byContractId(item.contractId),
+        item,
+        this.ttl,
+      );
+    }
+
+    this.logger.log(
+      `contract-config cache warmed: ${all.length} contract(s), ${byNetwork.size} network(s)`,
+    );
+
+    return {
+      refreshedAt: new Date(),
+      contractCount: all.length,
+      networkCount: byNetwork.size,
+    };
+  }
+
+  // ─── Private ────────────────────────────────────────────────────────────────
+
+  private mapToResponse(metadata: any): DeploymentMetadataResponseDto {
+    return {
+      id: metadata.id,
+      contractName: metadata.contractName,
+      network: metadata.network,
+      contractId: metadata.contractId,
+      wasmHash: metadata.wasmHash,
+      deployedAt: metadata.deployedAt,
+      commitSha: metadata.commitSha ?? undefined,
+      deployer: metadata.deployer ?? undefined,
+      transactionHash: metadata.transactionHash ?? undefined,
+      metadata: metadata.metadata ?? undefined,
+      createdAt: metadata.createdAt,
+      updatedAt: metadata.updatedAt,
+    };
+  }
+}

--- a/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.controller.ts
@@ -208,6 +208,44 @@ export class DeploymentMetadataController {
   }
 
   /**
+   * Refresh the contract-config cache (admin only)
+   * POST /deployment-metadata/cache/refresh
+   *
+   * Drops all cached contract ID / config snapshots and re-warms them from
+   * the database immediately. Useful after an out-of-band deployment or any
+   * time the cache needs to reflect the current DB state without waiting for
+   * the TTL to expire.
+   */
+  @Post('cache/refresh')
+  @Roles(AppRole.admin)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Refresh contract-config cache (admin only)',
+    description:
+      'Invalidates and re-warms all cached contract ID / deployment-config snapshots from the database.',
+  })
+  @ApiOkResponse({
+    description: 'Cache refreshed successfully.',
+    schema: {
+      type: 'object',
+      properties: {
+        refreshedAt: { type: 'string', format: 'date-time' },
+        contractCount: { type: 'integer' },
+        networkCount: { type: 'integer' },
+      },
+    },
+  })
+  @ApiInternalServerErrorResponse({ description: 'Cache refresh failed.' })
+  async refreshCache(): Promise<{
+    refreshedAt: Date;
+    contractCount: number;
+    networkCount: number;
+  }> {
+    this.logger.log('Admin-triggered contract-config cache refresh');
+    return this.deploymentMetadataService.refreshCache();
+  }
+
+  /**
    * Update deployment metadata
    * PUT /deployment-metadata/:id
    * @protected admin only

--- a/app/backend/src/deployment-metadata/deployment-metadata.module.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { DeploymentMetadataController } from './deployment-metadata.controller';
 import { DeploymentMetadataService } from './deployment-metadata.service';
+import { ContractConfigCacheService } from './contract-config-cache.service';
 
 @Module({
   imports: [PrismaModule],
   controllers: [DeploymentMetadataController],
-  providers: [DeploymentMetadataService],
-  exports: [DeploymentMetadataService],
+  providers: [DeploymentMetadataService, ContractConfigCacheService],
+  exports: [DeploymentMetadataService, ContractConfigCacheService],
 })
 export class DeploymentMetadataModule {}

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.spec.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.spec.ts
@@ -1,12 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DeploymentMetadataService } from './deployment-metadata.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { ContractConfigCacheService } from './contract-config-cache.service';
 
 describe('DeploymentMetadataService', () => {
   let service: DeploymentMetadataService;
-  let prisma: PrismaService;
+  let prisma: jest.Mocked<PrismaService>;
+  let cache: jest.Mocked<ContractConfigCacheService>;
 
-  const mockDeploymentMetadata = {
+  const mockRecord = {
     id: 'test-id-1',
     contractName: 'AidEscrow',
     network: 'testnet',
@@ -23,7 +25,7 @@ describe('DeploymentMetadataService', () => {
     updatedAt: new Date('2026-06-03T12:00:00Z'),
   };
 
-  const mockPrismaService = {
+  const mockPrisma = {
     deploymentMetadata: {
       create: jest.fn(),
       findMany: jest.fn(),
@@ -34,29 +36,43 @@ describe('DeploymentMetadataService', () => {
     },
   };
 
+  const mockCache = {
+    getAll: jest.fn(),
+    getByNetwork: jest.fn(),
+    getByNetworkAndContractName: jest.fn(),
+    getByContractId: jest.fn(),
+    invalidateAll: jest.fn(),
+    refreshAll: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeploymentMetadataService,
-        {
-          provide: PrismaService,
-          useValue: mockPrismaService,
-        },
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: ContractConfigCacheService, useValue: mockCache },
       ],
     }).compile();
 
     service = module.get<DeploymentMetadataService>(DeploymentMetadataService);
-    prisma = module.get<PrismaService>(PrismaService);
+    prisma = module.get(PrismaService);
+    cache = module.get(ContractConfigCacheService);
 
-    // Reset all mocks before each test
     jest.clearAllMocks();
+    // Default: invalidateAll and refreshAll resolve cleanly
+    mockCache.invalidateAll.mockResolvedValue(0);
+    mockCache.refreshAll.mockResolvedValue({
+      refreshedAt: new Date(),
+      contractCount: 1,
+      networkCount: 1,
+    });
   });
 
+  // ─── create ────────────────────────────────────────────────────────────────
+
   describe('create', () => {
-    it('should create a new deployment metadata', async () => {
-      mockPrismaService.deploymentMetadata.create.mockResolvedValue(
-        mockDeploymentMetadata,
-      );
+    it('creates a record and invalidates the cache', async () => {
+      mockPrisma.deploymentMetadata.create.mockResolvedValue(mockRecord);
 
       const dto = {
         contractName: 'AidEscrow',
@@ -73,33 +89,53 @@ describe('DeploymentMetadataService', () => {
 
       const result = await service.create(dto);
 
-      expect(result).toEqual(mockDeploymentMetadata);
-      expect(prisma.deploymentMetadata.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          contractName: dto.contractName,
-          network: dto.network,
-          contractId: dto.contractId,
+      expect(mockPrisma.deploymentMetadata.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            contractName: dto.contractName,
+            network: dto.network,
+            contractId: dto.contractId,
+          }),
         }),
+      );
+      expect(mockCache.invalidateAll).toHaveBeenCalledTimes(1);
+      expect(result.id).toBe(mockRecord.id);
+    });
+
+    it('propagates Prisma unique-constraint errors without swallowing them', async () => {
+      const err = Object.assign(new Error('Unique constraint failed'), {
+        code: 'P2002',
       });
+      mockPrisma.deploymentMetadata.create.mockRejectedValue(err);
+
+      await expect(
+        service.create({
+          contractName: 'AidEscrow',
+          network: 'testnet',
+          contractId: 'C123',
+          wasmHash: 'abc',
+          deployedAt: '2026-06-03T12:00:00Z',
+        }),
+      ).rejects.toThrow();
     });
   });
 
+  // ─── read helpers (all delegated to cache) ─────────────────────────────────
+
   describe('findAll', () => {
-    it('should return all deployment metadata', async () => {
-      mockPrismaService.deploymentMetadata.findMany.mockResolvedValue([
-        mockDeploymentMetadata,
-      ]);
+    it('delegates to ContractConfigCacheService.getAll()', async () => {
+      mockCache.getAll.mockResolvedValue([mockRecord]);
 
       const result = await service.findAll();
 
-      expect(result).toEqual([mockDeploymentMetadata]);
-      expect(prisma.deploymentMetadata.findMany).toHaveBeenCalledWith({
-        orderBy: { deployedAt: 'desc' },
-      });
+      expect(mockCache.getAll).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([mockRecord]);
+      // Prisma should NOT be called directly
+      expect(mockPrisma.deploymentMetadata.findMany).not.toHaveBeenCalled();
     });
 
-    it('should return empty array when no metadata exists', async () => {
-      mockPrismaService.deploymentMetadata.findMany.mockResolvedValue([]);
+    it('returns empty array when cache/DB has no records', async () => {
+      mockCache.getAll.mockResolvedValue([]);
 
       const result = await service.findAll();
 
@@ -108,53 +144,44 @@ describe('DeploymentMetadataService', () => {
   });
 
   describe('findByNetwork', () => {
-    it('should return metadata for a specific network', async () => {
-      mockPrismaService.deploymentMetadata.findMany.mockResolvedValue([
-        mockDeploymentMetadata,
-      ]);
+    it('delegates to ContractConfigCacheService.getByNetwork()', async () => {
+      mockCache.getByNetwork.mockResolvedValue([mockRecord]);
 
       const result = await service.findByNetwork('testnet');
 
-      expect(result).toEqual([mockDeploymentMetadata]);
-      expect(prisma.deploymentMetadata.findMany).toHaveBeenCalledWith({
-        where: { network: 'testnet' },
-        orderBy: { deployedAt: 'desc' },
-      });
+      expect(mockCache.getByNetwork).toHaveBeenCalledWith('testnet');
+      expect(result).toEqual([mockRecord]);
+      expect(mockPrisma.deploymentMetadata.findMany).not.toHaveBeenCalled();
     });
 
-    it('should return empty array for network with no deployments', async () => {
-      mockPrismaService.deploymentMetadata.findMany.mockResolvedValue([]);
+    it('returns empty array for unknown network', async () => {
+      mockCache.getByNetwork.mockResolvedValue([]);
 
-      const result = await service.findByNetwork('nonexistent');
+      const result = await service.findByNetwork('unknown');
 
       expect(result).toEqual([]);
     });
   });
 
   describe('findByNetworkAndContractName', () => {
-    it('should return metadata for a specific network and contract name', async () => {
-      mockPrismaService.deploymentMetadata.findUnique.mockResolvedValue(
-        mockDeploymentMetadata,
-      );
+    it('delegates to ContractConfigCacheService.getByNetworkAndContractName()', async () => {
+      mockCache.getByNetworkAndContractName.mockResolvedValue(mockRecord);
 
       const result = await service.findByNetworkAndContractName(
         'testnet',
         'AidEscrow',
       );
 
-      expect(result).toEqual(mockDeploymentMetadata);
-      expect(prisma.deploymentMetadata.findUnique).toHaveBeenCalledWith({
-        where: {
-          network_contractName: {
-            network: 'testnet',
-            contractName: 'AidEscrow',
-          },
-        },
-      });
+      expect(mockCache.getByNetworkAndContractName).toHaveBeenCalledWith(
+        'testnet',
+        'AidEscrow',
+      );
+      expect(result).toEqual(mockRecord);
+      expect(mockPrisma.deploymentMetadata.findUnique).not.toHaveBeenCalled();
     });
 
-    it('should return null if metadata not found', async () => {
-      mockPrismaService.deploymentMetadata.findUnique.mockResolvedValue(null);
+    it('returns null when contract is not found', async () => {
+      mockCache.getByNetworkAndContractName.mockResolvedValue(null);
 
       const result = await service.findByNetworkAndContractName(
         'testnet',
@@ -166,26 +193,22 @@ describe('DeploymentMetadataService', () => {
   });
 
   describe('findByContractId', () => {
-    it('should return metadata for a specific contract ID', async () => {
-      mockPrismaService.deploymentMetadata.findFirst.mockResolvedValue(
-        mockDeploymentMetadata,
-      );
+    it('delegates to ContractConfigCacheService.getByContractId()', async () => {
+      mockCache.getByContractId.mockResolvedValue(mockRecord);
 
       const result = await service.findByContractId(
         'CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG',
       );
 
-      expect(result).toEqual(mockDeploymentMetadata);
-      expect(prisma.deploymentMetadata.findFirst).toHaveBeenCalledWith({
-        where: {
-          contractId:
-            'CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG',
-        },
-      });
+      expect(mockCache.getByContractId).toHaveBeenCalledWith(
+        'CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG',
+      );
+      expect(result).toEqual(mockRecord);
+      expect(mockPrisma.deploymentMetadata.findFirst).not.toHaveBeenCalled();
     });
 
-    it('should return null if contract ID not found', async () => {
-      mockPrismaService.deploymentMetadata.findFirst.mockResolvedValue(null);
+    it('returns null when contract ID is not found', async () => {
+      mockCache.getByContractId.mockResolvedValue(null);
 
       const result = await service.findByContractId('NONEXISTENT');
 
@@ -193,68 +216,79 @@ describe('DeploymentMetadataService', () => {
     });
   });
 
+  // ─── update ────────────────────────────────────────────────────────────────
+
   describe('update', () => {
-    it('should update deployment metadata', async () => {
-      const updated = { ...mockDeploymentMetadata, commitSha: 'new-sha-123' };
-      mockPrismaService.deploymentMetadata.update.mockResolvedValue(updated);
+    it('updates the record and invalidates the cache', async () => {
+      const updated = { ...mockRecord, commitSha: 'new-sha-123' };
+      mockPrisma.deploymentMetadata.update.mockResolvedValue(updated);
 
-      const dto = { commitSha: 'new-sha-123' };
-      const result = await service.update('test-id-1', dto);
-
-      expect(result).toEqual(updated);
-      expect(prisma.deploymentMetadata.update).toHaveBeenCalledWith({
-        where: { id: 'test-id-1' },
-        data: expect.objectContaining(dto),
+      const result = await service.update('test-id-1', {
+        commitSha: 'new-sha-123',
       });
+
+      expect(mockPrisma.deploymentMetadata.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'test-id-1' } }),
+      );
+      expect(mockCache.invalidateAll).toHaveBeenCalledTimes(1);
+      expect(result.commitSha).toBe('new-sha-123');
     });
   });
 
+  // ─── delete ────────────────────────────────────────────────────────────────
+
   describe('delete', () => {
-    it('should delete deployment metadata', async () => {
-      mockPrismaService.deploymentMetadata.delete.mockResolvedValue(
-        mockDeploymentMetadata,
-      );
+    it('deletes the record and invalidates the cache', async () => {
+      mockPrisma.deploymentMetadata.delete.mockResolvedValue(mockRecord);
 
       await service.delete('test-id-1');
 
-      expect(prisma.deploymentMetadata.delete).toHaveBeenCalledWith({
+      expect(mockPrisma.deploymentMetadata.delete).toHaveBeenCalledWith({
         where: { id: 'test-id-1' },
       });
+      expect(mockCache.invalidateAll).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('tenant safety', () => {
-    it('should isolate deployment metadata per network', async () => {
-      const testnetMetadata = { ...mockDeploymentMetadata, network: 'testnet' };
-      const mainnetMetadata = { ...mockDeploymentMetadata, network: 'mainnet' };
+  // ─── refreshCache ──────────────────────────────────────────────────────────
 
-      mockPrismaService.deploymentMetadata.findMany
-        .mockResolvedValueOnce([testnetMetadata])
-        .mockResolvedValueOnce([mainnetMetadata]);
+  describe('refreshCache', () => {
+    it('delegates to ContractConfigCacheService.refreshAll() and returns stats', async () => {
+      const stats = {
+        refreshedAt: new Date('2026-06-03T12:00:00Z'),
+        contractCount: 3,
+        networkCount: 2,
+      };
+      mockCache.refreshAll.mockResolvedValue(stats);
 
-      const testnetResult = await service.findByNetwork('testnet');
-      const mainnetResult = await service.findByNetwork('mainnet');
+      const result = await service.refreshCache();
 
-      expect(testnetResult).toEqual([testnetMetadata]);
-      expect(mainnetResult).toEqual([mainnetMetadata]);
-      expect(prisma.deploymentMetadata.findMany).toHaveBeenCalledTimes(2);
+      expect(mockCache.refreshAll).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(stats);
+    });
+  });
+
+  // ─── network isolation ─────────────────────────────────────────────────────
+
+  describe('network isolation', () => {
+    it('returns only testnet records when querying testnet', async () => {
+      const testnetRecord = { ...mockRecord, network: 'testnet' };
+      mockCache.getByNetwork.mockResolvedValue([testnetRecord]);
+
+      const result = await service.findByNetwork('testnet');
+
+      expect(result).toEqual([testnetRecord]);
+      expect(result.every(r => r.network === 'testnet')).toBe(true);
     });
 
-    it('should enforce unique constraint on network and contractName', async () => {
-      const error = new Error('Unique constraint failed');
-      (error as any).code = 'P2002';
-      mockPrismaService.deploymentMetadata.create.mockRejectedValueOnce(error);
+    it('returns only mainnet records when querying mainnet', async () => {
+      const mainnetRecord = { ...mockRecord, network: 'mainnet' };
+      mockCache.getByNetwork.mockResolvedValue([mainnetRecord]);
 
-      const dto = {
-        contractName: 'AidEscrow',
-        network: 'testnet',
-        contractId: 'CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG',
-        wasmHash:
-          '24328e15b7c11c7ff07caeaf0328da591b3b63e84af57fa03623c10126eabc8d',
-        deployedAt: '2026-06-03T12:00:00Z',
-      };
+      const result = await service.findByNetwork('mainnet');
 
-      await expect(service.create(dto)).rejects.toThrow();
+      expect(result).toEqual([mainnetRecord]);
+      expect(result.every(r => r.network === 'mainnet')).toBe(true);
     });
   });
 });

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.spec.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.spec.ts
@@ -5,8 +5,8 @@ import { ContractConfigCacheService } from './contract-config-cache.service';
 
 describe('DeploymentMetadataService', () => {
   let service: DeploymentMetadataService;
-  let prisma: jest.Mocked<PrismaService>;
-  let cache: jest.Mocked<ContractConfigCacheService>;
+  let _prisma: jest.Mocked<PrismaService>;
+  let _cache: jest.Mocked<ContractConfigCacheService>;
 
   const mockRecord = {
     id: 'test-id-1',
@@ -55,8 +55,8 @@ describe('DeploymentMetadataService', () => {
     }).compile();
 
     service = module.get<DeploymentMetadataService>(DeploymentMetadataService);
-    prisma = module.get(PrismaService);
-    cache = module.get(ContractConfigCacheService);
+    _prisma = module.get(PrismaService);
+    _cache = module.get(ContractConfigCacheService);
 
     jest.clearAllMocks();
     // Default: invalidateAll and refreshAll resolve cleanly

--- a/app/backend/src/deployment-metadata/deployment-metadata.service.ts
+++ b/app/backend/src/deployment-metadata/deployment-metadata.service.ts
@@ -6,15 +6,20 @@ import {
   UpdateDeploymentMetadataDto,
   DeploymentMetadataResponseDto,
 } from './dto/deployment-metadata.dto';
+import { ContractConfigCacheService } from './contract-config-cache.service';
 
 @Injectable()
 export class DeploymentMetadataService {
   private readonly logger = new Logger(DeploymentMetadataService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly contractConfigCache: ContractConfigCacheService,
+  ) {}
 
   /**
-   * Create a new deployment metadata record
+   * Create a new deployment metadata record.
+   * Invalidates the contract-config cache so subsequent reads are fresh.
    */
   async create(
     dto: CreateDeploymentMetadataDto,
@@ -38,68 +43,51 @@ export class DeploymentMetadataService {
       },
     });
 
+    await this.contractConfigCache.invalidateAll();
     return this.mapToResponse(metadata);
   }
 
   /**
-   * List all deployment metadata
+   * List all deployment metadata (cache-backed).
    */
   async findAll(): Promise<DeploymentMetadataResponseDto[]> {
-    const metadata = await this.prisma.deploymentMetadata.findMany({
-      orderBy: { deployedAt: 'desc' },
-    });
-
-    return metadata.map(m => this.mapToResponse(m));
+    return this.contractConfigCache.getAll();
   }
 
   /**
-   * Get deployment metadata by network
+   * Get deployment metadata by network (cache-backed).
    */
   async findByNetwork(
     network: string,
   ): Promise<DeploymentMetadataResponseDto[]> {
-    const metadata = await this.prisma.deploymentMetadata.findMany({
-      where: { network },
-      orderBy: { deployedAt: 'desc' },
-    });
-
-    return metadata.map(m => this.mapToResponse(m));
+    return this.contractConfigCache.getByNetwork(network);
   }
 
   /**
-   * Get deployment metadata by network and contract name
+   * Get deployment metadata by network and contract name (cache-backed).
    */
   async findByNetworkAndContractName(
     network: string,
     contractName: string,
   ): Promise<DeploymentMetadataResponseDto | null> {
-    const metadata = await this.prisma.deploymentMetadata.findUnique({
-      where: {
-        network_contractName: {
-          network,
-          contractName,
-        },
-      },
-    });
-
-    return metadata ? this.mapToResponse(metadata) : null;
+    return this.contractConfigCache.getByNetworkAndContractName(
+      network,
+      contractName,
+    );
   }
 
   /**
-   * Get deployment metadata by contract ID
+   * Get deployment metadata by contract ID (cache-backed).
    */
   async findByContractId(
     contractId: string,
   ): Promise<DeploymentMetadataResponseDto | null> {
-    const metadata = await this.prisma.deploymentMetadata.findFirst({
-      where: { contractId },
-    });
-
-    return metadata ? this.mapToResponse(metadata) : null;
+    return this.contractConfigCache.getByContractId(contractId);
   }
 
   /**
-   * Update deployment metadata
+   * Update deployment metadata.
+   * Invalidates the contract-config cache so subsequent reads are fresh.
    */
   async update(
     id: string,
@@ -119,17 +107,32 @@ export class DeploymentMetadataService {
       },
     });
 
+    await this.contractConfigCache.invalidateAll();
     return this.mapToResponse(metadata);
   }
 
   /**
-   * Delete deployment metadata
+   * Delete deployment metadata.
+   * Invalidates the contract-config cache so the deleted entry isn't served.
    */
   async delete(id: string): Promise<void> {
     this.logger.log(`Deleting deployment metadata ${id}`);
     await this.prisma.deploymentMetadata.delete({
       where: { id },
     });
+    await this.contractConfigCache.invalidateAll();
+  }
+
+  /**
+   * Admin-triggered cache refresh.
+   * Drops all contract-config keys and re-warms them from the DB.
+   */
+  async refreshCache(): Promise<{
+    refreshedAt: Date;
+    contractCount: number;
+    networkCount: number;
+  }> {
+    return this.contractConfigCache.refreshAll();
   }
 
   /**


### PR DESCRIPTION
closes #563 