### PR TITLE
feat(ai-service): canonical callback payload contract for AI verifica…

### DIFF
--- a/app/ai-service/.env.example
+++ b/app/ai-service/.env.example
@@ -26,6 +26,11 @@ REDIS_URL=redis://localhost:6379/0
 # Default: http://localhost:3001/ai/webhook
 BACKEND_WEBHOOK_URL=http://localhost:3001/ai/webhook
 
+# Shared HMAC-SHA256 secret for signing outbound webhook payloads.
+# Must match WEBHOOK_SECRET in the NestJS backend .env.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+WEBHOOK_SECRET=change-me-to-a-strong-random-secret
+
 # Proof-of-life defaults
 # Confidence threshold range: 0.0 to 1.0
 PROOF_OF_LIFE_CONFIDENCE_THRESHOLD=0.65

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -73,6 +73,11 @@ class Settings(BaseSettings):
     # Backend webhook URL for notifications
     backend_webhook_url: Optional[str] = "http://localhost:3001/ai/webhook"
 
+    # Shared HMAC secret for signing outbound webhook payloads.
+    # Must match WEBHOOK_SECRET on the NestJS backend.
+    # If unset, webhook calls are sent unsigned (development only).
+    webhook_secret: Optional[str] = None
+
     # Proof-of-life settings
     proof_of_life_confidence_threshold: float = 0.65
     proof_of_life_min_face_size: int = 80

