### PR TITLE
Fix CI workflow issues

### DIFF
--- a/.github/workflows/ai-service-ci.yml
+++ b/.github/workflows/ai-service-ci.yml
@@ -44,13 +44,11 @@ jobs:
       working-directory: ./app/ai-service
       run: |
         black --check .
-      continue-on-error: true
       
     - name: Type checking with mypy
       working-directory: ./app/ai-service
       run: |
         mypy . --ignore-missing-imports
-      continue-on-error: true
 
   test:
     runs-on: ubuntu-latest
@@ -77,7 +75,6 @@ jobs:
       working-directory: ./app/ai-service
       run: |
         pytest --cov=. --cov-report=xml || echo "No tests found or tests failed"
-      continue-on-error: true
       
     - name: Run setup verification
       working-directory: ./app/ai-service

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile --engine-strict=false
+        run: pnpm install
 
       - name: Lint
         run: pnpm --filter backend run lint

--- a/.github/workflows/ci-python-tests.yml
+++ b/.github/workflows/ci-python-tests.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         working-directory: app/ai-service


### PR DESCRIPTION
- Update Python version from 3.10 to 3.11 in ci-python-tests.yml for consistency
- Remove --no-frozen-lockfile and --engine-strict=false flags from backend-ci.yml for reproducible builds
- Remove continue-on-error flags from critical AI service CI checks (black, mypy, pytest)
- Keep continue-on-error only for optional steps (codecov upload, security scans)
closes #560 