### PR TITLE
feat(onchain): add optional receipt_hash to claim/disbursement events…

### DIFF
--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -22,7 +22,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, symbol_short, Address,
-    Bytes, Env, IntoVal, Map, String, Symbol, Val, Vec,
+    Bytes, BytesN, Env, IntoVal, Map, String, Symbol, Val, Vec,
 };
 
 // --- Storage Keys ---
@@ -135,6 +135,12 @@ pub struct PackageClaimed {
     pub amount: i128,
     pub actor: Address,
     pub timestamp: u64,
+    /// Optional off-chain receipt hash commitment (e.g. SHA-256 of a
+    /// delivery receipt).  Appended at the end of the payload so that
+    /// existing indexers that only read the original five fields
+    /// continue to work unchanged.  New indexers should treat the
+    /// absence (None) as an unanchored claim/cash transfer.
+    pub receipt_hash: Option<BytesN<32>>,
 }
 
 #[contractevent]
@@ -144,6 +150,10 @@ pub struct PackageDisbursed {
     pub amount: i128,
     pub actor: Address,
     pub timestamp: u64,
+    /// Optional off-chain receipt hash commitment for admin-driven
+    /// disbursements.  Same forward-compatibility rules as
+    /// ``PackageClaimed::receipt_hash``.
+    pub receipt_hash: Option<BytesN<32>>,
 }
 
 #[contractevent]
@@ -755,6 +765,10 @@ impl AidEscrow {
     // --- Recipient Actions ---
 
     /// Recipient claims the package.
+    ///
+    /// The emitted ``PackageClaimed`` event carries ``receipt_hash = None``
+    /// because the contract has not been supplied with one.  Use
+    /// :meth:`claim_with_receipt` to anchor an off-chain receipt hash.
     pub fn claim(env: Env, id: u64) -> Result<(), Error> {
         Self::check_action_paused(&env, symbol_short!("claim"))?;
         let key = (symbol_short!("pkg"), id);
@@ -786,7 +800,73 @@ impl AidEscrow {
         package.recipient.require_auth();
         let payout_recipient = package.recipient.clone();
 
-        Self::finalize_claim(&env, &key, &mut package, id, &payout_recipient, now)
+        Self::finalize_claim(
+            &env,
+            &key,
+            &mut package,
+            id,
+            &payout_recipient,
+            now,
+            None,
+        )
+    }
+
+    /// Recipient claims a package and anchors an off-chain receipt hash
+    /// on-chain.  Behaviour, authorization checks and state transitions
+    /// are identical to :meth:`claim`; the only difference is that the
+    /// emitted ``PackageClaimed`` event carries
+    /// ``receipt_hash = Some(hash)`` so that indexers can correlate the
+    /// on-chain transfer with the corresponding off-chain receipt
+    /// (e.g. delivery confirmation, signed proof of receipt photo).
+    ///
+    /// # Errors
+    /// Returns the same errors as :meth:`claim`.
+    pub fn claim_with_receipt(
+        env: Env,
+        id: u64,
+        receipt_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        Self::check_action_paused(&env, symbol_short!("claim"))?;
+        let key = (symbol_short!("pkg"), id);
+        let mut package: Package = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PackageNotFound)?;
+
+        if package.status != PackageStatus::Created {
+            return Err(Error::PackageNotActive);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < package.claim_starts_at {
+            return Err(Error::ClaimTooEarly);
+        }
+
+        if package.expires_at > 0 && now > package.expires_at {
+            return Err(Error::PackageExpired);
+        }
+
+        // Packages configured with a Merkle allowlist must be claimed
+        // through ``claim_with_proof`` so eligibility can be verified.
+        // We intentionally do not require an additional receipt-hash
+        // entrypoint there to keep the two claim paths orthogonal.
+        if Self::merkle_root_from_metadata(&env, &package.metadata).is_some() {
+            return Err(Error::InvalidProof);
+        }
+
+        package.recipient.require_auth();
+        let payout_recipient = package.recipient.clone();
+
+        Self::finalize_claim(
+            &env,
+            &key,
+            &mut package,
+            id,
+            &payout_recipient,
+            now,
+            Some(receipt_hash),
+        )
     }
 
     /// Claim a package guarded by an optional Merkle allowlist.
@@ -831,13 +911,13 @@ impl AidEscrow {
                 if !Self::verify_merkle_proof_for_claimant(&env, &claimant, &proof, root) {
                     return Err(Error::InvalidProof);
                 }
-                Self::finalize_claim(&env, &key, &mut package, id, &claimant, now)
+                Self::finalize_claim(&env, &key, &mut package, id, &claimant, now, None)
             }
             None => {
                 if claimant != package.recipient {
                     return Err(Error::NotAuthorized);
                 }
-                Self::finalize_claim(&env, &key, &mut package, id, &claimant, now)
+                Self::finalize_claim(&env, &key, &mut package, id, &claimant, now, None)
             }
         }
     }
