### PR TITLE
feat: Add multilingual OCR language hints

### DIFF
--- a/app/ai-service/api/routes.py
+++ b/app/ai-service/api/routes.py
@@ -1,13 +1,13 @@
 import io
 import time
-from typing import Annotated
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 import metrics
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-from schemas.ocr import OCRData, OCRFieldResult, OCRResponse
+from schemas.ocr import OCRData, OCRFieldResult, OCRResponse, LanguageHint
 from services.ocr import OCRService
 from config import settings
 
@@ -31,6 +31,7 @@ ocr_service = OCRService()
 async def process_ocr(
     request: Request,
     image: Annotated[UploadFile, File(description="Image file to process")],
+    language_hint: Annotated[Optional[LanguageHint], Form(description="Language hint for OCR")] = None,
 ) -> OCRResponse:
     start_time = time.time()
 
@@ -69,7 +70,7 @@ async def process_ocr(
             )
 
         start_inference = time.time()
-        result = ocr_service.process_image(img)
+        result = ocr_service.process_image(img, language_hint=language_hint.value if language_hint else None)
         inference_latency = time.time() - start_inference
         
         metrics.INFERENCE_LATENCY.labels(task_type="ocr").observe(inference_latency)

--- a/app/ai-service/api/v1/ocr.py
+++ b/app/ai-service/api/v1/ocr.py
@@ -16,7 +16,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 import tasks
-from schemas.ocr import OCRData
+from schemas.ocr import OCRData, LanguageHint
 from schemas.common import ResultEnvelope
 from services.ocr_job import run_ocr_from_bytes
 from config import settings
@@ -47,6 +47,7 @@ async def process_ocr(
     request: Request,
     image: Annotated[UploadFile, File(description="Image file to process")],
     anchor_metadata: Annotated[Optional[str], Form(description="JSON encoded AnchorMetadata")] = None,
+    language_hint: Annotated[Optional[LanguageHint], Form(description="Language hint for OCR")] = None,
 ) -> ResultEnvelope[OCRData]:
     """Extract text fields from an uploaded document image."""
     start_time = time.time()
@@ -76,7 +77,11 @@ async def process_ocr(
             )
 
         _validate_image_bytes(contents)
-        raw = run_ocr_from_bytes(contents, anchor_metadata)
+        raw = run_ocr_from_bytes(
+            contents,
+            anchor_metadata,
+            language_hint=language_hint.value if language_hint else None
+        )
 
         from main import correlation_id_var
         ocr_data = OCRData(**raw["data"]) if isinstance(raw["data"], dict) else raw["data"]
@@ -119,6 +124,7 @@ async def queue_ocr_job(
     request: Request,
     image: Annotated[UploadFile, File(description="Image file to process")],
     anchor_metadata: Annotated[Optional[str], Form(description="JSON encoded AnchorMetadata")] = None,
+    language_hint: Annotated[Optional[LanguageHint], Form(description="Language hint for OCR")] = None,
 ) -> QueuedOCRResponse:
     """Queue OCR processing and return immediately with a pollable job URL."""
     if image.content_type not in ALLOWED_CONTENT_TYPES:
@@ -152,6 +158,7 @@ async def queue_ocr_job(
             "content_type": image.content_type,
             "filename": image.filename,
             "anchor_metadata": anchor_metadata,
+            "language_hint": language_hint.value if language_hint else None,
         },
     )
 

--- a/app/ai-service/schemas/ocr.py
+++ b/app/ai-service/schemas/ocr.py
@@ -1,6 +1,20 @@
+from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
 from schemas.common import AnchorMetadata
+
+
+class LanguageHint(str, Enum):
+    eng = "eng"
+    spa = "spa"
+    fra = "fra"
+    deu = "deu"
+    ita = "ita"
+    por = "por"
+    chi_sim = "chi_sim"
+    ara = "ara"
+    hin = "hin"
+    jpn = "jpn"
 
 
 class OCRFieldResult(BaseModel):

--- a/app/ai-service/services/ocr.py
+++ b/app/ai-service/services/ocr.py
@@ -1,7 +1,7 @@
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Optional
 
 import pytesseract
 from PIL import Image
