### PR TITLE
Add machine-readable contract registry artifact

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -46,12 +46,12 @@ jobs:
 
       - name: Generate contract registry artifact
         run: |
-          python3 app/onchain/scripts/generate_contract_registry.py \
-            --registry-json app/onchain/deployments/registry.json \
-            --output app/onchain/deployments/contract-registry.json
+          python3 scripts/generate_contract_registry.py \
+            --registry-json deployments/registry.json \
+            --output deployments/contract-registry.json
 
       - name: Upload contract registry artifact
         uses: actions/upload-artifact@v4
         with:
           name: contract-registry
-          path: app/onchain/deployments/contract-registry.json
+          path: deployments/contract-registry.json

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -2,11 +2,11 @@ name: Contract CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'app/onchain/**'
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
       - 'app/onchain/**'
 
@@ -31,7 +31,7 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "app/onchain"
+          workspaces: 'app/onchain'
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -43,3 +43,15 @@ jobs:
 
       - name: Run tests
         run: cargo test --target x86_64-unknown-linux-gnu
+
+      - name: Generate contract registry artifact
+        run: |
+          python3 app/onchain/scripts/generate_contract_registry.py \
+            --registry-json app/onchain/deployments/registry.json \
+            --output app/onchain/deployments/contract-registry.json
+
+      - name: Upload contract registry artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-registry
+          path: app/onchain/deployments/contract-registry.json

--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -46,12 +46,12 @@ jobs:
 
       - name: Generate contract registry artifact
         run: |
-          python3 scripts/generate_contract_registry.py \
-            --registry-json deployments/registry.json \
-            --output deployments/contract-registry.json
+          python3 app/onchain/scripts/generate_contract_registry.py \
+            --registry-json app/onchain/deployments/registry.json \
+            --output app/onchain/deployments/contract-registry.json
 
       - name: Upload contract registry artifact
         uses: actions/upload-artifact@v4
         with:
           name: contract-registry
-          path: deployments/contract-registry.json
+          path: app/onchain/deployments/contract-registry.json

--- a/app/onchain/README.md
+++ b/app/onchain/README.md
@@ -10,6 +10,18 @@ This module contains Soroban smart contracts for Soter's on-chain escrow and cla
 
 [View on Stellar Expert](https://stellar.expert/explorer/testnet/contract/CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG) · [View on Stellar Lab](https://lab.stellar.org/r/testnet/contract/CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG)
 
+### Machine-readable registry artifact
+
+The deployment registry is available at [deployments/contract-registry.json](deployments/contract-registry.json). It is generated deterministically from [deployments/registry.json](deployments/registry.json) and includes the contract name, network, version, contract ID, deployed timestamp, and optional deployment metadata for backend/frontend consumers.
+
+Generate it locally or in CI with:
+
+```bash
+python3 scripts/generate_contract_registry.py \
+  --registry-json deployments/registry.json \
+  --output deployments/contract-registry.json
+```
+
 ## 🧠 AidEscrow Contract
 
 The **AidEscrow** contract facilitates secure, transparent aid disbursement. Packages are created for specific recipients with locked funds, and can be disbursed by administrators.

--- a/app/onchain/deployments/contract-registry.json
+++ b/app/onchain/deployments/contract-registry.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "contracts": [
+    {
+      "name": "aid_escrow",
+      "network": "testnet",
+      "version": "0.1.0",
+      "contract_id": "CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG",
+      "deployed_at": "2026-06-03",
+      "wasm_hash": "24328e15b7c11c7ff07caeaf0328da591b3b63e84af57fa03623c10126eabc8d",
+      "record": "deployments/testnet-2026-06-03.md",
+      "version_tag": "v0.1.0-testnet"
+    }
+  ]
+}