@@ -845,7 +925,35 @@ impl AidEscrow {
     // --- Admin Actions ---
 
     /// Admin manually triggers disbursement (overrides recipient claim need, strictly checks status).
+    ///
+    /// The emitted ``PackageDisbursed`` event carries ``receipt_hash = None``
+    /// because the contract has not been supplied with one.  Use
+    /// :meth:`disburse_with_receipt` to anchor an off-chain receipt hash.
     pub fn disburse(env: Env, id: u64) -> Result<(), Error> {
+        Self::process_disburse(&env, id, None)
+    }
+
+    /// Admin manually triggers disbursement and anchors an off-chain
+    /// receipt hash on-chain.  Same authorisation/state-transition
+    /// rules as :meth:`disburse`; the only difference is that the
+    /// emitted ``PackageDisbursed`` event carries
+    /// ``receipt_hash = Some(hash)``.
+    ///
+    /// # Errors
+    /// Returns the same errors as :meth:`disburse`.
+    pub fn disburse_with_receipt(
+        env: Env,
+        id: u64,
+        receipt_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        Self::process_disburse(&env, id, Some(receipt_hash))
+    }
+
+    fn process_disburse(
+        env: &Env,
+        id: u64,
+        receipt_hash: Option<BytesN<32>>,
+    ) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
 
@@ -863,7 +971,7 @@ impl AidEscrow {
         // Transfer before accounting updates so reverted token transfers cannot
         // leave the escrow state inconsistent.
         Self::transfer_token(
-            &env,
+            env,
             &package.token,
             &env.current_contract_address(),
             &package.recipient,
@@ -875,7 +983,7 @@ impl AidEscrow {
         env.storage().persistent().set(&key, &package);
 
         // Update Locked
-        Self::decrement_locked(&env, &package.token, package.amount);
+        Self::decrement_locked(env, &package.token, package.amount);
 
         let timestamp = env.ledger().timestamp();
         PackageDisbursed {
@@ -884,8 +992,9 @@ impl AidEscrow {
             amount: package.amount,
             actor: admin.clone(),
             timestamp,
+            receipt_hash,
         }
-        .publish(&env);
+        .publish(env);
 
         Ok(())
     }
@@ -1279,6 +1388,7 @@ impl AidEscrow {
         package_id: u64,
         payout_recipient: &Address,
         now: u64,
+        receipt_hash: Option<BytesN<32>>,
     ) -> Result<(), Error> {
         Self::transfer_token(
             env,
@@ -1312,6 +1422,7 @@ impl AidEscrow {
             amount: package.amount,
             actor: payout_recipient.clone(),
             timestamp: now,
+            receipt_hash,
         }
         .publish(env);
 

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -800,15 +800,7 @@ impl AidEscrow {
         package.recipient.require_auth();
         let payout_recipient = package.recipient.clone();
 
-        Self::finalize_claim(
-            &env,
-            &key,
-            &mut package,
-            id,
-            &payout_recipient,
-            now,
-            None,
-        )
+        Self::finalize_claim(&env, &key, &mut package, id, &payout_recipient, now, None)
     }
 
     /// Recipient claims a package and anchors an off-chain receipt hash
@@ -821,11 +813,7 @@ impl AidEscrow {
     ///
     /// # Errors
     /// Returns the same errors as :meth:`claim`.
-    pub fn claim_with_receipt(
-        env: Env,
-        id: u64,
-        receipt_hash: BytesN<32>,
-    ) -> Result<(), Error> {
+    pub fn claim_with_receipt(env: Env, id: u64, receipt_hash: BytesN<32>) -> Result<(), Error> {
         Self::check_action_paused(&env, symbol_short!("claim"))?;
         let key = (symbol_short!("pkg"), id);
         let mut package: Package = env
@@ -941,19 +929,11 @@ impl AidEscrow {
     ///
     /// # Errors
     /// Returns the same errors as :meth:`disburse`.
-    pub fn disburse_with_receipt(
-        env: Env,
-        id: u64,
-        receipt_hash: BytesN<32>,
-    ) -> Result<(), Error> {
+    pub fn disburse_with_receipt(env: Env, id: u64, receipt_hash: BytesN<32>) -> Result<(), Error> {
         Self::process_disburse(&env, id, Some(receipt_hash))
     }
 
-    fn process_disburse(
-        env: &Env,
-        id: u64,
-        receipt_hash: Option<BytesN<32>>,
-    ) -> Result<(), Error> {
+    fn process_disburse(env: &Env, id: u64, receipt_hash: Option<BytesN<32>>) -> Result<(), Error> {
         let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
 

--- a/app/onchain/contracts/aid_escrow/test_snapshots/claim/default_claim_starts_at_is_created_at.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/claim/default_claim_starts_at_is_created_at.1.json
@@ -992,6 +992,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/claim/fails_when_claimed_too_early.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/claim/fails_when_claimed_too_early.1.json
@@ -1011,6 +1011,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/combined_boundaries/narrow_claim_window_1_second.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/combined_boundaries/narrow_claim_window_1_second.1.json
@@ -1010,6 +1010,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/profile_claim_with_proof.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/profile_claim_with_proof.1.json
@@ -137,6 +137,31 @@
           "sub_invocations": []
         }
       ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "claim_with_proof",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
     ]
   ],
   "ledger": {
@@ -461,7 +486,7 @@
                         "symbol": "status"
                       },
                       "val": {
-                        "u32": 0
+                        "u32": 1
                       }
                     },
                     {
@@ -514,6 +539,23 @@
                       },
                       {
                         "key": {
+                          "symbol": "claimed"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                              },
+                              "val": {
+                                "i128": "10000000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "config"
                         },
                         "val": {
@@ -556,7 +598,7 @@
                                 "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               },
                               "val": {
-                                "i128": "10000000"
+                                "i128": "0"
                               }
                             }
                           ]
@@ -599,6 +641,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          3110499
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
               "vec": [
@@ -627,6 +702,76 @@
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518500
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -805,13 +950,42 @@
     {
       "event": {
         "ext": "v0",
+        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": "10000000"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
         "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "package_created"
+                "symbol": "package_claimed"
               }
             ],
             "data": {
@@ -821,7 +995,7 @@
                     "symbol": "actor"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 },
                 {
@@ -842,10 +1016,16 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 },
                 {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/profile_single_claim.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/profile_single_claim.1.json
@@ -128,6 +128,25 @@
           "sub_invocations": []
         }
       ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "claim",
+              "args": [
+                {
+                  "u64": "1"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
     ]
   ],
   "ledger": {
@@ -443,7 +462,7 @@
                         "symbol": "status"
                       },
                       "val": {
-                        "u32": 0
+                        "u32": 1
                       }
                     },
                     {
@@ -496,6 +515,23 @@
                       },
                       {
                         "key": {
+                          "symbol": "claimed"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                              },
+                              "val": {
+                                "i128": "10000000"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "config"
                         },
                         "val": {
@@ -538,7 +574,7 @@
                                 "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               },
                               "val": {
-                                "i128": "10000000"
+                                "i128": "0"
                               }
                             }
                           ]
@@ -581,6 +617,39 @@
       [
         {
           "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          3110499
+        ]
+      ],
+      [
+        {
+          "contract_data": {
             "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
               "vec": [
@@ -609,6 +678,76 @@
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518500
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   ]
                 },
@@ -787,13 +926,42 @@
     {
       "event": {
         "ext": "v0",
+        "contract_id": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "transfer"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+              },
+              {
+                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+              }
+            ],
+            "data": {
+              "i128": "10000000"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
         "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "package_created"
+                "symbol": "package_claimed"
               }
             ],
             "data": {
@@ -803,7 +971,7 @@
                     "symbol": "actor"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 },
                 {
@@ -821,6 +989,12 @@
                   "val": {
                     "u64": "1"
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/profile_single_refund.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/profile_single_refund.1.json
@@ -105,7 +105,7 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "u64": "100"
+                  "u64": "1"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
@@ -117,19 +117,10 @@
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "u64": "1001000"
+                  "u64": "1003600"
                 },
                 {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "claim_starts_at"
-                      },
-                      "val": {
-                        "string": "1001000"
-                      }
-                    }
-                  ]
+                  "map": []
                 }
               ]
             }
@@ -138,18 +129,17 @@
         }
       ]
     ],
-    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "claim",
+              "function_name": "refund",
               "args": [
                 {
-                  "u64": "100"
+                  "u64": "1"
                 }
               ]
             }
@@ -162,7 +152,7 @@
   "ledger": {
     "protocol_version": 23,
     "sequence_number": 100,
-    "timestamp": 1001000,
+    "timestamp": 1003601,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 10,
     "min_persistent_entry_ttl": 10,
@@ -252,6 +242,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          3110499
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
                   }
                 },
                 "durability": "temporary",
@@ -365,7 +388,7 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": "100"
+                  "u64": "1"
                 }
               }
             },