--- a/app/ai-service/schemas/callback.py
+++ b/app/ai-service/schemas/callback.py
@@ -1,0 +1,206 @@
+"""
+Canonical callback payload contract for AI verification results.
+
+Schema version: v1
+
+This module is the single source of truth for the payload that the AI service
+POSTs to the NestJS backend webhook endpoint (`POST /aid/webhook`).  Both
+sides MUST derive their field expectations from this file (or its TypeScript
+mirror in `app/backend/src/aid/dto/ai-task-webhook.dto.ts`).
+
+Field alignment with AiTaskWebhookDto (backend):
+  AI service field  <->  Backend DTO field
+  ─────────────────────────────────────────
+  task_id           <->  taskId
+  delivery_id       <->  deliveryId
+  timestamp         <->  timestamp         (ISO-8601 string)
+  status            <->  status            (TaskStatus enum)
+  result            <->  result            (optional object)
+  error             <->  error             (optional string)
+  task_type         <->  taskType          (optional string)
+  completed_at      <->  completedAt       (optional ISO-8601 string)
+  schema_version    <->  (informational — backend ignores unknown fields)
+
+HMAC header:
+  Header name : x-webhook-signature
+  Algorithm   : HMAC-SHA256 over the raw JSON body (UTF-8)
+  Encoding    : lowercase hex digest
+  Secret      : WEBHOOK_SECRET env var (must match backend WEBHOOK_SECRET)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+# ---------------------------------------------------------------------------
+# Schema version — bump the minor when adding optional fields, bump the major
+# when removing or renaming existing fields.
+# ---------------------------------------------------------------------------
+SCHEMA_VERSION = "1.0"
+
+
+class CallbackStatus(str, Enum):
+    """Mirrors TaskStatus in the backend DTO."""
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class AiCallbackPayload(BaseModel):
+    """
+    Versioned, canonical payload for AI-service → backend callbacks.
+
+    Instantiate via the convenience constructor :meth:`build` so that
+    ``delivery_id``, ``timestamp``, and ``schema_version`` are always
+    populated correctly.
+    """
+
+    # ── Required fields ──────────────────────────────────────────────────
+    task_id: str = Field(
+        ...,
+        alias="taskId",
+        description="Stable identifier of the AI task (UUIDv4 recommended).",
+        min_length=1,
+    )
+    delivery_id: str = Field(
+        ...,
+        alias="deliveryId",
+        description=(
+            "Unique per-delivery nonce (UUIDv4). "
+            "The backend uses this for idempotent dedup."
+        ),
+        min_length=1,
+    )
+    timestamp: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp of event generation (e.g. 2024-03-24T10:30:00Z).",
+    )
+    status: CallbackStatus = Field(
+        ...,
+        description="Current task lifecycle status.",
+    )
+
+    # ── Optional fields ──────────────────────────────────────────────────
+    result: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Task output when status=completed.",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Human-readable error message when status=failed.",
+    )
+    task_type: Optional[str] = Field(
+        default=None,
+        alias="taskType",
+        description="Discriminator for the kind of AI task (e.g. 'humanitarian_verification').",
+    )
+    completed_at: Optional[str] = Field(
+        default=None,
+        alias="completedAt",
+        description="ISO-8601 UTC timestamp of task completion (status=completed only).",
+    )
+
+    # ── Metadata ─────────────────────────────────────────────────────────
+    schema_version: str = Field(
+        default=SCHEMA_VERSION,
+        alias="schemaVersion",
+        description="Payload schema version for forward-compatibility checks.",
+    )
+
+    model_config = {
+        # Accept both snake_case (our internal code) and camelCase (wire format).
+        "populate_by_name": True,
+        # Serialise to camelCase so the payload matches the backend DTO exactly.
+        "by_alias": True,
+    }
+
+    # ── Cross-field validation ────────────────────────────────────────────
+
+    @model_validator(mode="after")
+    def _result_xor_error(self) -> "AiCallbackPayload":
+        """A completed task must carry a result; a failed task must carry an error."""
+        if self.status == CallbackStatus.COMPLETED and self.result is None:
+            # Allow result-less completed payloads (e.g. fire-and-forget tasks)
+            # but log a warning in the constructor.
+            pass
+        if self.status == CallbackStatus.FAILED and not self.error:
+            raise ValueError(
+                "Callback payload with status='failed' must include an 'error' message."
+            )
+        return self
+
+    # ── Factory ──────────────────────────────────────────────────────────
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        task_id: str,
+        status: CallbackStatus | str,
+        task_type: Optional[str] = None,
+        result: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> "AiCallbackPayload":
+        """
+        Preferred constructor: auto-generates ``delivery_id``, ``timestamp``,
+        and ``completed_at`` so callers cannot forget them.
+        """
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return cls(
+            task_id=task_id,
+            delivery_id=str(uuid.uuid4()),
+            timestamp=now_iso,
+            status=CallbackStatus(status),
+            task_type=task_type,
+            result=result,
+            error=error,
+            completed_at=now_iso if CallbackStatus(status) == CallbackStatus.COMPLETED else None,
+        )
+
+    # ── Wire serialisation ────────────────────────────────────────────────
+
+    def to_json_bytes(self) -> bytes:
+        """Serialise to the canonical wire format (camelCase JSON, UTF-8)."""
+        return self.model_dump_json(by_alias=True).encode("utf-8")
+
+    def sign(self, secret: str) -> str:
+        """
+        Compute HMAC-SHA256 over the canonical JSON representation.
+
+        Returns the lowercase hex digest suitable for the
+        ``x-webhook-signature`` HTTP header.
+        """
+        raw = self.to_json_bytes()
+        return hmac.new(
+            secret.encode("utf-8"),
+            raw,
+            hashlib.sha256,
+        ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# HMAC helpers (standalone, for callers that already have the raw bytes)
+# ---------------------------------------------------------------------------
+
+def compute_hmac(body_bytes: bytes, secret: str) -> str:
+    """Return hex HMAC-SHA256 of *body_bytes* signed with *secret*."""
+    return hmac.new(
+        secret.encode("utf-8"),
+        body_bytes,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_hmac(body_bytes: bytes, secret: str, signature: str) -> bool:
+    """Timing-safe comparison of the expected HMAC against a received *signature*."""
+    expected = compute_hmac(body_bytes, secret)
+    return hmac.compare_digest(expected, signature)

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -13,6 +13,7 @@ import httpx
 
 import metrics
 from config import settings
+from schemas.callback import AiCallbackPayload, CallbackStatus
 from services.load_shedder import ensure_queue_capacity
 from services.pii_scrubber import PIIScrubberService
 from services.humanitarian_verification import HumanitarianVerificationService
@@ -129,49 +130,72 @@ def update_task_status(
 
 def send_webhook_notification(task_id: str, status: str, result: Any = None, error: str = None) -> None:
     """
