### PR TITLE
a11y: announce pagination page changes with accessible status region

### DIFF
--- a/app/frontend/src/components/Pagination.tsx
+++ b/app/frontend/src/components/Pagination.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  /** Current 1-based page number. */
+  page: number;
+  /** Total number of pages. */
+  totalPages: number;
+  /** Number of items per page. */
+  pageSize: number;
+  /** Total item count across all pages. */
+  totalItems: number;
+  /** Called with the requested page number when the user navigates. */
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * Pagination – keyboard-navigable prev/next controls with a single polite
+ * ARIA live region that announces page changes to screen readers.
+ *
+ * Announcement format: "Page X of Y, showing items A–B"
+ *
+ * The live region fires only when the current page actually changes, so
+ * initial render and same-page re-renders are silent.  Mount this component
+ * once per paginated list to avoid duplicate announcements.
+ */
+export function Pagination({
+  page,
+  totalPages,
+  pageSize,
+  totalItems,
+  onPageChange,
+}: PaginationProps) {
+  const prevPageRef = useRef<number | null>(null);
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    // Skip the very first render – no page change has occurred yet
+    if (prevPageRef.current === null) {
+      prevPageRef.current = page;
+      return;
+    }
+    // Skip if the page didn't actually change
+    if (prevPageRef.current === page) return;
+
+    prevPageRef.current = page;
+
+    const firstItem = (page - 1) * pageSize + 1;
+    const lastItem = Math.min(page * pageSize, totalItems);
+    setAnnouncement(
+      `Page ${page} of ${totalPages}, showing items ${firstItem}\u2013${lastItem}`,
+    );
+  }, [page, totalPages, pageSize, totalItems]);
+
+  return (
+    <div className="flex items-center justify-between pt-2">
+      {/* Visually hidden polite live region – announces page changes to screen readers */}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {announcement}
+      </div>
+
+      <span className="text-xs text-gray-500 dark:text-gray-400" aria-hidden="true">
+        Page {page} of {totalPages}
+      </span>
+
+      <div className="flex gap-1">
+        <button
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+          aria-label="Previous page"
+          className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronLeft size={14} aria-hidden={true} />
+        </button>
+        <button
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= totalPages}
+          aria-label="Next page"
+          className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronRight size={14} aria-hidden={true} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/__tests__/Pagination.announce.test.tsx
+++ b/app/frontend/src/components/__tests__/Pagination.announce.test.tsx
@@ -1,0 +1,177 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { Pagination } from '../Pagination';
+
+// lucide-react icons aren't critical to test – keep the mock minimal
+jest.mock('lucide-react', () => ({
+  ChevronLeft: (props: Record<string, unknown>) => <svg data-testid="icon-prev" {...props} />,
+  ChevronRight: (props: Record<string, unknown>) => <svg data-testid="icon-next" {...props} />,
+}));
+
+const defaultProps = {
+  page: 1,
+  totalPages: 5,
+  pageSize: 10,
+  totalItems: 47,
+  onPageChange: jest.fn(),
+};
+
+function setup(props = {}) {
+  const merged = { ...defaultProps, ...props };
+  return render(<Pagination {...merged} />);
+}
+
+// Helper: find the single polite live region
+function getLiveRegion() {
+  return screen.getByRole('status');
+}
+
+describe('Pagination – rendering', () => {
+  it('renders previous and next buttons', () => {
+    setup();
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+  });
+
+  it('disables Previous on first page', () => {
+    setup({ page: 1 });
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled();
+  });
+
+  it('disables Next on last page', () => {
+    setup({ page: 5, totalPages: 5 });
+    expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+  });
+
+  it('enables both buttons on a middle page', () => {
+    setup({ page: 3, totalPages: 5 });
+    expect(screen.getByRole('button', { name: /previous page/i })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /next page/i })).not.toBeDisabled();
+  });
+
+  it('calls onPageChange with page-1 when Previous is clicked', () => {
+    const onPageChange = jest.fn();
+    setup({ page: 3, onPageChange });
+    fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('calls onPageChange with page+1 when Next is clicked', () => {
+    const onPageChange = jest.fn();
+    setup({ page: 3, onPageChange });
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+});
+
+describe('Pagination – ARIA live region', () => {
+  it('contains exactly one element with role="status"', () => {
+    setup();
+    expect(screen.getAllByRole('status')).toHaveLength(1);
+  });
+
+  it('live region has aria-live="polite" and aria-atomic="true"', () => {
+    setup();
+    const region = getLiveRegion();
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('live region is visually hidden via sr-only', () => {
+    setup();
+    expect(getLiveRegion()).toHaveClass('sr-only');
+  });
+
+  it('does NOT announce on initial render', () => {
+    setup({ page: 1 });
+    expect(getLiveRegion()).toHaveTextContent('');
+  });
+
+  it('announces after page change with correct format', () => {
+    // page=2, pageSize=10, totalItems=47 → items 11–20
+    const { rerender } = setup({ page: 1, totalPages: 5, pageSize: 10, totalItems: 47 });
+    act(() => {
+      rerender(
+        <Pagination
+          page={2}
+          totalPages={5}
+          pageSize={10}
+          totalItems={47}
+          onPageChange={defaultProps.onPageChange}
+        />
+      );
+    });
+    expect(getLiveRegion()).toHaveTextContent('Page 2 of 5, showing items 11–20');
+  });
+
+  it('announcement includes correct last-item when final page is partial', () => {
+    // page=5, pageSize=10, totalItems=47 → items 41–47
+    const { rerender } = setup({ page: 1, totalPages: 5, pageSize: 10, totalItems: 47 });
+    act(() => {
+      rerender(
+        <Pagination
+          page={5}
+          totalPages={5}
+          pageSize={10}
+          totalItems={47}
+          onPageChange={defaultProps.onPageChange}
+        />
+      );
+    });
+    expect(getLiveRegion()).toHaveTextContent('Page 5 of 5, showing items 41–47');
+  });
+
+  it('does NOT announce when the page prop is re-rendered with the same value', () => {
+    const { rerender } = setup({ page: 2 });
+    // First change: page 1 → 2 (announced)
+    act(() => {
+      rerender(
+        <Pagination {...defaultProps} page={2} />
+      );
+    });
+    const afterChange = getLiveRegion().textContent;
+
+    // Re-render with same page – announcement must not change
+    act(() => {
+      rerender(
+        <Pagination {...defaultProps} page={2} />
+      );
+    });
+    expect(getLiveRegion()).toHaveTextContent(afterChange ?? '');
+  });
+
+  it('updates announcement for each subsequent page change', () => {
+    const { rerender } = setup({ page: 1 });
+
+    act(() => {
+      rerender(<Pagination {...defaultProps} page={2} />);
+    });
+    expect(getLiveRegion()).toHaveTextContent('Page 2 of 5, showing items 11–20');
+
+    act(() => {
+      rerender(<Pagination {...defaultProps} page={3} />);
+    });
+    expect(getLiveRegion()).toHaveTextContent('Page 3 of 5, showing items 21–30');
+  });
+});
+
+describe('Pagination – coordination with marketplace list announcer', () => {
+  it('only one polite live region is present in the component output', () => {
+    setup();
+    const politeRegions = document
+      .querySelectorAll('[aria-live="polite"]');
+    // The component must not render more than one polite region
+    expect(politeRegions.length).toBe(1);
+  });
+
+  it('the live region is role=status (not role=log or role=alert)', () => {
+    setup();
+    const region = getLiveRegion();
+    expect(region.getAttribute('role')).toBe('status');
+    expect(region.getAttribute('aria-live')).toBe('polite');
+    // assertive would compete with other live regions
+    expect(region.getAttribute('aria-live')).not.toBe('assertive');
+  });
+});

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,67 @@
+# Accessibility
+
+This document describes the accessibility patterns used in the Soter frontend.
+
+---
+
+## Pagination status region (issue #276)
+
+### Behavior
+
+When a user navigates to a new page, a screen reader will announce:
+
+```
+Page X of Y, showing items A–B
+```
+
+where X is the current page, Y is the total number of pages, A is the first visible item number, and B is the last visible item number (capped at `totalItems` on the final page).
+
+### Live-region implementation
+
+The `<Pagination>` component (`src/components/Pagination.jsx`) renders a single polite ARIA live region:
+
+```jsx
+<div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+  {announcement}
+</div>
+```
+
+Key design decisions:
+
+- **`aria-live="polite"`** – the announcement waits for the screen reader to finish its current utterance, so it does not interrupt the user.
+- **`aria-atomic="true"`** – the entire message is read as one unit, preventing partial reads.
+- **`className="sr-only"`** – the region is visually hidden but available to assistive technology; this matches the same pattern used in `ImportRecipientsWizard` and `VerificationFlow`.
+- **No announcement on initial render** – `useRef` tracks the previous page value and the effect is skipped on mount, avoiding a redundant "Page 1 of Y" read when the list first loads.
+- **No announcement on same-page re-renders** – the effect compares the incoming `page` prop against the stored previous value and only updates the announcement string when they differ.
+
+### Coordination with existing list announcements
+
+The app's other live regions use `aria-live="polite"` for status feedback (wizard steps in `ImportRecipientsWizard`, inline feedback in `InlineFeedback`) and `aria-live="assertive"` for urgent alerts (`NetworkMismatchBanner`).
+
+The `<Pagination>` component:
+
+- Renders **exactly one** `role="status"` live region per instance.
+- Must be mounted **once per paginated list** — placing multiple `<Pagination>` instances on the same page would produce duplicate announcements.
+- Uses `polite` priority, so it naturally queues behind any concurrent toast or inline feedback without competing.
+
+There is no dedicated marketplace-list announcer in the current codebase. If one is added in the future, coordinate by ensuring it does not also announce page-position changes, and consider a shared `useAnnouncer` hook to serialise messages through a single live region.
+
+### WCAG 2.1 AA compliance
+
+| Criterion | Satisfied by |
+|-----------|-------------|
+| 1.3.1 Info and Relationships | Pagination buttons have descriptive `aria-label` attributes |
+| 2.1.1 Keyboard | Prev/Next are native `<button>` elements, fully keyboard accessible |
+| 4.1.3 Status Messages | Page-change announcements delivered via `role="status"` polite live region |
+
+---
+
+## Other patterns
+
+| Component | Pattern |
+|-----------|---------|
+| `ImportRecipientsWizard` | `role="status" aria-live="polite"` for step-transition and CSV feedback |
+| `VerificationFlow` | `role="status" className="sr-only"` for wizard-step announcements |
+| `InlineFeedback` | `role="status" aria-live="polite"` for form validation messages |
+| `NetworkMismatchBanner` | `aria-live="assertive"` for urgent network-mismatch alerts |
+| `ToastProvider` | Radix UI toast (manages its own live region via `@radix-ui/react-toast`) |


### PR DESCRIPTION
## Summary

Implements issue #276. Adds a single polite ARIA live region to the new `Pagination` component so screen-reader users hear a concise update whenever they navigate to a new page:

> "Page X of Y, showing items A–B"

## Accessibility implementation

- One `role="status" aria-live="polite" aria-atomic="true"` region per component instance, visually hidden with `sr-only` (matches the existing pattern in `ImportRecipientsWizard` and `VerificationFlow`).
- A `useRef` guard skips the initial render — no announcement on mount.
- A same-value guard skips re-renders where the page prop hasn't changed.
- Uses `polite` priority throughout — no competition with `NetworkMismatchBanner` or toasts.
- Prev/Next buttons are native `<button>` elements with `aria-label` — fully keyboard accessible.

## Changes

| File | Description |
|------|-------------|
| `app/frontend/src/components/Pagination.tsx` | New reusable pagination component with live region |
| `app/frontend/src/components/__tests__/Pagination.announce.test.tsx` | 16 tests covering rendering, ARIA attributes, announcement logic, no-duplicate guarantees |
| `docs/accessibility.md` | New doc: live-region pattern, WCAG 2.1 AA mapping, coordination guidance |

## Validation

```
pnpm eslint  →  0 errors on new files
pnpm jest    →  102 passed, 0 failed
pnpm build   →  ✓ Compiled successfully
```

Closes #276