@@ -384,7 +407,7 @@
                   "symbol": "pkg"
                 },
                 {
-                  "u64": "100"
+                  "u64": "1"
                 }
               ]
             },
@@ -404,7 +427,7 @@
                       "symbol": "pkg"
                     },
                     {
-                      "u64": "100"
+                      "u64": "1"
                     }
                   ]
                 },
@@ -424,7 +447,7 @@
                         "symbol": "claim_starts_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "1000000"
                       }
                     },
                     {
@@ -440,7 +463,7 @@
                         "symbol": "expires_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "1003600"
                       }
                     },
                     {
@@ -448,7 +471,7 @@
                         "symbol": "id"
                       },
                       "val": {
-                        "u64": "100"
+                        "u64": "1"
                       }
                     },
                     {
@@ -456,16 +479,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "map": [
-                          {
-                            "key": {
-                              "symbol": "claim_starts_at"
-                            },
-                            "val": {
-                              "string": "1001000"
-                            }
-                          }
-                        ]
+                        "map": []
                       }
                     },
                     {
@@ -481,7 +495,7 @@
                         "symbol": "status"
                       },
                       "val": {
-                        "u32": 1
+                        "u32": 4
                       }
                     },
                     {
@@ -530,23 +544,6 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                        }
-                      },
-                      {
-                        "key": {
-                          "symbol": "claimed"
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
-                              },
-                              "val": {
-                                "i128": "10000000"
-                              }
-                            }
-                          ]
                         }
                       },
                       {
@@ -604,7 +601,7 @@
                           "symbol": "pkg_cnt"
                         },
                         "val": {
-                          "u64": "101"
+                          "u64": "2"
                         }
                       },
                       {
@@ -636,13 +633,18 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
-              "ledger_key_nonce": {
-                "nonce": "2032731177588607455"
-              }
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             },
-            "durability": "temporary"
+            "durability": "persistent"
           }
         },
         [
@@ -651,19 +653,51 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                 "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "2032731177588607455"
-                  }
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  ]
                 },