-    Send webhook notification to NestJS backend when task completes
-    
+    Send a signed webhook notification to the NestJS backend when a task
+    transitions to a terminal state.
+
+    The payload is serialised using :class:`~schemas.callback.AiCallbackPayload`
+    (the canonical contract) and signed with HMAC-SHA256 if ``WEBHOOK_SECRET``
+    is configured.  The resulting signature is sent in the
+    ``x-webhook-signature`` header, matching what :class:`WebhookHmacGuard`
+    on the backend expects.
+
     Args:
-        task_id: Unique identifier for the task
-        status: Final status (completed, failed)
-        result: Task result data (if completed)
-        error: Error message (if failed)
+        task_id: Unique identifier of the completed/failed task.
+        status:  Terminal status string ("completed" or "failed").
+        result:  Task output dict (required when status="completed").
+        error:   Error message string (required when status="failed").
     """
     if not settings.backend_webhook_url:
         logger.warning("Backend webhook URL not configured, skipping notification")
         return
-    
-    payload = {
-        'task_id': task_id,
-        'status': status,
-        'service': 'soter-ai-service',
-        'timestamp': time.time(),
-    }
-    
-    if result is not None:
-        payload['result'] = result
-    
-    if error:
-        payload['error'] = error
-    
+
     try:
-        # Fire and forget - don't block the task completion
+        payload = AiCallbackPayload.build(
+            task_id=task_id,
+            status=CallbackStatus(status),
+            result=result,
+            error=error,
+        )
+    except Exception as exc:
+        logger.error(f"Failed to build callback payload for task {task_id}: {exc}")
+        return
+
+    body_bytes = payload.to_json_bytes()
+    headers: dict = {"Content-Type": "application/json"}
+
+    if settings.webhook_secret:
+        headers["x-webhook-signature"] = payload.sign(settings.webhook_secret)
+    else:
+        logger.warning(
+            "WEBHOOK_SECRET not configured — sending unsigned webhook for task %s. "
+            "Set WEBHOOK_SECRET in .env to enable HMAC verification.",
+            task_id,
+        )
+
+    try:
         import threading
-        def send_notification():
+
+        def send_notification() -> None:
             try:
                 with httpx.Client(timeout=10.0) as client:
-                    response = client.post(settings.backend_webhook_url, json=payload)
+                    response = client.post(
+                        settings.backend_webhook_url,
+                        content=body_bytes,
+                        headers=headers,
+                    )
                     if response.status_code >= 400:
-                        logger.error(f"Webhook notification failed: {response.status_code} - {response.text}")
+                        logger.error(
+                            f"Webhook notification failed: {response.status_code} - {response.text}"
+                        )
                     else:
                         logger.info(f"Webhook notification sent for task {task_id}")
-            except Exception as e:
-                logger.error(f"Failed to send webhook notification: {e}")
-        
-        thread = threading.Thread(target=send_notification)
+            except Exception as exc:
+                logger.error(f"Failed to send webhook notification: {exc}")
+
+        thread = threading.Thread(target=send_notification, daemon=True)
         thread.start()
-    except Exception as e:
-        logger.error(f"Error setting up webhook notification: {e}")
+    except Exception as exc:
+        logger.error(f"Error setting up webhook notification thread: {exc}")
 
 
 def process_heavy_inference_impl(self, task_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/ai-service/tests/test_callback_schema.py
+++ b/app/ai-service/tests/test_callback_schema.py
@@ -1,0 +1,348 @@
+"""
+Tests for the canonical AI-callback payload contract.
+
+Covers:
+  - Schema construction and field validation
+  - camelCase wire serialisation (must match AiTaskWebhookDto on the backend)
+  - HMAC-SHA256 signing / verification helpers
+  - The ``build()`` factory convenience method
+  - Rejection of malformed payloads (missing required fields, bad enum values,
+    failed cross-field rules)
+  - Round-trip: serialise → parse → re-serialise produces identical bytes
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.callback import (
+    SCHEMA_VERSION,
+    AiCallbackPayload,
+    CallbackStatus,
+    compute_hmac,
+    verify_hmac,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SECRET = "test-hmac-secret-32-chars-long!!"
+_TASK_ID = "task-abc-123"
+_DELIVERY_ID = "del-xyz-456"
+_TIMESTAMP = "2024-03-24T10:30:00Z"
+
+
+def _make_payload(**overrides) -> dict:
+    """Return a minimal valid payload dict (snake_case, for direct construction)."""
+    base = {
+        "task_id": _TASK_ID,
+        "delivery_id": _DELIVERY_ID,
+        "timestamp": _TIMESTAMP,
+        "status": CallbackStatus.COMPLETED,
+        "result": {"score": 0.9},
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# 1. Field presence and types
+# ===========================================================================
+
+
+class TestRequiredFields:
+    def test_all_required_fields_present(self):
+        p = AiCallbackPayload(**_make_payload())
+        assert p.task_id == _TASK_ID
+        assert p.delivery_id == _DELIVERY_ID
+        assert p.timestamp == _TIMESTAMP
+        assert p.status == CallbackStatus.COMPLETED
+
+    def test_missing_task_id_raises(self):
+        data = _make_payload()
+        del data["task_id"]
+        with pytest.raises(ValidationError) as exc_info:
+            AiCallbackPayload(**data)
+        errors = exc_info.value.errors()
+        # Pydantic may report via the snake_case name or the camelCase alias.
+        field_names = {str(loc) for e in errors for loc in e["loc"]}
+        assert "task_id" in field_names or "taskId" in field_names
+
+    def test_missing_delivery_id_raises(self):
+        data = _make_payload()
+        del data["delivery_id"]
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**data)
+
+    def test_missing_timestamp_raises(self):
+        data = _make_payload()
+        del data["timestamp"]
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**data)
+
+    def test_missing_status_raises(self):
+        data = _make_payload()
+        del data["status"]
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**data)
+
+    def test_empty_task_id_raises(self):
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**_make_payload(task_id=""))
+
+    def test_empty_delivery_id_raises(self):
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**_make_payload(delivery_id=""))
+
+
+# ===========================================================================
+# 2. Status enum semantics
+# ===========================================================================
+
+
+class TestStatusSemantics:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            CallbackStatus.PENDING,
+            CallbackStatus.PROCESSING,
+            CallbackStatus.COMPLETED,
+            CallbackStatus.FAILED,
+        ],
+    )
+    def test_valid_statuses_accepted(self, status: CallbackStatus):
+        extra = {"error": "oops"} if status == CallbackStatus.FAILED else {}
+        p = AiCallbackPayload(**_make_payload(status=status, **extra))
+        assert p.status == status
+
+    def test_invalid_status_string_raises(self):
+        with pytest.raises(ValidationError):
+            AiCallbackPayload(**_make_payload(status="unknown_status"))
+
+    def test_status_string_coercion(self):
+        """String literals matching enum values must be accepted."""
+        p = AiCallbackPayload(**_make_payload(status="completed"))
+        assert p.status == CallbackStatus.COMPLETED
+
+    def test_failed_status_without_error_raises(self):
+        """Cross-field rule: failed payload must carry an error message."""
+        with pytest.raises(ValidationError) as exc_info:
+            AiCallbackPayload(**_make_payload(status=CallbackStatus.FAILED, error=None))
+        assert "error" in str(exc_info.value).lower()
+
+    def test_failed_status_with_error_accepted(self):
+        p = AiCallbackPayload(
+            **_make_payload(status=CallbackStatus.FAILED, error="Out of memory", result=None)
+        )
+        assert p.status == CallbackStatus.FAILED
+        assert p.error == "Out of memory"
+
+
+# ===========================================================================
+# 3. Optional fields
+# ===========================================================================
+
+
+class TestOptionalFields:
+    def test_result_defaults_to_none(self):
+        p = AiCallbackPayload(**_make_payload(result=None))
+        assert p.result is None
+
+    def test_error_defaults_to_none_for_completed(self):
+        p = AiCallbackPayload(**_make_payload())
+        assert p.error is None
+
+    def test_task_type_accepted(self):
+        p = AiCallbackPayload(**_make_payload(task_type="humanitarian_verification"))
+        assert p.task_type == "humanitarian_verification"
+
+    def test_completed_at_accepted(self):
+        p = AiCallbackPayload(**_make_payload(completed_at="2024-03-24T10:35:00Z"))
+        assert p.completed_at == "2024-03-24T10:35:00Z"
+
+    def test_schema_version_default(self):
+        p = AiCallbackPayload(**_make_payload())
+        assert p.schema_version == SCHEMA_VERSION
+
+
+# ===========================================================================
+# 4. Wire serialisation — camelCase JSON must match backend DTO field names
+# ===========================================================================
+
+
+class TestWireSerialization:
+    def test_serialises_to_camel_case(self):
+        p = AiCallbackPayload(
+            **_make_payload(task_type="image_analysis", completed_at="2024-03-24T10:35:00Z")
+        )
+        wire = json.loads(p.model_dump_json(by_alias=True))
+
+        # These field names must match AiTaskWebhookDto on the backend exactly.
+        assert "taskId" in wire
+        assert "deliveryId" in wire
+        assert "timestamp" in wire
+        assert "status" in wire
+        assert "taskType" in wire
+        assert "completedAt" in wire
+        assert "schemaVersion" in wire
+
+        # snake_case variants must NOT appear in the wire payload
+        assert "task_id" not in wire
+        assert "delivery_id" not in wire
+        assert "task_type" not in wire
+        assert "completed_at" not in wire
+        assert "schema_version" not in wire
+
+    def test_to_json_bytes_is_utf8(self):
+        p = AiCallbackPayload(**_make_payload())
+        raw = p.to_json_bytes()
+        assert isinstance(raw, bytes)
+        parsed = json.loads(raw.decode("utf-8"))
+        assert parsed["taskId"] == _TASK_ID
+
+    def test_round_trip(self):
+        """Serialise → parse → re-serialise must produce bit-identical JSON."""
+        p1 = AiCallbackPayload(**_make_payload())
+        raw1 = p1.to_json_bytes()
+
+        wire_dict = json.loads(raw1)
+        # Backend would receive camelCase — simulate re-parsing using aliases.
+        p2 = AiCallbackPayload.model_validate(wire_dict)
+        raw2 = p2.to_json_bytes()
+
+        assert json.loads(raw1) == json.loads(raw2)
+
+    def test_none_optional_fields_omitted_or_null(self):
+        """None optional fields should not break deserialisation."""
+        p = AiCallbackPayload(**_make_payload())
+        wire = json.loads(p.to_json_bytes())
+        # result is set; error, taskType, completedAt are None — must be present as null
+        assert "result" in wire
+
+
+# ===========================================================================
+# 5. HMAC signing and verification
+# ===========================================================================
+
+
+class TestHmacSigning:
+    def test_sign_produces_hex_string(self):
+        p = AiCallbackPayload(**_make_payload())
+        sig = p.sign(_SECRET)
+        assert isinstance(sig, str)
+        assert len(sig) == 64  # SHA-256 hex digest is always 64 chars
+
+    def test_sign_is_deterministic_for_same_payload(self):
+        """Signing the same serialised payload twice must yield the same digest."""
+        p = AiCallbackPayload(**_make_payload())
+        raw = p.to_json_bytes()
+        assert p.sign(_SECRET) == compute_hmac(raw, _SECRET)
+
+    def test_sign_changes_with_different_secret(self):
+        p = AiCallbackPayload(**_make_payload())
+        sig1 = p.sign(_SECRET)
+        sig2 = p.sign("different-secret")
+        assert sig1 != sig2
+
+    def test_verify_hmac_passes_with_correct_secret(self):
+        p = AiCallbackPayload(**_make_payload())
+        body = p.to_json_bytes()
+        sig = compute_hmac(body, _SECRET)
+        assert verify_hmac(body, _SECRET, sig) is True
+
+    def test_verify_hmac_fails_with_wrong_secret(self):
+        p = AiCallbackPayload(**_make_payload())
+        body = p.to_json_bytes()
+        sig = compute_hmac(body, _SECRET)
+        assert verify_hmac(body, "wrong-secret", sig) is False
+
+    def test_verify_hmac_fails_with_tampered_body(self):
+        p = AiCallbackPayload(**_make_payload())
+        body = p.to_json_bytes()
+        sig = compute_hmac(body, _SECRET)
+        tampered = body[:-1] + b"X"
+        assert verify_hmac(tampered, _SECRET, sig) is False
+
+    def test_verify_hmac_fails_with_truncated_signature(self):
+        p = AiCallbackPayload(**_make_payload())
+        body = p.to_json_bytes()
+        sig = compute_hmac(body, _SECRET)[:32]  # truncate
+        assert verify_hmac(body, _SECRET, sig) is False
+
+    def test_standalone_compute_hmac_matches_sign_method(self):
+        p = AiCallbackPayload(**_make_payload())
+        assert p.sign(_SECRET) == compute_hmac(p.to_json_bytes(), _SECRET)
+
+
+# ===========================================================================
+# 6. build() factory
+# ===========================================================================
+
+
+class TestBuildFactory:
+    def test_build_completed(self):
+        p = AiCallbackPayload.build(
+            task_id=_TASK_ID,
+            status=CallbackStatus.COMPLETED,
+            result={"score": 0.88},
+            task_type="humanitarian_verification",
+        )
+        assert p.task_id == _TASK_ID
+        assert p.status == CallbackStatus.COMPLETED
+        assert p.result == {"score": 0.88}
+        assert p.task_type == "humanitarian_verification"
+        assert p.completed_at is not None
+        # delivery_id must be a valid UUID
+        uuid.UUID(p.delivery_id)
+
+    def test_build_failed(self):
+        p = AiCallbackPayload.build(
+            task_id=_TASK_ID,
+            status="failed",
+            error="Inference timeout",
+        )
+        assert p.status == CallbackStatus.FAILED
+        assert p.error == "Inference timeout"
+        assert p.completed_at is None
+
+    def test_build_timestamp_is_iso8601_utc(self):
+        p = AiCallbackPayload.build(task_id=_TASK_ID, status="processing")
+        # Must be parseable as an ISO-8601 date string
+        dt = datetime.fromisoformat(p.timestamp.replace("Z", "+00:00"))
+        assert dt.tzinfo is not None
+
+    def test_build_delivery_id_is_unique(self):
+        p1 = AiCallbackPayload.build(task_id=_TASK_ID, status="pending")
+        p2 = AiCallbackPayload.build(task_id=_TASK_ID, status="pending")
+        assert p1.delivery_id != p2.delivery_id
+
+    def test_build_invalid_status_raises(self):
+        with pytest.raises((ValidationError, ValueError)):
+            AiCallbackPayload.build(task_id=_TASK_ID, status="not_a_status")
+
+    def test_build_failed_without_error_raises(self):
+        with pytest.raises((ValidationError, ValueError)):
+            AiCallbackPayload.build(task_id=_TASK_ID, status="failed")  # no error
+
+
+# ===========================================================================
+# 7. Schema version
+# ===========================================================================
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_correct_constant(self):
+        assert SCHEMA_VERSION == "1.0"
+
+    def test_payload_carries_schema_version(self):
+        p = AiCallbackPayload(**_make_payload())
+        wire = json.loads(p.to_json_bytes())
+        assert wire["schemaVersion"] == SCHEMA_VERSION


### PR DESCRIPTION
Closes #759

---

…tion results

- Add schemas/callback.py with versioned AiCallbackPayload Pydantic model that serialises to camelCase wire format matching AiTaskWebhookDto on the backend (taskId, deliveryId, timestamp, status, result, error, taskType, completedAt, schemaVersion)
- Add CallbackStatus enum mirroring backend TaskStatus
- Add HMAC-SHA256 signing helpers (sign, compute_hmac, verify_hmac)
- Add build() factory that auto-generates delivery_id (UUID4) and ISO-8601 timestamps so callers cannot omit required nonce/timestamp fields
- Cross-field validation: status=failed without error message is rejected
- Update tasks.py send_webhook_notification to use canonical schema: correct camelCase field names, ISO-8601 timestamp, deliveryId nonce, and x-webhook-signature HMAC header
- Add webhook_secret config setting (reads WEBHOOK_SECRET env var)
- Document WEBHOOK_SECRET in .env.example
- Add 40 tests in tests/test_callback_schema.py covering schema validation, camelCase serialisation, HMAC signing/verification, build() factory, and rejection of malformed payloads