@@ -83,7 +83,7 @@ class OCRService:
         self.field_detector = FieldDetector()
         self.test_provider = TestProvider()
 
-    def process_image(self, image: Image.Image) -> OCRResult:
+    def process_image(self, image: Image.Image, language_hint: Optional[str] = None) -> OCRResult:
         if settings.test_provider_mode:
             response = self.test_provider.get_response("ocr", {"image_size": str(image.size)})
             fields: Dict[str, FieldMatch] = {}
@@ -108,7 +108,7 @@ class OCRService:
                 processing_time_ms=int((time.time() - start_time) * 1000),
             )
 
-        tesseract_data = self._run_tesseract(preprocessed)
+        tesseract_data = self._run_tesseract(preprocessed, language_hint=language_hint)
 
         raw_text = tesseract_data.get("text", "")
         if isinstance(raw_text, list):
@@ -132,11 +132,12 @@ class OCRService:
             processing_time_ms=int(latency * 1000),
         )
 
-    def _run_tesseract(self, image: Image.Image) -> dict:
+    def _run_tesseract(self, image: Image.Image, language_hint: Optional[str] = None) -> dict:
         config = "--psm 6 --oem 3"
-        data = pytesseract.image_to_data(
-            image, config=config, output_type=pytesseract.Output.DICT
-        )
+        kwargs = {"config": config, "output_type": pytesseract.Output.DICT}
+        if language_hint:
+            kwargs["lang"] = language_hint
+        data = pytesseract.image_to_data(image, **kwargs)
         return data
 
     def _extract_field_chars(

--- a/app/ai-service/services/ocr_job.py
+++ b/app/ai-service/services/ocr_job.py
@@ -17,12 +17,13 @@ ocr_service = OCRService()
 def run_ocr_from_bytes(
     contents: bytes,
     anchor_metadata: Optional[str] = None,
+    language_hint: Optional[str] = None,
 ) -> dict:
     start_time = time.time()
     img = Image.open(io.BytesIO(contents))
 
     start_inference = time.time()
-    result = ocr_service.process_image(img)
+    result = ocr_service.process_image(img, language_hint=language_hint)
     inference_latency = time.time() - start_inference
 
     metrics.INFERENCE_LATENCY.labels(task_type="ocr").observe(inference_latency)
@@ -52,8 +53,9 @@ def run_ocr_from_bytes(
 def run_ocr_from_base64(
     image_base64: str,
     anchor_metadata: Optional[str] = None,
+    language_hint: Optional[str] = None,
 ) -> dict:
-    return run_ocr_from_bytes(base64.b64decode(image_base64), anchor_metadata)
+    return run_ocr_from_bytes(base64.b64decode(image_base64), anchor_metadata, language_hint=language_hint)
 
 
 def _parse_anchor_metadata(anchor_metadata: Optional[str]) -> Optional[AnchorMetadata]:

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -268,6 +268,7 @@ def _process_ocr(payload: Dict[str, Any]) -> Dict[str, Any]:
         'result': run_ocr_from_base64(
             image_base64,
             payload.get('anchor_metadata'),
+            language_hint=payload.get('language_hint'),
         ),
     }
 

--- a/app/ai-service/tests/test_ocr.py
+++ b/app/ai-service/tests/test_ocr.py
@@ -84,7 +84,7 @@ class TestOCRService:
         
         from PIL import Image
 
-        def fake_run_tesseract(_image):
+        def fake_run_tesseract(_image, **kwargs):
             return {
                 "text": ["Name:", "John", "Doe", "ID", "AB123456"],
                 "conf": [90, 92, 91, 88, 95],
@@ -101,6 +101,29 @@ class TestOCRService:
         
         mock_labels.assert_called_with(step_name='ocr')
         assert mock_observe.call_count == 2
+
+    @patch('metrics.PIPELINE_STEP_LATENCY.labels')
+    def test_process_image_passes_language_hint(self, mock_labels, monkeypatch):
+        mock_observe = MagicMock()
+        mock_labels.return_value.observe = mock_observe
+        
+        from PIL import Image
+
+        captured_kwargs = {}
+        def fake_run_tesseract(_image, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "text": ["Name:", "Jane"],
+                "conf": [90, 92],
+            }
+
+        monkeypatch.setattr(self.ocr, "_run_tesseract", fake_run_tesseract)
+
+        img = Image.new("RGB", (200, 100), color="white")
+        result = self.ocr.process_image(img, language_hint="fra")
+        
+        assert captured_kwargs.get("language_hint") == "fra"
+        assert result.raw_text == "Name: Jane"
 
     def test_process_image_empty_image(self):
         from PIL import Image

--- a/app/ai-service/tests/test_routes.py
+++ b/app/ai-service/tests/test_routes.py
@@ -62,6 +62,39 @@ class TestOCRRoutes:
         # Legacy /ai/ocr returns OCRResponse (old flat shape)
         assert "processing_time_ms" in data
 
+    def test_ocr_endpoint_with_language_hint(self):
+        from PIL import Image
+
+        img = Image.new("RGB", (50, 50), color="blue")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        
+        with patch("services.ocr.OCRService._run_tesseract", return_value={"text": ["Test"], "conf": [90]}) as mock_run:
+            response = client.post(
+                "/ai/ocr",
+                files={"image": ("test.png", buf.getvalue(), "image/png")},
+                data={"language_hint": "eng"},
+            )
+        assert response.status_code == 200
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1].get("language_hint") == "eng"
+
+    def test_ocr_endpoint_unsupported_language_hint(self):
+        from PIL import Image
+
+        img = Image.new("RGB", (50, 50), color="blue")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        
+        response = client.post(
+            "/ai/ocr",
+            files={"image": ("test.png", buf.getvalue(), "image/png")},
+            data={"language_hint": "invalid"},
+        )
+        assert response.status_code == 422
+
 
 class TestRootEndpoint:
     def test_root_returns_welcome(self):

--- a/app/ai-service/tests/test_versioned_routes.py
+++ b/app/ai-service/tests/test_versioned_routes.py
@@ -174,6 +174,35 @@ class TestOCRV1Path:
             )
         assert response.status_code == 200
 