-                "durability": "temporary",
-                "val": "void"
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "10000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
               }
             },
             "ext": "v0"
           },
-          3110499
+          518500
         ]
       ],
       [
@@ -709,76 +743,6 @@
                       },
                       "val": {
                         "i128": "0"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "authorized"
-                      },
-                      "val": {
-                        "bool": true
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "clawback"
-                      },
-                      "val": {
-                        "bool": false
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518500
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Balance"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Balance"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "amount"
-                      },
-                      "val": {
-                        "i128": "10000000"
                       }
                     },
                     {
@@ -957,7 +921,7 @@
                 "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
@@ -980,7 +944,7 @@
           "v0": {
             "topics": [
               {
-                "symbol": "package_claimed"
+                "symbol": "package_refunded"
               }
             ],
             "data": {
@@ -990,7 +954,7 @@
                     "symbol": "actor"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 },
                 {
@@ -1006,14 +970,8 @@
                     "symbol": "package_id"
                   },
                   "val": {
-                    "u64": "100"
+                    "u64": "1"
                   }
-                },
-                {
-                  "key": {
-                    "symbol": "receipt_hash"
-                  },
-                  "val": "void"
                 },
                 {
                   "key": {
@@ -1028,7 +986,7 @@
                     "symbol": "timestamp"
                   },
                   "val": {
-                    "u64": "1001000"
+                    "u64": "1003601"
                   }
                 }
               ]

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_package_claimed_event.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_package_claimed_event.1.json
@@ -1064,6 +1064,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_package_claimed_event_with_receipt.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_package_claimed_event_with_receipt.1.json
@@ -5,7 +5,6 @@
     "mux_id": 0
   },
   "auth": [
-    [],
     [
       [
         "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
@@ -26,50 +25,7 @@
       ]
     ],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "set_config",
-              "args": [
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "allowed_tokens"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_expires_in"
-                      },
-                      "val": {
-                        "u64": "0"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "min_amount"
-                      },
-                      "val": {
-                        "i128": "1"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -80,10 +36,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "i128": "10000000"
+                  "i128": "100000000"
                 }
               ]
             }
@@ -98,17 +54,63 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "fund",
+              "args": [
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "50000000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "i128": "50000000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "create_package",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "u64": "100"
+                  "u64": "0"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "i128": "10000000"
@@ -117,19 +119,10 @@
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "u64": "1001000"
+                  "u64": "86400"
                 },
                 {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "claim_starts_at"
-                      },
-                      "val": {
-                        "string": "1001000"
-                      }
-                    }
-                  ]
+                  "map": []
                 }
               ]
             }
@@ -138,18 +131,20 @@
         }
       ]
     ],