--- a/app/onchain/scripts/deploy-testnet.sh
+++ b/app/onchain/scripts/deploy-testnet.sh
@@ -64,9 +64,14 @@ REGISTER_OUT=$(python3 "$SCRIPT_DIR/register-deployment.py" \
 
 echo "$REGISTER_OUT"
 
+python3 "$SCRIPT_DIR/generate_contract_registry.py" \
+    --registry-json "$PROJECT_DIR/deployments/registry.json" \
+    --output "$PROJECT_DIR/deployments/contract-registry.json"
+
 VERSION_TAG=$(echo "$REGISTER_OUT" | awk -F= '/^VERSION_TAG=/{print $2}')
 echo ""
 echo "✅ Registered deployment in deployments/registry.json"
+echo "✅ Wrote deployments/contract-registry.json"
 echo "🏷️  Suggested git tag: $VERSION_TAG"
 echo "   git tag -a '$VERSION_TAG' -m 'aid_escrow $CONTRACT_VERSION testnet deploy ($CONTRACT_ID)'"
 

--- a/app/onchain/scripts/deploy.sh
+++ b/app/onchain/scripts/deploy.sh
@@ -167,6 +167,11 @@ if [ -n "$CONTRACT_ID" ]; then
                 esac
             done
         fi
+
+        python3 "$SCRIPT_DIR/generate_contract_registry.py" \
+            --registry-json "$PROJECT_DIR/deployments/registry.json" \
+            --output "$PROJECT_DIR/deployments/contract-registry.json"
+        echo "✅ Wrote deployments/contract-registry.json"
     else
         echo "⚠️  python3 not found; skipped registry update (run scripts/register-deployment.py manually)"
     fi

--- a/app/onchain/scripts/generate_contract_registry.py
+++ b/app/onchain/scripts/generate_contract_registry.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Generate a machine-readable contract registry artifact from deployments/registry.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_registry(path: Path) -> dict[str, Any]:
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    return {
+        "schema_version": 1,
+        "contract": "aid_escrow",
+        "deployments": [],
+    }
+
+
+def build_contract_registry(registry_path: Path) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    deployments = registry.get("deployments", [])
+
+    contracts: list[dict[str, Any]] = []
+    for deployment in deployments:
+        contract_id = deployment.get("contract_id")
+        if not contract_id:
+            continue
+
+        contracts.append(
+            {
+                "name": deployment.get("contract_name") or registry.get("contract") or "unknown",
+                "network": deployment.get("network"),
+                "version": deployment.get("version"),
+                "contract_id": contract_id,
+                "deployed_at": deployment.get("deployed_at"),
+                "wasm_hash": deployment.get("wasm_hash"),
+                "record": deployment.get("record"),
+                "version_tag": deployment.get("version_tag"),
+            }
+        )
+
+    contracts.sort(
+        key=lambda item: (
+            str(item.get("name", "")),
+            str(item.get("network", "")),
+            str(item.get("version", "")),
+            str(item.get("contract_id", "")),
+        )
+    )
+
+    return {
+        "schema_version": registry.get("schema_version", 1),
+        "contracts": contracts,
+    }
+
+
+def write_contract_registry(artifact: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a machine-readable contract registry artifact")
+    parser.add_argument(
+        "--registry-json",
+        default="deployments/registry.json",
+        help="Path to the source registry JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        default="deployments/contract-registry.json",
+        help="Path to write the generated contract registry JSON",
+    )
+    args = parser.parse_args()
+
+    registry_path = Path(args.registry_json)
+    output_path = Path(args.output)
+
+    if not registry_path.is_absolute():
+        project_dir = Path(__file__).resolve().parents[1]
+        registry_path = project_dir / registry_path
+        output_path = project_dir / output_path
+
+    artifact = build_contract_registry(registry_path)
+    write_contract_registry(artifact, output_path)
+    print(f"WROTE={output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/onchain/tests/test_contract_registry.py
+++ b/app/onchain/tests/test_contract_registry.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+import json
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from generate_contract_registry import build_contract_registry, write_contract_registry
+
+
+def test_build_contract_registry_uses_registry_entries_and_sorts_output(tmp_path):
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "contract": "aid_escrow",
+                "deployments": [
+                    {
+                        "network": "testnet",
+                        "version": "0.1.0",
+                        "contract_id": "CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG",
+                        "deployed_at": "2026-06-03",
+                    },
+                    {
+                        "network": "mainnet",
+                        "version": "0.2.0",
+                        "contract_id": "CBLAH1234567890",
+                        "deployed_at": "2026-06-04",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    output_path = tmp_path / "contract-registry.json"
+    artifact = build_contract_registry(registry_path)
+    write_contract_registry(artifact, output_path)
+
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert written["schema_version"] == 1
+    assert written["contracts"][0]["name"] == "aid_escrow"
+    assert written["contracts"][0]["contract_id"] == "CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG"
+    assert written["contracts"][0]["network"] == "testnet"
+    assert written["contracts"][0]["version"] == "0.1.0"
+    assert written["contracts"][0]["deployed_at"] == "2026-06-03"
+    assert written["contracts"][1]["contract_id"] == "CBLAH1234567890"


### PR DESCRIPTION
Closes #571 

## PR Title
Add machine-readable contract registry artifact for on-chain deployments

## Summary
This PR adds a deterministic, machine-readable contract registry artifact for Soter’s on-chain deployments so backend and frontend consumers can rely on a stable JSON file for contract metadata.

## What changed
- Added a generated JSON artifact at contract-registry.json
- Implemented a deterministic registry generator in generate_contract_registry.py
- Wired artifact generation into the existing deployment flow for local and testnet deployments
- Updated CI to generate and upload the artifact automatically
- Documented the artifact and generation command in the on-chain README
- Added regression coverage for the registry generation behavior

## Why
The repository already had deployment metadata in a registry-style structure, but there was no reusable machine-readable artifact tailored for downstream consumption. This change makes contract IDs, network, version, and deployment timestamps available in a predictable JSON format for backend/frontend integration and CI workflows.

## Acceptance criteria covered
- Output includes all contracts and their IDs
- Artifact can be generated locally or in CI deterministically

## Validation
- Verified the generator script runs successfully and writes the artifact
- Added a regression test covering the generated JSON structure and ordering

## Notes
- The artifact is generated from deployments/registry.json and can be recreated with:
  - python3 scripts/generate_contract_registry.py --registry-json deployments/registry.json --output deployments/contract-registry.json