+    def test_v1_ocr_with_language_hint_returns_200(self, client):
+        from PIL import Image
+
+        img = Image.new("RGB", (60, 60), color="green")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        with patch("api.v1.ocr.run_ocr_from_bytes", return_value=self._FAKE_OCR) as mock_run:
+            response = client.post(
+                "/v1/ai/ocr",
+                files={"image": ("img.png", buf.getvalue(), "image/png")},
+                data={"language_hint": "eng"},
+            )
+        assert response.status_code == 200
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1].get("language_hint") == "eng"
+
+    def test_v1_ocr_unsupported_language_hint_returns_422(self, client):
+        from PIL import Image
+
+        img = Image.new("RGB", (60, 60), color="green")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        response = client.post(
+            "/v1/ai/ocr",
+            files={"image": ("img.png", buf.getvalue(), "image/png")},
+            data={"language_hint": "unsupported"},
+        )
+        assert response.status_code == 422
+
     def test_v1_ocr_processing_time_present(self, client):
         from PIL import Image
 


### PR DESCRIPTION
Resolves #774

### Description
This PR adds optional language hint support to the OCR endpoints to improve text extraction on multilingual and region-specific documents. 

### Changes Made
1. **Schema**: Added a `LanguageHint` Enum in `app/ai-service/schemas/ocr.py` that restricts inputs to standard Tesseract language codes (e.g., `eng`, `spa`, `fra`).
2. **Service Layer**: Updated `OCRService.process_image` and `OCRService._run_tesseract` to pass the `language_hint` to the underlying `pytesseract` engine. Updated `run_ocr_from_bytes`, `run_ocr_from_base64`, and the Celery task processor in `tasks.py` to route the hint appropriately.
3. **Endpoints**: Modified `/ai/ocr` and `/v1/ai/ocr/jobs` to accept `language_hint` as an optional form parameter. It uses FastAPI and the `LanguageHint` Enum to automatically validate the hint and reject unsupported ones with a 422 Unprocessable Entity error.
4. **Testing**: Added integration and unit tests covering successful requests with supported language hints and failure cases with unsupported ones. All tests are passing.