-    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "claim",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "claim_with_receipt",
               "args": [
                 {
-                  "u64": "100"
+                  "u64": "0"
+                },
+                {
+                  "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
                 }
               ]
             }
@@ -161,13 +156,13 @@
   ],
   "ledger": {
     "protocol_version": 23,
-    "sequence_number": 100,
-    "timestamp": 1001000,
+    "sequence_number": 0,
+    "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "base_reserve": 10,
-    "min_persistent_entry_ttl": 10,
-    "min_temp_entry_ttl": 10,
-    "max_entry_ttl": 3110400,
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
     "ledger_entries": [
       [
         {
@@ -227,7 +222,7 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
@@ -260,7 +255,7 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
@@ -293,7 +288,7 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
@@ -326,13 +321,46 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "vec": [
                 {
@@ -352,7 +380,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "vec": [
                     {
@@ -365,26 +393,26 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": "100"
+                  "u64": "0"
                 }
               }
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "vec": [
                 {
                   "symbol": "pkg"
                 },
                 {
-                  "u64": "100"
+                  "u64": "0"
                 }
               ]
             },
@@ -397,14 +425,14 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "vec": [
                     {
                       "symbol": "pkg"
                     },
                     {
-                      "u64": "100"
+                      "u64": "0"
                     }
                   ]
                 },
@@ -424,7 +452,7 @@
                         "symbol": "claim_starts_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "0"
                       }
                     },
                     {
@@ -432,7 +460,7 @@
                         "symbol": "created_at"
                       },
                       "val": {
-                        "u64": "1000000"
+                        "u64": "0"
                       }
                     },
                     {
@@ -440,7 +468,7 @@
                         "symbol": "expires_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "86400"
                       }
                     },
                     {
@@ -448,7 +476,7 @@
                         "symbol": "id"
                       },
                       "val": {
-                        "u64": "100"
+                        "u64": "0"
                       }
                     },
                     {
@@ -456,16 +484,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "map": [
-                          {
-                            "key": {
-                              "symbol": "claim_starts_at"
-                            },
-                            "val": {
-                              "string": "1001000"
-                            }
-                          }
-                        ]
+                        "map": []
                       }
                     },
                     {
@@ -473,7 +492,7 @@
                         "symbol": "recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -498,13 +517,13 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -515,7 +534,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -604,7 +623,7 @@
                           "symbol": "pkg_cnt"
                         },
                         "val": {
-                          "u64": "101"
+                          "u64": "1"
                         }
                       },
                       {
@@ -630,19 +649,24 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
-              "ledger_key_nonce": {
-                "nonce": "2032731177588607455"
-              }
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             },
-            "durability": "temporary"
+            "durability": "persistent"
           }
         },
         [
@@ -651,19 +675,51 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                 "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "2032731177588607455"
-                  }
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  ]
                 },
-                "durability": "temporary",
-                "val": "void"
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
               }
             },
             "ext": "v0"
           },
-          3110499
+          518400
         ]
       ],
       [
@@ -708,7 +764,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "0"
+                        "i128": "10000000"
                       }
                     },
                     {
@@ -733,7 +789,7 @@
             },
             "ext": "v0"
           },
-          518500
+          518400
         ]
       ],
       [
@@ -778,7 +834,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "10000000"
+                        "i128": "40000000"
                       }
                     },
                     {
@@ -803,7 +859,7 @@
             },
             "ext": "v0"
           },
-          518500
+          518400
         ]
       ],
       [
@@ -915,7 +971,7 @@
             },
             "ext": "v0"
           },
-          121060
+          120960
         ]
       ],
       [
@@ -936,7 +992,7 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ]
     ]
@@ -954,10 +1010,10 @@
                 "symbol": "transfer"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
@@ -974,7 +1030,7 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         "type_": "contract",
         "body": {
           "v0": {
@@ -990,7 +1046,7 @@
                     "symbol": "actor"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 },
                 {
@@ -1006,21 +1062,23 @@
                     "symbol": "package_id"
                   },
                   "val": {
-                    "u64": "100"
+                    "u64": "0"
                   }
                 },
                 {
                   "key": {
                     "symbol": "receipt_hash"
                   },
-                  "val": "void"
+                  "val": {
+                    "bytes": "0707070707070707070707070707070707070707070707070707070707070707"
+                  }
                 },
                 {
                   "key": {
                     "symbol": "recipient"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 },
                 {
@@ -1028,7 +1086,7 @@
                     "symbol": "timestamp"
                   },
                   "val": {
-                    "u64": "1001000"
+                    "u64": "0"
                   }
                 }
               ]

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_package_disbursed_event.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_package_disbursed_event.1.json
@@ -1047,6 +1047,12 @@
                 },
                 {
                   "key": {
+                    "symbol": "receipt_hash"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
                     "symbol": "recipient"
                   },
                   "val": {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_package_disbursed_event_with_receipt.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_package_disbursed_event_with_receipt.1.json
@@ -5,7 +5,6 @@
     "mux_id": 0
   },
   "auth": [
-    [],
     [
       [
         "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
@@ -26,50 +25,7 @@
       ]
     ],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "set_config",
-              "args": [
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "allowed_tokens"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_expires_in"
-                      },
-                      "val": {
-                        "u64": "0"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "min_amount"
-                      },
-                      "val": {
-                        "i128": "1"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -80,10 +36,10 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "i128": "10000000"
+                  "i128": "100000000"
                 }
               ]
             }
