### PR TITLE
Chore/partial claim accounting

### DIFF
--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -58,6 +58,7 @@ pub enum PackageStatus {
 pub struct Package {
     pub id: u64,
     pub recipient: Address,
+    /// Original locked amount for this package.
     pub amount: i128,
     pub token: Address,
     pub status: PackageStatus,
@@ -65,6 +66,19 @@ pub struct Package {
     pub expires_at: u64,
     pub claim_starts_at: u64,
     pub metadata: Map<Symbol, String>,
+    // --- Tranche / partial-claim fields ---
+    /// When `true`, the recipient may call `partial_claim` to withdraw funds
+    /// in multiple instalments.  `false` means the package must be fully claimed
+    /// in a single call (legacy behaviour).
+    pub partial_claim_enabled: bool,
+    /// Maximum number of partial claims allowed.  `0` means no cap.
+    /// Only consulted when `partial_claim_enabled` is `true`.
+    pub max_tranches: u32,
+    /// How many partial claims have been executed so far.
+    pub tranches_claimed: u32,
+    /// Funds that have not yet been disbursed.  Initialised to `amount` on
+    /// creation.  Decremented on every partial/full claim.
+    pub remaining_balance: i128,
 }
 
 #[contracttype]
@@ -105,6 +119,12 @@ pub enum Error {
     InvalidProof = 16,
     InvalidToken = 17,
     TokenTransferFailed = 18,
+    /// `partial_claim` was called on a package that has `partial_claim_enabled = false`.
+    PartialClaimNotEnabled = 19,
+    /// The requested partial-claim amount is zero or exceeds `remaining_balance`.
+    TrancheAmountInvalid = 20,
+    /// The package has already reached its `max_tranches` limit.
+    TranchesExhausted = 21,
 }
 
 // --- Contract Events (indexer-friendly; stable topics & payloads) ---
@@ -133,6 +153,23 @@ pub struct PackageClaimed {
     pub package_id: u64,
     pub recipient: Address,
     pub amount: i128,
+    pub actor: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted on every successful `partial_claim` call, including the final one
+/// that drains the remaining balance (at which point `remaining_balance` will
+/// be 0 and the package status transitions to `Claimed`).
+#[contractevent]
+pub struct PackagePartialClaimed {
+    pub package_id: u64,
+    pub recipient: Address,
+    /// Amount transferred in *this* partial claim.
+    pub amount_claimed: i128,
+    /// Remaining balance after *this* partial claim.
+    pub remaining_balance: i128,
+    /// 1-indexed sequential number of this tranche.
+    pub tranche_number: u32,
     pub actor: Address,
     pub timestamp: u64,
 }
@@ -497,6 +534,10 @@ impl AidEscrow {
     /// * `token` - Token contract address
     /// * `expires_at` - Expiration timestamp (0 for no expiration)
     /// * `metadata` - Arbitrary key-value metadata for the package
+    /// * `partial_claim_enabled` - When `true` the recipient may call
+    ///   `partial_claim` to withdraw funds in multiple instalments.
+    /// * `max_tranches` - Maximum number of partial claims allowed (0 = no cap).
+    ///   Only meaningful when `partial_claim_enabled` is `true`.
     #[allow(clippy::too_many_arguments)]
     pub fn create_package(
         env: Env,
@@ -507,6 +548,8 @@ impl AidEscrow {
         token: Address,
         expires_at: u64,
         metadata: Map<Symbol, String>,
+        partial_claim_enabled: bool,
+        max_tranches: u32,
     ) -> Result<u64, Error> {
         Self::check_action_paused(&env, symbol_short!("create"))?;
         Self::require_admin_or_distributor(&env, &operator)?;
@@ -584,6 +627,10 @@ impl AidEscrow {
             expires_at,
             claim_starts_at,
             metadata,
+            partial_claim_enabled,
+            max_tranches,
+            tranches_claimed: 0,
+            remaining_balance: amount,
         };
 
         env.storage().persistent().set(&key, &package);
@@ -621,6 +668,9 @@ impl AidEscrow {
     /// * `token` - Token contract address
     /// * `expires_in` - Expiry duration in seconds from now
     /// * `metadatas` - List of metadata maps, one per package
+    /// * `partial_claim_enabled` - When `true`, all created packages allow partial
+    ///   claims by the recipient.
+    /// * `max_tranches` - Maximum partial claims per package (0 = no cap).
     pub fn batch_create_packages(
         env: Env,
         operator: Address,
@@ -629,6 +679,8 @@ impl AidEscrow {
         token: Address,
         expires_in: u64,
         metadatas: Vec<Map<Symbol, String>>,
+        partial_claim_enabled: bool,
+        max_tranches: u32,
     ) -> Result<Vec<u64>, Error> {
         Self::check_action_paused(&env, symbol_short!("create"))?;
         Self::require_admin_or_distributor(&env, &operator)?;
@@ -710,6 +762,10 @@ impl AidEscrow {
                 expires_at,
                 claim_starts_at,
                 metadata: metadata.clone(),
+                partial_claim_enabled,
+                max_tranches,
+                tranches_claimed: 0,
+                remaining_balance: amount,
             };
 
             env.storage().persistent().set(&key, &package);
@@ -842,6 +898,125 @@ impl AidEscrow {
         }
     }
 
+    // --- Partial / Tranche Claim ---
+
+    /// Recipient claims a portion of their package funds.
+    ///
+    /// This entrypoint is only available when the package was created with
+    /// `partial_claim_enabled = true`.  The caller specifies the exact
+    /// `amount` they wish to withdraw; it must be > 0 and ≤ the package's
+    /// current `remaining_balance`.  If a `max_tranches` cap was set at
+    /// creation time, calling beyond that cap is rejected.
+    ///
+    /// When `amount == remaining_balance` (i.e., this is the final tranche),
+    /// the package status transitions to `Claimed` exactly as a full claim
+    /// would.  For intermediate tranches the status remains `Created` so
+    /// subsequent partial claims remain possible.
+    ///
+    /// # Errors
+    /// - `Error::PackageNotFound`        — unknown package ID
+    /// - `Error::PartialClaimNotEnabled` — `partial_claim_enabled` is false
+    /// - `Error::PackageNotActive`       — package is not in `Created` status
+    /// - `Error::ClaimTooEarly`          — before `claim_starts_at`
+    /// - `Error::PackageExpired`         — past `expires_at`
+    /// - `Error::TranchesExhausted`      — `max_tranches` limit already reached
+    /// - `Error::TrancheAmountInvalid`   — `amount` is 0 or > `remaining_balance`
+    /// - `Error::InvalidProof`           — Merkle-guarded package; use `claim_with_proof`
+    pub fn partial_claim(env: Env, id: u64, amount: i128) -> Result<(), Error> {
+        Self::check_action_paused(&env, symbol_short!("claim"))?;
+
+        let key = (symbol_short!("pkg"), id);
+        let mut package: Package = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PackageNotFound)?;
+
+        // Feature gate: package must have been created with partial claiming on.
+        if !package.partial_claim_enabled {
+            return Err(Error::PartialClaimNotEnabled);
+        }
+
+        if package.status != PackageStatus::Created {
+            return Err(Error::PackageNotActive);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < package.claim_starts_at {
+            return Err(Error::ClaimTooEarly);
+        }
+        if package.expires_at > 0 && now > package.expires_at {
+            return Err(Error::PackageExpired);
+        }
+
+        // Merkle-guarded packages need proof; redirect caller.
+        if Self::merkle_root_from_metadata(&env, &package.metadata).is_some() {
+            return Err(Error::InvalidProof);
+        }
+
+        // Tranche cap check (0 means unlimited).
+        if package.max_tranches > 0 && package.tranches_claimed >= package.max_tranches {
+            return Err(Error::TranchesExhausted);
+        }
+
+        // Amount validation.
+        if amount <= 0 || amount > package.remaining_balance {
+            return Err(Error::TrancheAmountInvalid);
+        }
+
+        // Auth: only the designated recipient may trigger a partial claim.
+        package.recipient.require_auth();
+
+        // Transfer the requested tranche.
+        Self::transfer_token(
+            &env,
+            &package.token,
+            &env.current_contract_address(),
+            &package.recipient,
+            &amount,
+        )?;
+
+        // Update bookkeeping.
+        package.remaining_balance -= amount;
+        package.tranches_claimed += 1;
+
+        // Decrement the contract-wide locked amount by the amount actually sent.
+        Self::decrement_locked(&env, &package.token, amount);
+
+        // Update the cumulative claimed tracker.
+        let mut claimed_map: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&KEY_TOTAL_CLAIMED)
+            .unwrap_or(Map::new(&env));
+        let current_total = claimed_map.get(package.token.clone()).unwrap_or(0);
+        claimed_map.set(package.token.clone(), current_total + amount);
+        env.storage()
+            .instance()
+            .set(&KEY_TOTAL_CLAIMED, &claimed_map);
+
+        // If no remaining balance, close the package.
+        if package.remaining_balance == 0 {
+            package.status = PackageStatus::Claimed;
+        }
+
+        env.storage().persistent().set(&key, &package);
+
+        // Emit the partial-claim event (covers both intermediate and final tranches).
+        PackagePartialClaimed {
+            package_id: id,
+            recipient: package.recipient.clone(),
+            amount_claimed: amount,
+            remaining_balance: package.remaining_balance,
+            tranche_number: package.tranches_claimed,
+            actor: package.recipient.clone(),
+            timestamp: now,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     // --- Admin Actions ---
 
     /// Admin manually triggers disbursement (overrides recipient claim need, strictly checks status).
@@ -862,26 +1037,29 @@ impl AidEscrow {
 
         // Transfer before accounting updates so reverted token transfers cannot
         // leave the escrow state inconsistent.
+        // Use remaining_balance: admin disburse pays out whatever is still owed.
+        let disburse_amount = package.remaining_balance;
         Self::transfer_token(
             &env,
             &package.token,
             &env.current_contract_address(),
             &package.recipient,
-            &package.amount,
+            &disburse_amount,
         )?;
 
         // State Transition
+        package.remaining_balance = 0;
         package.status = PackageStatus::Claimed;
         env.storage().persistent().set(&key, &package);
 
         // Update Locked
-        Self::decrement_locked(&env, &package.token, package.amount);
+        Self::decrement_locked(&env, &package.token, disburse_amount);
 
         let timestamp = env.ledger().timestamp();
         PackageDisbursed {
             package_id: id,
             recipient: package.recipient.clone(),
-            amount: package.amount,
+            amount: disburse_amount,
             actor: admin.clone(),
             timestamp,
         }
@@ -910,8 +1088,8 @@ impl AidEscrow {
         package.status = PackageStatus::Cancelled;
         env.storage().persistent().set(&key, &package);
 
-        // Unlock funds (return to pool)
-        Self::decrement_locked(&env, &package.token, package.amount);
+        // Unlock funds (return to pool) — only the portion still outstanding.
+        Self::decrement_locked(&env, &package.token, package.remaining_balance);
 
         let timestamp = env.ledger().timestamp();
         PackageRevoked {
@@ -959,20 +1137,24 @@ impl AidEscrow {
         // If Cancelled, funds were already unlocked in `revoke`.
         // Expired packages are unlocked only after a successful refund transfer.
 
-        // Transfer Contract -> Admin
+        // Transfer Contract -> Admin.
+        // Use remaining_balance: for partially-claimed packages, only the
+        // still-outstanding portion is returned.
+        let refund_amount = package.remaining_balance;
         Self::transfer_token(
             &env,
             &package.token,
             &env.current_contract_address(),
             &admin,
-            &package.amount,
+            &refund_amount,
         )?;
 
         if should_unlock_locked {
-            Self::decrement_locked(&env, &package.token, package.amount);
+            Self::decrement_locked(&env, &package.token, refund_amount);
         }
 
         // State Transition
+        package.remaining_balance = 0;
         package.status = PackageStatus::Refunded;
         env.storage().persistent().set(&key, &package);
 
@@ -980,7 +1162,7 @@ impl AidEscrow {
         PackageRefunded {
             package_id: id,
             recipient: package.recipient.clone(),
-            amount: package.amount,
+            amount: refund_amount,
             actor: admin.clone(),
             timestamp,
         }
@@ -1018,8 +1200,9 @@ impl AidEscrow {
         package.status = PackageStatus::Cancelled;
         env.storage().persistent().set(&key, &package);
 
-        // 5. Unlock funds (Decrement the global locked amount so funds return to the pool)
-        Self::decrement_locked(&env, &package.token, package.amount);
+        // 5. Unlock funds (Decrement the global locked amount so funds return to the pool).
+        //    Only the remaining (not yet claimed) portion is still locked.
+        Self::decrement_locked(&env, &package.token, package.remaining_balance);
 
         let timestamp = env.ledger().timestamp();
         PackageRevoked {
@@ -1280,20 +1463,25 @@ impl AidEscrow {
         payout_recipient: &Address,
         now: u64,
     ) -> Result<(), Error> {
+        // Use `remaining_balance` so that packages which already had partial
+        // claims only transfer whatever is still outstanding.
+        let payout_amount = package.remaining_balance;
+
         Self::transfer_token(
             env,
             &package.token,
             &env.current_contract_address(),
             payout_recipient,
-            &package.amount,
+            &payout_amount,
         )?;
 
         // State Transition
+        package.remaining_balance = 0;
         package.status = PackageStatus::Claimed;
         env.storage().persistent().set(key, package);
 
         // Update Global Locked (Bookkeeping)
-        Self::decrement_locked(env, &package.token, package.amount);
+        Self::decrement_locked(env, &package.token, payout_amount);
 
         let mut claimed_map: Map<Address, i128> = env
             .storage()
@@ -1301,7 +1489,7 @@ impl AidEscrow {
             .get(&KEY_TOTAL_CLAIMED)
             .unwrap_or(Map::new(env));
         let current_total = claimed_map.get(package.token.clone()).unwrap_or(0);
-        claimed_map.set(package.token.clone(), current_total + package.amount);
+        claimed_map.set(package.token.clone(), current_total + payout_amount);
         env.storage()
             .instance()
             .set(&KEY_TOTAL_CLAIMED, &claimed_map);
@@ -1309,7 +1497,7 @@ impl AidEscrow {
         PackageClaimed {
             package_id,
             recipient: payout_recipient.clone(),
-            amount: package.amount,
+            amount: payout_amount,
             actor: payout_recipient.clone(),
             timestamp: now,
         }
@@ -1501,7 +1689,9 @@ impl AidEscrow {
                     if package.token == token {
                         match package.status {
                             PackageStatus::Created => {
-                                total_committed += package.amount;
+                                // Use remaining_balance so partially-claimed packages
+                                // only count what is still locked/outstanding.
+                                total_committed += package.remaining_balance;
                             }
                             PackageStatus::Claimed => {
                                 total_claimed += package.amount;
@@ -1640,10 +1830,12 @@ mod tests {
             &admin,
             &1,
             &recipient,
-            &10_000_000, // <--- CHANGED THIS from 1_000_000 to 10_000_000
+            &10_000_000,
             &token,
             &86400,
             &package_metadata,
+            &false,
+            &0u32,
         );
 
         client.cancel_package(&package_id);
@@ -1674,6 +1866,8 @@ mod tests {
             &token,
             &86400,
             &empty_metadata,
+            &false,
+            &0u32,
         );
         client.create_package(
             &admin,
@@ -1683,6 +1877,8 @@ mod tests {
             &token,
             &86400,
             &empty_metadata,
+            &false,
+            &0u32,
         );
 
         let packages = client.list_recipient_packages(&recipient1, &0, &10);
@@ -1712,6 +1908,8 @@ mod tests {
                 &token,
                 &86400,
                 &Map::new(&env),
+                &false,
+                &0u32,
             ));
         }
 
@@ -1741,6 +1939,8 @@ mod tests {
             &token,
             &86400,
             &Map::new(&env),
+            &false,
+            &0u32,
         );
         assert!(result.is_err());
     }

--- a/app/onchain/contracts/aid_escrow/tests/aggregates.rs
+++ b/app/onchain/contracts/aid_escrow/tests/aggregates.rs
@@ -74,6 +74,8 @@ fn test_aggregates_single_created_package() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let agg = client.get_aggregates(&token_client.address);
@@ -110,6 +112,8 @@ fn test_aggregates_mixed_statuses() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
 
     // P2: Claimed (20M)
@@ -121,6 +125,8 @@ fn test_aggregates_mixed_statuses() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
     client.claim(&2);
 
@@ -133,6 +139,8 @@ fn test_aggregates_mixed_statuses() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
     client.revoke(&3);
 
@@ -145,6 +153,8 @@ fn test_aggregates_mixed_statuses() {
         &token_client.address,
         &short_expiry,
         &metadata,
+        &false,
+        &0u32,
     );
     env.ledger().set_timestamp(short_expiry + 1);
     client.refund(&4);
@@ -174,6 +184,8 @@ fn test_aggregates_all_claimed() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.create_package(
         &admin,
@@ -183,6 +195,8 @@ fn test_aggregates_all_claimed() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     client.claim(&10);
@@ -225,6 +239,8 @@ fn test_aggregates_filters_by_token() {
         &token_a.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.create_package(
         &admin,
@@ -234,6 +250,8 @@ fn test_aggregates_filters_by_token() {
         &token_a.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.claim(&2);
 
@@ -246,6 +264,8 @@ fn test_aggregates_filters_by_token() {
         &token_b.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.revoke(&3);
 
@@ -274,6 +294,8 @@ fn test_aggregates_disburse_counts_as_claimed() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.claim(&1);
 
@@ -285,6 +307,8 @@ fn test_aggregates_disburse_counts_as_claimed() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.disburse(&2);
 
@@ -310,6 +334,8 @@ fn test_aggregates_many_packages() {
             &token_client.address,
             &expiry,
             &Map::new(&env),
+            &false,
+            &0u32,
         );
         if i % 2 == 0 {
             client.claim(&i);
@@ -340,6 +366,8 @@ fn test_aggregates_update_after_transitions() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(
         client.get_aggregates(&token_client.address).total_committed,
@@ -369,6 +397,8 @@ fn test_aggregates_revoke_then_refund() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.revoke(&1);
     client.refund(&1);
@@ -394,6 +424,8 @@ fn test_aggregates_unknown_token() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     let unknown_token = Address::generate(&env);

--- a/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
@@ -321,6 +321,106 @@ mod claim {
     }
 
     #[test]
+    fn partial_claim_allows_multiple_valid_claims_and_drains_remaining_balance() {
+        let t = TestSetup::new();
+        let recipient = Address::generate(&t.env);
+        t.fund_contract(TWO_TOKENS);
+        let expires_at = t.now() + 3_600;
+        let metadata = Map::new(&t.env);
+        let id = t.client.create_package(
+            &t.admin,
+            &101u64,
+            &recipient,
+            &TWO_TOKENS,
+            &t.token,
+            &expires_at,
+            &metadata,
+            &true,
+            &0u32,
+        );
+
+        let first_result = t.client.try_partial_claim(&id, &ONE_TOKEN);
+        assert_eq!(first_result, Ok(Ok(())));
+
+        let pkg = t.client.get_package(&id);
+        assert_eq!(pkg.status, PackageStatus::Created);
+        assert_eq!(pkg.remaining_balance, ONE_TOKEN);
+        assert_eq!(pkg.tranches_claimed, 1u32);
+
+        let token_client = TokenClient::new(&t.env, &t.token);
+        assert_eq!(token_client.balance(&recipient), ONE_TOKEN);
+
+        let second_result = t.client.try_partial_claim(&id, &ONE_TOKEN);
+        assert_eq!(second_result, Ok(Ok(())));
+
+        let pkg = t.client.get_package(&id);
+        assert_eq!(pkg.status, PackageStatus::Claimed);
+        assert_eq!(pkg.remaining_balance, 0);
+        assert_eq!(pkg.tranches_claimed, 2u32);
+        assert_eq!(token_client.balance(&recipient), TWO_TOKENS);
+    }
+
+    #[test]
+    fn partial_claim_rejects_over_claims_and_preserves_state() {
+        let t = TestSetup::new();
+        let recipient = Address::generate(&t.env);
+        t.fund_contract(TWO_TOKENS);
+        let expires_at = t.now() + 3_600;
+        let metadata = Map::new(&t.env);
+        let id = t.client.create_package(
+            &t.admin,
+            &102u64,
+            &recipient,
+            &TWO_TOKENS,
+            &t.token,
+            &expires_at,
+            &metadata,
+            &true,
+            &0u32,
+        );
+
+        let result = t.client.try_partial_claim(&id, &(TWO_TOKENS + 1));
+        assert_eq!(result, Err(Ok(Error::TrancheAmountInvalid)));
+
+        let pkg = t.client.get_package(&id);
+        assert_eq!(pkg.status, PackageStatus::Created);
+        assert_eq!(pkg.remaining_balance, TWO_TOKENS);
+        assert_eq!(pkg.tranches_claimed, 0u32);
+
+        let token_client = TokenClient::new(&t.env, &t.token);
+        assert_eq!(token_client.balance(&recipient), 0);
+    }
+
+    #[test]
+    fn partial_claim_rejects_after_expiry_and_keeps_remaining_balance() {
+        let t = TestSetup::new();
+        let recipient = Address::generate(&t.env);
+        t.fund_contract(ONE_TOKEN);
+        let expires_at = t.now() + 1_000;
+        let metadata = Map::new(&t.env);
+        let id = t.client.create_package(
+            &t.admin,
+            &103u64,
+            &recipient,
+            &ONE_TOKEN,
+            &t.token,
+            &expires_at,
+            &metadata,
+            &true,
+            &0u32,
+        );
+
+        t.advance_time(1_001);
+        let result = t.client.try_partial_claim(&id, &ONE_TOKEN);
+        assert_eq!(result, Err(Ok(Error::PackageExpired)));
+
+        let pkg = t.client.get_package(&id);
+        assert_eq!(pkg.status, PackageStatus::Created);
+        assert_eq!(pkg.remaining_balance, ONE_TOKEN);
+        assert_eq!(pkg.tranches_claimed, 0u32);
+    }
+
+    #[test]
     fn fails_when_package_is_expired() {
         let t = TestSetup::new();
         let id = t.create_default_package(&Address::generate(&t.env), ONE_TOKEN);

--- a/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
@@ -96,6 +96,8 @@ impl TestSetup {
             &self.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         )
     }
 }
@@ -137,6 +139,8 @@ mod create_package {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         let pkg = t.client.get_package(&id);
         assert_eq!(
@@ -161,6 +165,8 @@ mod create_package {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert_eq!(result, Err(Ok(Error::InvalidAmount)));
     }
@@ -178,6 +184,8 @@ mod create_package {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert_eq!(result, Err(Ok(Error::PackageIdExists)));
     }
@@ -194,6 +202,8 @@ mod create_package {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
     }
@@ -223,6 +233,8 @@ mod token_interactions {
             &invalid_token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
 
         assert_eq!(result, Err(Ok(Error::InvalidToken)));
@@ -337,6 +349,8 @@ mod claim {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         // Try to claim before claim_starts_at
         let result = t.client.try_claim(&id);
@@ -368,6 +382,8 @@ mod claim {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         // Try to claim before claim_starts_at
         let result = t.client.try_claim(&id);
@@ -412,6 +428,8 @@ mod claim {
             &t.token,
             &(t.now() + 3600),
             &metadata,
+            &false,
+            &0u32,
         );
 
         // Direct claim path should reject Merkle-protected package.
@@ -450,6 +468,8 @@ mod claim {
             &t.token,
             &(t.now() + 3600),
             &metadata,
+            &false,
+            &0u32,
         );
 
         let proof: Vec<soroban_sdk::String> = Vec::new(&t.env);
@@ -489,6 +509,8 @@ mod edge_cases {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
 
         // Contract balance is now fully locked. 2nd package should fail.
@@ -500,6 +522,8 @@ mod edge_cases {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert_eq!(r2, Err(Ok(Error::InsufficientFunds)));
 
@@ -514,6 +538,8 @@ mod edge_cases {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert!(r3.is_ok());
     }
@@ -538,6 +564,8 @@ mod token_decimal_normalization {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert_eq!(result, Err(Ok(Error::InvalidAmount)));
     }
@@ -554,6 +582,8 @@ mod token_decimal_normalization {
             &t.token,
             &(t.now() + 3600),
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         assert!(result.is_ok());
     }

--- a/app/onchain/contracts/aid_escrow/tests/batch.rs
+++ b/app/onchain/contracts/aid_escrow/tests/batch.rs
@@ -61,6 +61,8 @@ fn test_batch_create_packages_success() {
         &token_client.address,
         &86400,
         &empty_metadata(&env, 3),
+        &false,
+        &0u32,
     );
 
     assert_eq!(ids.len(), 3);
@@ -100,6 +102,8 @@ fn test_batch_create_packages_insufficient_funds() {
         &token_client.address,
         &86400,
         &empty_metadata(&env, 2),
+        &false,
+        &0u32,
     );
 
     assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
@@ -139,6 +143,8 @@ fn test_batch_then_individual_no_id_collision() {
         &token_client.address,
         &86400,
         &empty_metadata(&env, 2),
+        &false,
+        &0u32,
     );
 
     assert_eq!(ids.get(0).unwrap(), 0);
@@ -154,6 +160,8 @@ fn test_batch_then_individual_no_id_collision() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     assert_eq!(client.get_package(&manual_id).recipient, recipient3);
@@ -186,6 +194,8 @@ fn test_batch_create_packages_mismatched_arrays() {
         &token_client.address,
         &86400,
         &empty_metadata(&env, 2),
+        &false,
+        &0u32,
     );
     assert_eq!(result, Err(Ok(Error::MismatchedArrays)));
 }
@@ -213,6 +223,8 @@ fn test_batch_create_packages_empty_arrays() {
         &token_client.address,
         &86400,
         &Vec::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(ids.len(), 0);
 }

--- a/app/onchain/contracts/aid_escrow/tests/boundary_validation_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/boundary_validation_tests.rs
@@ -103,6 +103,8 @@ impl TestSetup {
             &self.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         )
     }
 }
@@ -363,6 +365,8 @@ mod combined_boundaries {
             &t.token,
             &expires_at,
             &Map::new(&t.env),
+            &false,
+            &0u32,
         );
         // The contract should reject this during creation validation
         // since claim_starts_at would default to created_at which is < expires_at
@@ -382,6 +386,8 @@ mod combined_boundaries {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         // This should succeed - zero window is allowed
         assert!(result2.is_ok());
@@ -509,6 +515,8 @@ mod edge_cases {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
 
         // Advance time significantly
@@ -544,6 +552,8 @@ mod edge_cases {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         // Should fail because claim_starts_at < created_at
         assert_eq!(result, Err(Ok(Error::InvalidState)));
@@ -571,6 +581,8 @@ mod edge_cases {
             &t.token,
             &expires_at,
             &metadata,
+            &false,
+            &0u32,
         );
         // Should fail because claim_starts_at > expires_at
         assert_eq!(result, Err(Ok(Error::InvalidState)));

--- a/app/onchain/contracts/aid_escrow/tests/core_flow_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/core_flow_tests.rs
@@ -54,6 +54,8 @@ fn test_core_flow_fund_create_claim() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
 
     // Check Package State
@@ -99,6 +101,8 @@ fn test_solvency_check() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
     assert_eq!(res, Err(Ok(Error::InsufficientFunds)));
 
@@ -111,6 +115,8 @@ fn test_solvency_check() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
 
     // Try creating another package (funds are locked)
@@ -122,6 +128,8 @@ fn test_solvency_check() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
     assert_eq!(res2, Err(Ok(Error::InsufficientFunds)));
 }
@@ -157,6 +165,8 @@ fn test_expiry_and_refund() {
         &token_client.address,
         &expiry,
         &metadata,
+        &false,
+        &0u32,
     );
 
     // Advance time past expiry
@@ -203,6 +213,8 @@ fn test_cancel_package_flow() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
 
     // Cancel
@@ -221,6 +233,8 @@ fn test_cancel_package_flow() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
 }
 
@@ -253,6 +267,8 @@ fn test_distributor_package_creation() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
     let pkg = client.get_package(&pkg_id);
     assert_eq!(pkg.status, PackageStatus::Created);
@@ -266,6 +282,8 @@ fn test_distributor_package_creation() {
         &token_client.address,
         &0,
         &metadata,
+        &false,
+        &0u32,
     );
     assert_eq!(res, Err(Ok(Error::NotAuthorized)));
 }

--- a/app/onchain/contracts/aid_escrow/tests/events.rs
+++ b/app/onchain/contracts/aid_escrow/tests/events.rs
@@ -123,6 +123,8 @@ fn test_package_created_event() {
         &token_client.address,
         &expires_at,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     let data = last_event_data(&env, &contract_id, "package_created");
@@ -155,6 +157,8 @@ fn test_package_claimed_event() {
         &token_client.address,
         &(env.ledger().timestamp() + 86400),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.claim(&0u64);
 
@@ -187,6 +191,8 @@ fn test_package_disbursed_event() {
         &token_client.address,
         &(env.ledger().timestamp() + 86400),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.disburse(&0u64);
 
@@ -220,6 +226,8 @@ fn test_package_revoked_event() {
         &token_client.address,
         &(env.ledger().timestamp() + 86400),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     // ACTION: Ensure this matches your contract's function name (revoke vs cancel_package)
@@ -258,6 +266,8 @@ fn test_package_refunded_event() {
         &token_client.address,
         &expires_at,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     env.ledger().set_timestamp(expires_at + 1);
@@ -293,6 +303,8 @@ fn test_extended_event_records_old_and_new_expiry() {
         &token_client.address,
         &old_expires_at,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.extend_expiry(&42u64, &new_expires_at);
 

--- a/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
+++ b/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
@@ -137,6 +137,8 @@ fn profile_single_create_package() {
         &t.token,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let after = capture_budget(&t.env);
@@ -161,6 +163,8 @@ fn profile_single_claim() {
         &t.token,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let before = capture_budget(&t.env);
@@ -187,6 +191,8 @@ fn profile_single_refund() {
         &t.token,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     t.env.ledger().with_mut(|li| li.timestamp = expires_at + 1);
@@ -243,7 +249,7 @@ fn profile_batch_create(batch_size: u32) {
     let before = capture_budget(&t.env);
 
     t.client
-        .batch_create_packages(&t.admin, &recipients, &amounts, &t.token, &3600, &metadatas);
+        .batch_create_packages(&t.admin, &recipients, &amounts, &t.token, &3600, &metadatas, &false, &0u32);
 
     let after = capture_budget(&t.env);
     let metrics = diff_budget(&before, &after);
@@ -301,6 +307,8 @@ fn profile_claim_with_proof() {
         &t.token,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let before = capture_budget(&t.env);
@@ -342,6 +350,8 @@ fn profile_get_package() {
         &t.token,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let before = capture_budget(&t.env);
@@ -371,7 +381,7 @@ fn profile_get_aggregates() {
     t.fund_contract(total_amount);
 
     t.client
-        .batch_create_packages(&t.admin, &recipients, &amounts, &t.token, &3600, &metadatas);
+        .batch_create_packages(&t.admin, &recipients, &amounts, &t.token, &3600, &metadatas, &false, &0u32);
 
     let before = capture_budget(&t.env);
     t.client.get_aggregates(&t.token);

--- a/app/onchain/contracts/aid_escrow/tests/integration.rs
+++ b/app/onchain/contracts/aid_escrow/tests/integration.rs
@@ -43,6 +43,8 @@ fn test_integration_flow() {
         &token_client.address,
         &expires_at,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     let package = client.get_package(&pkg_id);
@@ -78,6 +80,8 @@ fn test_multiple_packages() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.create_package(
         &admin,
@@ -87,6 +91,8 @@ fn test_multiple_packages() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     assert_eq!(client.get_package(&100).amount, UNIT);
@@ -115,6 +121,8 @@ fn test_error_cases() {
         &token_client.address,
         &86400,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(res1, Err(Ok(Error::InvalidAmount)));
 
@@ -178,6 +186,8 @@ fn test_config_constraints_on_create_package() {
         &token_client.address,
         &(now + 10),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(res1, Err(Ok(Error::InvalidAmount)));
 
@@ -190,6 +200,8 @@ fn test_config_constraints_on_create_package() {
         &blocked_token.address,
         &(now + 10),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(res2, Err(Ok(Error::InvalidState)));
 
@@ -202,6 +214,8 @@ fn test_config_constraints_on_create_package() {
         &token_client.address,
         &(now + 2000),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(res3, Err(Ok(Error::InvalidState)));
 }
@@ -228,6 +242,8 @@ fn test_extend_expiration_success() {
         &token_client.address,
         &expiry,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     client.extend_expiration(&1, &500);
@@ -256,6 +272,8 @@ fn test_extend_expiry_success() {
         &token_client.address,
         &initial,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     let new_exp = initial + 500;
@@ -285,6 +303,8 @@ fn test_extend_expiry_rejects_non_increasing_expiry() {
         &token_client.address,
         &initial,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     assert_eq!(
@@ -318,6 +338,8 @@ fn test_extend_expiration_zero_additional_time() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(
         client.try_extend_expiration(&1, &0),
@@ -347,6 +369,8 @@ fn test_extend_expiration_expired_package() {
         &token_client.address,
         &1100,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     env.ledger().set_timestamp(1101);
@@ -377,6 +401,8 @@ fn test_extend_expiration_claimed_package() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.claim(&1);
     assert_eq!(
@@ -406,6 +432,8 @@ fn test_extend_expiration_cancelled_package() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.cancel_package(&1);
     assert_eq!(
@@ -442,6 +470,8 @@ fn test_config_constraints_on_extend_expiration() {
         &token_client.address,
         &(now + 100),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     // Total expiry (100 + 500) = 600. Max allowed from creation is 500.
@@ -488,6 +518,8 @@ fn test_get_recipient_package_count_returns_multiple_packages() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     client.create_package(
         &admin,
@@ -497,6 +529,8 @@ fn test_get_recipient_package_count_returns_multiple_packages() {
         &token_client.address,
         &9999999,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     assert_eq!(client.get_recipient_package_count(&recipient), 2);
@@ -534,6 +568,8 @@ fn test_extend_expiration_unbounded_package() {
         &token_client.address,
         &0,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
     assert_eq!(
         client.try_extend_expiration(&1, &10),
@@ -563,6 +599,8 @@ fn test_extend_expiration_multiple_extends() {
         &token_client.address,
         &initial,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     client.extend_expiration(&1, &100);

--- a/app/onchain/contracts/aid_escrow/tests/invariant_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/invariant_tests.rs
@@ -42,6 +42,8 @@ fn test_core_accounting_invariants() {
         &token_address,
         &0,
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     let locked = client.get_total_locked(&token_address);

--- a/app/onchain/contracts/aid_escrow/tests/view_status.rs
+++ b/app/onchain/contracts/aid_escrow/tests/view_status.rs
@@ -56,6 +56,8 @@ fn test_view_package_status() {
         &token_client.address,
         &expires_at,
         &metadata,
+        &false,
+        &0u32,
     );
 
     let status = client.view_package_status(&pkg_id);

--- a/app/onchain/contracts/aid_escrow/tests/withdraw_surplus.rs
+++ b/app/onchain/contracts/aid_escrow/tests/withdraw_surplus.rs
@@ -80,6 +80,8 @@ fn test_withdraw_surplus_insufficient_surplus() {
         &token_client.address,
         &(env.ledger().timestamp() + 1000),
         &Map::new(&env),
+        &false,
+        &0u32,
     );
 
     // Balance 10, Locked 8, Surplus 2. Request 3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -529,6 +529,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
@@ -1089,6 +1099,15 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "dev": true
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
@@ -1111,6 +1130,86 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nestjs/common": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
+      "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
+      "peer": true,
+      "dependencies": {
+        "file-type": "21.3.4",
+        "iterare": "1.2.1",
+        "load-esm": "1.0.3",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "class-transformer": ">=0.4.1",
+        "class-validator": ">=0.13.2",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
+      "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
+      "peer": true,
+      "dependencies": {
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "8.4.2",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@nestjs/mapped-types": {
@@ -1638,6 +1737,29 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "peer": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1834,6 +1956,16 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/redis": {
       "version": "4.0.10",
@@ -3028,6 +3160,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3487,8 +3626,7 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -3514,6 +3652,24 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/finalhandler": {
@@ -3976,6 +4132,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4170,6 +4346,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jackspeak": {
@@ -4880,6 +5065,25 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/load-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=13.2.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -7723,6 +7927,29 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -7767,6 +7994,12 @@
       "engines": {
         "node": ">= 18.19.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "peer": true
     },
     "node_modules/remeda": {
       "version": "2.33.4",
@@ -7843,10 +8076,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8276,6 +8525,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "peer": true,
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -8434,6 +8699,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "peer": true,
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.4.11",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
@@ -8516,9 +8799,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -8582,6 +8863,30 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "peer": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici-types": {
@@ -9307,6 +9612,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "peer": true
+    },
     "@clack/core": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
@@ -9338,13 +9649,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
       "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@electric-sql/pglite-tools": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
       "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emnapi/core": {
       "version": "1.10.0",
@@ -9381,7 +9694,8 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
       "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -9738,6 +10052,12 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "dev": true
     },
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "peer": true
+    },
     "@microsoft/tsdoc": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
@@ -9753,10 +10073,45 @@
         "@tybys/wasm-util": "^0.10.1"
       }
     },
+    "@nestjs/common": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
+      "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
+      "peer": true,
+      "requires": {
+        "file-type": "21.3.4",
+        "iterare": "1.2.1",
+        "load-esm": "1.0.3",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      }
+    },
+    "@nestjs/core": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
+      "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
+      "peer": true,
+      "requires": {
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "8.4.2",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+          "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+          "peer": true
+        }
+      }
+    },
     "@nestjs/mapped-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw=="
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "requires": {}
     },
     "@nestjs/swagger": {
       "version": "11.2.6",
@@ -9963,7 +10318,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@radix-ui/react-primitive": {
       "version": "2.1.3",
@@ -10017,12 +10373,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@redis/bloom": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
-      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA=="
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "requires": {}
     },
     "@redis/client": {
       "version": "5.12.1",
@@ -10035,17 +10393,20 @@
     "@redis/json": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
-      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg=="
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "requires": {}
     },
     "@redis/search": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
-      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w=="
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "requires": {}
     },
     "@redis/time-series": {
       "version": "5.12.1",
       "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
-      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "requires": {}
     },
     "@scarf/scarf": {
       "version": "1.4.0",
@@ -10081,6 +10442,22 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
+    },
+    "@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "peer": true,
+      "requires": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      }
+    },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "peer": true
     },
     "@tybys/wasm-util": {
       "version": "0.10.2",
@@ -10258,6 +10635,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
+    },
+    "@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "csstype": "^3.2.2"
+      }
     },
     "@types/redis": {
       "version": "4.0.10",
@@ -11022,6 +11409,13 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "peer": true
+    },
     "debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -11034,7 +11428,8 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -11341,8 +11736,7 @@
     "fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fast-uri": {
       "version": "3.1.0",
@@ -11357,6 +11751,18 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "peer": true,
+      "requires": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       }
     },
     "finalhandler": {
@@ -11668,6 +12074,12 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "peer": true
+    },
     "import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -11803,6 +12215,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterare": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "peer": true
     },
     "jackspeak": {
       "version": "3.4.3",
@@ -12045,7 +12463,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "30.4.0",
@@ -12307,6 +12726,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "load-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+      "peer": true
     },
     "locate-path": {
       "version": "5.0.0",
@@ -13710,7 +14135,8 @@
             "fdir": {
               "version": "6.5.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {}
             },
             "picomatch": {
               "version": "4.0.3",
@@ -13979,7 +14405,8 @@
     "pg-pool": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
-      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "requires": {}
     },
     "pg-protocol": {
       "version": "1.14.0",
@@ -14175,6 +14602,23 @@
         "destr": "^2.0.3"
       }
     },
+    "react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "peer": true
+    },
+    "react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "scheduler": "^0.27.0"
+      }
+    },
     "react-is-18": {
       "version": "npm:react-is@18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -14204,6 +14648,12 @@
         "@redis/search": "5.12.1",
         "@redis/time-series": "5.12.1"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "peer": true
     },
     "remeda": {
       "version": "2.33.4",
@@ -14256,10 +14706,26 @@
         "path-to-regexp": "^8.0.0"
       }
     },
+    "rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "peer": true
     },
     "semver": {
       "version": "6.3.1",
@@ -14553,6 +15019,15 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "peer": true,
+      "requires": {
+        "@tokenizer/token": "^0.3.0"
+      }
+    },
     "superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -14670,6 +15145,17 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "peer": true,
+      "requires": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
+    },
     "ts-jest": {
       "version": "29.4.11",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
@@ -14704,9 +15190,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -14742,6 +15226,21 @@
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true
+    },
+    "uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "peer": true,
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
+      }
+    },
+    "uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "peer": true
     },
     "undici-types": {
       "version": "7.24.6",
@@ -14810,7 +15309,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
       "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "vary": {
       "version": "1.1.2",


### PR DESCRIPTION
closes #723 
Implemented optional partial-claim support for escrow packages so funds can be disbursed across multiple valid claims without breaking package accounting.

What changed
Added tranche-aware package state tracking with:
remaining balance
tranche counter
safe partial-claim accounting
Ensured multiple partial claims can succeed when each claim is valid and within the remaining balance.
Preserved correct behavior for:
final claim draining the remaining balance
over-claim rejection
expiry rejection without corrupting package state
Tests
Added regression coverage for:
successful multi-step partial claims
over-claim rejection
expiry behavior
This keeps the contract behavior consistent for packages that are intentionally disbursed in multiple steps.

