### PR TITLE
✨ Add non-blocking env warning banner for preview deployments

### DIFF
--- a/app/frontend/src/app/layout.tsx
+++ b/app/frontend/src/app/layout.tsx
@@ -10,6 +10,7 @@ import TestnetFaucetHelper from '@/components/systems/TestnetFaucetHelper';
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { MisconfiguredPage } from '@/components/MisconfiguredPage';
+import { EnvWarningBanner } from '@/components/EnvWarningBanner';
 import { VersionProvider } from '@/components/VersionProvider';
 import { validateEnv } from '@/lib/env';
 
@@ -37,12 +38,9 @@ export default async function RootLayout({
   // Fail fast: validate required environment variables before rendering anything.
   // This runs server-side only; no secret values are forwarded to the client.
   const envResult = validateEnv();
-  const allowBootWithoutFullConfig =
-    process.env.NODE_ENV !== 'production' ||
-    process.env.NEXT_PUBLIC_USE_MOCKS === 'true' ||
-    !process.env.NEXT_PUBLIC_API_URL;
+  const isProduction = process.env.NODE_ENV === 'production';
 
-  if (!envResult.ok && !allowBootWithoutFullConfig) {
+  if (!envResult.ok && isProduction) {
     return (
       <MisconfiguredPage
         missing={envResult.missing}
@@ -66,6 +64,7 @@ export default async function RootLayout({
               <VersionProvider>
                 <QueryProvider>
                   <ToastProvider>
+                    {!envResult.ok && <EnvWarningBanner missing={envResult.missing} invalid={envResult.invalid} />}
                     <Navbar />
                     {children}
                   </ToastProvider>

--- a/app/frontend/src/components/EnvWarningBanner.tsx
+++ b/app/frontend/src/components/EnvWarningBanner.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Settings2, X } from 'lucide-react';
+import { useState } from 'react';
+
+interface EnvWarningBannerProps {
+  missing: string[];
+  invalid: string[];
+}
+
+export function EnvWarningBanner({ missing, invalid }: EnvWarningBannerProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (isDismissed) return null;
+
+  return (
+    <div className="w-full bg-amber-50 border-b border-amber-200 dark:bg-amber-500/10 dark:border-amber-500/30">
+      <div className="max-w-7xl mx-auto px-4 py-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-100 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400 shrink-0">
+            <Settings2 size={20} />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+              Preview deployment — some environment variables are missing or invalid
+            </p>
+            <p className="text-xs text-amber-700 dark:text-amber-200/80 mt-1">
+              This is expected for preview builds. Some features may be limited.
+            </p>
+            {(missing.length > 0 || invalid.length > 0) && (
+              <div className="mt-2 space-y-1">
+                {missing.length > 0 && (
+                  <p className="text-xs text-amber-700 dark:text-amber-200/70 font-mono">
+                    Missing: {missing.join(', ')}
+                  </p>
+                )}
+                {invalid.length > 0 && (
+                  <p className="text-xs text-amber-700 dark:text-amber-200/70 font-mono">
+                    Invalid: {invalid.join(', ')}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+          <button
+            onClick={() => setIsDismissed(true)}
+            className="text-amber-700/70 hover:text-amber-800 dark:text-amber-300/70 dark:hover:text-amber-200 transition-colors"
+            aria-label="Dismiss environment warning"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR allows preview/test environments to render basic pages with a clear warning banner instead of blocking the UI entirely when required environment variables are missing or invalid, while still maintaining strict validation for production.

closes #587