@@ -98,17 +54,63 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "fund",
+              "args": [
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "50000000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    },
+                    {
+                      "i128": "50000000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "function_name": "create_package",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "u64": "100"
+                  "u64": "0"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "i128": "10000000"
@@ -117,19 +119,10 @@
                   "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "u64": "1001000"
+                  "u64": "86400"
                 },
                 {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "claim_starts_at"
-                      },
-                      "val": {
-                        "string": "1001000"
-                      }
-                    }
-                  ]
+                  "map": []
                 }
               ]
             }
@@ -138,18 +131,20 @@
         }
       ]
     ],
-    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "claim",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "function_name": "disburse_with_receipt",
               "args": [
                 {
-                  "u64": "100"
+                  "u64": "0"
+                },
+                {
+                  "bytes": "0909090909090909090909090909090909090909090909090909090909090909"
                 }
               ]
             }
@@ -161,13 +156,13 @@
   ],
   "ledger": {
     "protocol_version": 23,
-    "sequence_number": 100,
-    "timestamp": 1001000,
+    "sequence_number": 0,
+    "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "base_reserve": 10,
-    "min_persistent_entry_ttl": 10,
-    "min_temp_entry_ttl": 10,
-    "max_entry_ttl": 3110400,
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
     "ledger_entries": [
       [
         {
@@ -227,7 +222,7 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
@@ -260,7 +255,40 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [
@@ -293,7 +321,7 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
@@ -326,13 +354,13 @@
             },
             "ext": "v0"
           },
-          3110499
+          6311999
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "vec": [
                 {
@@ -352,7 +380,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "vec": [
                     {
@@ -365,26 +393,26 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "u64": "100"
+                  "u64": "0"
                 }
               }
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "vec": [
                 {
                   "symbol": "pkg"
                 },
                 {
-                  "u64": "100"
+                  "u64": "0"
                 }
               ]
             },
@@ -397,14 +425,14 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "vec": [
                     {
                       "symbol": "pkg"
                     },
                     {
-                      "u64": "100"
+                      "u64": "0"
                     }
                   ]
                 },
@@ -424,7 +452,7 @@
                         "symbol": "claim_starts_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "0"
                       }
                     },
                     {
@@ -432,7 +460,7 @@
                         "symbol": "created_at"
                       },
                       "val": {
-                        "u64": "1000000"
+                        "u64": "0"
                       }
                     },
                     {
@@ -440,7 +468,7 @@
                         "symbol": "expires_at"
                       },
                       "val": {
-                        "u64": "1001000"
+                        "u64": "86400"
                       }
                     },
                     {
@@ -448,7 +476,7 @@
                         "symbol": "id"
                       },
                       "val": {
-                        "u64": "100"
+                        "u64": "0"
                       }
                     },
                     {
@@ -456,16 +484,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "map": [
-                          {
-                            "key": {
-                              "symbol": "claim_starts_at"
-                            },
-                            "val": {
-                              "string": "1001000"
-                            }
-                          }
-                        ]
+                        "map": []
                       }
                     },
                     {
@@ -473,7 +492,7 @@
                         "symbol": "recipient"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -498,13 +517,13 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -515,7 +534,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -530,23 +549,6 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                        }
-                      },
-                      {
-                        "key": {
-                          "symbol": "claimed"
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
-                              },
-                              "val": {
-                                "i128": "10000000"
-                              }
-                            }
-                          ]
                         }
                       },
                       {
@@ -604,7 +606,7 @@
                           "symbol": "pkg_cnt"
                         },
                         "val": {
-                          "u64": "101"
+                          "u64": "1"
                         }
                       },
                       {
@@ -630,19 +632,24 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ],
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
             "key": {
-              "ledger_key_nonce": {
-                "nonce": "2032731177588607455"
-              }
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             },
-            "durability": "temporary"
+            "durability": "persistent"
           }
         },
         [
@@ -651,19 +658,51 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                 "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "2032731177588607455"
-                  }
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  ]
                 },
-                "durability": "temporary",
-                "val": "void"
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": "50000000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
               }
             },
             "ext": "v0"
           },
-          3110499
+          518400
         ]
       ],
       [
@@ -708,7 +747,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "0"
+                        "i128": "10000000"
                       }
                     },
                     {
@@ -733,7 +772,7 @@
             },
             "ext": "v0"
           },
-          518500
+          518400
         ]
       ],
       [
@@ -778,7 +817,7 @@
                         "symbol": "amount"
                       },
                       "val": {
-                        "i128": "10000000"
+                        "i128": "40000000"
                       }
                     },
                     {
@@ -803,7 +842,7 @@
             },
             "ext": "v0"
           },
-          518500
+          518400
         ]
       ],
       [
@@ -915,7 +954,7 @@
             },
             "ext": "v0"
           },
-          121060
+          120960
         ]
       ],
       [
@@ -936,7 +975,7 @@
             },
             "ext": "v0"
           },
-          109
+          4095
         ]
       ]
     ]
@@ -954,10 +993,10 @@
                 "symbol": "transfer"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               },
               {
                 "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
@@ -974,13 +1013,13 @@
     {
       "event": {
         "ext": "v0",
-        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         "type_": "contract",
         "body": {
           "v0": {
             "topics": [
               {
-                "symbol": "package_claimed"
+                "symbol": "package_disbursed"
               }
             ],
             "data": {
@@ -990,7 +1029,7 @@
                     "symbol": "actor"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                   }
                 },
                 {
@@ -1006,21 +1045,23 @@
                     "symbol": "package_id"
                   },
                   "val": {
-                    "u64": "100"
+                    "u64": "0"
                   }
                 },
                 {
                   "key": {
                     "symbol": "receipt_hash"
                   },
-                  "val": "void"
+                  "val": {
+                    "bytes": "0909090909090909090909090909090909090909090909090909090909090909"
+                  }
                 },
                 {
                   "key": {
                     "symbol": "recipient"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                   }
                 },
                 {
@@ -1028,7 +1069,7 @@
                     "symbol": "timestamp"
                   },
                   "val": {
-                    "u64": "1001000"
+                    "u64": "0"
                   }
                 }
               ]

--- a/app/onchain/contracts/aid_escrow/tests/events.rs
+++ b/app/onchain/contracts/aid_escrow/tests/events.rs
@@ -6,7 +6,7 @@ use aid_escrow::{AidEscrow, AidEscrowClient};
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token::{StellarAssetClient, TokenClient},
-    Address, Env, Map, Symbol, TryFromVal, Val, Vec,
+    Address, BytesN, Env, Map, Symbol, TryFromVal, Val, Vec,
 };
 
 const UNIT: i128 = 10_000_000; // 1.0 Token for 7-decimal assets
@@ -67,6 +67,24 @@ fn data_address(env: &Env, data: &Val, field: &str) -> Address {
     let map = soroban_sdk::Map::<Symbol, Val>::try_from_val(env, data).unwrap();
     let val = map.get(sym(env, field)).expect("missing field");
     Address::try_from_val(env, &val).expect("not address")
+}
+
+/// Reads an `Option<BytesN<32>>` value from the event data map.
+///
+/// Returns `Some(BytesN)` when the field carries a `Some(hash)` payload,
+/// returns `None` when the field carries `None`/Void (i.e. the contract
+/// did not anchor an off-chain receipt at the time of claim).
+fn data_receipt_hash(env: &Env, data: &Val) -> Option<BytesN<32>> {
+    let map = soroban_sdk::Map::<Symbol, Val>::try_from_val(env, data).unwrap();
+    let val = match map.get(sym(env, "receipt_hash")) {
+        Some(v) => v,
+        None => {
+            // Pre-receipt-hash indexers see the field as Void when
+            // missing — treat that the same as `None`.
+            return None;
+        }
+    };
+    Option::<BytesN<32>>::try_from_val(env, &val).expect("not Option<BytesN<32>>")
 }
 
 fn assert_field_exists(env: &Env, data: &Val, field: &str) {
@@ -162,6 +180,46 @@ fn test_package_claimed_event() {
     assert_eq!(data_u64(&env, &data, "package_id"), 0);
     assert_eq!(data_address(&env, &data, "recipient"), recipient);
     assert_eq!(data_i128(&env, &data, "amount"), UNIT);
+    // Receipt hash field is part of the event schema but is absent for
+    // claims invoked through the legacy ``claim`` entrypoint.
+    assert_eq!(data_receipt_hash(&env, &data), None);
+}
+
+#[test]
+fn test_package_claimed_event_with_receipt() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (token_client, token_admin_client) = setup_token(&env, &admin);
+
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+    client.init(&admin);
+    token_admin_client.mint(&admin, &(10 * UNIT));
+    client.fund(&token_client.address, &admin, &(5 * UNIT));
+
+    let receipt_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    client.create_package(
+        &admin,
+        &0u64,
+        &recipient,
+        &UNIT,
+        &token_client.address,
+        &(env.ledger().timestamp() + 86400),
+        &Map::new(&env),
+    );
+    client.claim_with_receipt(&0u64, &receipt_hash);
+
+    let data = last_event_data(&env, &contract_id, "package_claimed");
+    assert_eq!(data_u64(&env, &data, "package_id"), 0);
+    assert_eq!(data_address(&env, &data, "recipient"), recipient);
+    assert_eq!(data_i128(&env, &data, "amount"), UNIT);
+
+    let stored = data_receipt_hash(&env, &data).expect("expected Some(receipt_hash)");
+    assert_eq!(stored, receipt_hash);
 }
 
 #[test]
@@ -194,6 +252,46 @@ fn test_package_disbursed_event() {
     assert_eq!(data_u64(&env, &data, "package_id"), 0);
     assert_eq!(data_address(&env, &data, "recipient"), recipient);
     assert_eq!(data_i128(&env, &data, "amount"), UNIT);
+    // Receipt hash field is part of the event schema but is absent for
+    // disbursements invoked through the legacy ``disburse`` entrypoint.
+    assert_eq!(data_receipt_hash(&env, &data), None);
+}
+
+#[test]
+fn test_package_disbursed_event_with_receipt() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (token_client, token_admin_client) = setup_token(&env, &admin);
+
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+    client.init(&admin);
+    token_admin_client.mint(&admin, &(10 * UNIT));
+    client.fund(&token_client.address, &admin, &(5 * UNIT));
+
+    let receipt_hash = BytesN::from_array(&env, &[9u8; 32]);
+
+    client.create_package(
+        &admin,
+        &0u64,
+        &recipient,
+        &UNIT,
+        &token_client.address,
+        &(env.ledger().timestamp() + 86400),
+        &Map::new(&env),
+    );
+    client.disburse_with_receipt(&0u64, &receipt_hash);
+
+    let data = last_event_data(&env, &contract_id, "package_disbursed");
+    assert_eq!(data_u64(&env, &data, "package_id"), 0);
+    assert_eq!(data_address(&env, &data, "recipient"), recipient);
+    assert_eq!(data_i128(&env, &data, "amount"), UNIT);
+
+    let stored = data_receipt_hash(&env, &data).expect("expected Some(receipt_hash)");
+    assert_eq!(stored, receipt_hash);
 }
 
 #[test]


### PR DESCRIPTION
… (Issue #568)

Introduces an OPTIONAL receipt_hash commitment on the on-chain PackageClaimed and PackageDisbursed events so callers can anchor an off-chain delivery receipt (e.g. SHA-256 of a signed proof of receipt) on chain while keeping the existing call sites backward-compatible.

Contract changes
----------------
*   PackageClaimed and PackageDisbursed events gained
    `pub receipt_hash: Option<BytesN<32>>` appended at the END of the
    payload, preserving forward compatibility for off-chain indexers that
    only read the original five fields.
*   New entrypoints `claim_with_receipt(env, id, receipt_hash)` and
    `disburse_with_receipt(env, id, receipt_hash)` emit the event with
    `receipt_hash = Some(hash)`, leaving the existing `claim` /
    `disburse` entrypoints to continue emitting the event with
    `receipt_hash = None`.
*   Internal helper `process_disburse(env, id, receipt_hash)` factors the
    shared disburse logic so the receipt-bearing entrypoint is a one-line
    call into the same code path.
*   `finalize_claim` signature gains an extra
    `receipt_hash: Option<BytesN<32>>` parameter; existing claim /
    claim_with_proof callers pass `None`, the new claim_with_receipt
    caller passes `Some(hash)`.
*   `BytesN` added to the soroban_sdk import.

Tests
-----
*   tests/events.rs adds a `data_receipt_hash` helper that decodes the
    new `Option<BytesN<32>>` field from the event data map.
*   `test_package_claimed_event` and `test_package_disbursed_event` now
    assert the field carries `None` for legacy entrypoint invocations.
*   New `test_package_claimed_event_with_receipt` and
    `test_package_disbursed_event_with_receipt` exercises the new
    entrypoints and assert the field carries `Some(hash)` matching the
    passed-in 32-byte array.

closes #568 