### PR TITLE
feat: add dead-letter replay for callback and async jobs

### DIFF
--- a/app/ai-service/README.md
+++ b/app/ai-service/README.md
@@ -152,6 +152,33 @@ Response body:
 }
 ```
 
+### Dead-Letter Replay
+
+Failed callback deliveries (webhook POSTs to the backend that keep 4xx/5xx-ing)
+and async jobs that exhaust their Celery retry budget are captured in an
+in-memory dead-letter queue instead of being silently dropped, so operators
+can recover from transient outages without manual patching.
+
+- **GET** `/v1/ai/dead-letter` - List dead-letter items (`?kind=callback|async_job&status=pending|succeeded|exhausted`)
+- **GET** `/v1/ai/dead-letter/{item_id}` - Get a single item, including its full replay audit log
+- **POST** `/v1/ai/dead-letter/{item_id}/replay` - Replay a single item (resend the callback, or re-run the async job)
+
+All three endpoints require an `X-User-Role` header (`admin`, `operator`, or
+`reviewer` to read; `admin` or `operator` to replay). Replay is rate-limited
+two ways: a per-item cooldown (`DEAD_LETTER_REPLAY_COOLDOWN_SECONDS`, default
+10s) enforced between attempts on the same item, and a per-client request
+rate limit (`DEAD_LETTER_REPLAY_RATE_LIMIT`, default `10/minute`) on the
+route itself. Items that fail `DEAD_LETTER_MAX_REPLAY_ATTEMPTS` times
+(default 5) move to `exhausted` and stop accepting further replays.
+
+Every replay attempt - success or failure - is appended to the item's
+`audit_log` with the actor (`X-User-Id`), outcome, and error.
+
+```bash
+curl -X POST "http://localhost:8000/v1/ai/dead-letter/callback:task-123/replay" \
+  -H "X-User-Role: operator" -H "X-User-Id: alice"
+```
+
 ## Project Structure
 
 ```

--- a/app/ai-service/api/v1/dead_letter.py
+++ b/app/ai-service/api/v1/dead_letter.py
@@ -1,0 +1,149 @@
+"""
+Dead-letter listing and replay endpoints for failed callback deliveries and
+exhausted async jobs (Issue #776).
+
+Replay is a privileged, operator-triggered recovery action:
+- Requires an authorized role (``X-User-Role: admin`` or ``operator``),
+  mirroring the role check used for verification-artifact access.
+- Every attempt is appended to the item's audit log (actor, outcome, error).
+- Replay is rate-limited two ways: a per-item cooldown enforced by the
+  DeadLetterQueue service, and a per-client request rate limit on the route
+  itself. Items that exhaust ``dead_letter_max_replay_attempts`` stop being
+  replayable until an operator intervenes out-of-band.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+import metrics
+import tasks
+from config import settings
+from services.dead_letter import DeadLetterError, dead_letter_queue
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["dead-letter"])
+limiter = Limiter(key_func=get_remote_address)
+
+REPLAY_AUTHORIZED_ROLES = {"admin", "operator"}
+READ_AUTHORIZED_ROLES = {"admin", "operator", "reviewer"}
+
+_ERROR_STATUS = {
+    "not_found": 404,
+    "already_succeeded": 409,
+    "exhausted": 409,
+    "rate_limited": 429,
+}
+_ERROR_MESSAGES = {
+    "not_found": "Dead-letter item not found",
+    "already_succeeded": "Item has already been successfully replayed",
+    "exhausted": "Item has exhausted its replay attempts",
+    "rate_limited": "Replay attempted too soon; wait for the cooldown to elapse",
+}
+
+
+def _error_response(code: str) -> JSONResponse:
+    status_code = _ERROR_STATUS.get(code, 400)
+    headers = {}
+    if code == "rate_limited":
+        headers["Retry-After"] = str(int(settings.dead_letter_replay_cooldown_seconds))
+    return JSONResponse(
+        status_code=status_code,
+        headers=headers,
+        content={"error": {"code": code, "message": _ERROR_MESSAGES.get(code, "Request failed")}},
+    )
+
+
+def _forbidden(message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=403,
+        content={"error": {"code": "forbidden_role", "message": message}},
+    )
+
+
+@router.get("/ai/dead-letter")
+async def list_dead_letter_items(
+    kind: Optional[str] = None,
+    status: Optional[str] = None,
+    x_user_role: str = Header(default="", alias="X-User-Role"),
+):
+    """List dead-letter items, optionally filtered by kind and/or status."""
+    if x_user_role not in READ_AUTHORIZED_ROLES:
+        return _forbidden(f"User role '{x_user_role}' is not authorized to view dead-letter items")
+
+    items = dead_letter_queue.list(kind=kind, status=status)
+    return {
+        "items": [item.to_dict() for item in items],
+        "count": len(items),
+    }
+
+
+@router.get("/ai/dead-letter/{item_id}")
+async def get_dead_letter_item(
+    item_id: str,
+    x_user_role: str = Header(default="", alias="X-User-Role"),
+):
+    """Get a single dead-letter item with its full replay audit log."""
+    if x_user_role not in READ_AUTHORIZED_ROLES:
+        return _forbidden(f"User role '{x_user_role}' is not authorized to view dead-letter items")
+
+    entry = dead_letter_queue.get(item_id)
+    if entry is None:
+        return _error_response("not_found")
+    return entry.to_dict()
+
+
+@router.post("/ai/dead-letter/{item_id}/replay")
+@limiter.limit(settings.dead_letter_replay_rate_limit)
+async def replay_dead_letter_item(
+    item_id: str,
+    request: Request,
+    x_user_role: str = Header(default="", alias="X-User-Role"),
+    x_user_id: str = Header(default="", alias="X-User-Id"),
+):
+    """
+    Replay a single dead-letter item (resend a callback or re-run an async job).
+
+    Returns 404 if the item doesn't exist, 409 if it has already succeeded or
+    exhausted its retry budget, and 429 if replayed again before the
+    per-item cooldown elapses.
+    """
+    if x_user_role not in REPLAY_AUTHORIZED_ROLES:
+        return _forbidden(f"User role '{x_user_role}' is not authorized to replay dead-letter items")
+
+    try:
+        entry = dead_letter_queue.check_replayable(item_id)
+    except DeadLetterError as exc:
+        return _error_response(str(exc))
+
+    actor = x_user_id.strip() or x_user_role
+
+    try:
+        if entry.kind == "callback":
+            tasks.replay_callback_delivery(entry.task_id, entry.payload)
+        else:
+            tasks.replay_async_job(entry.task_id, entry.payload)
+        success = True
+        replay_error = None
+    except Exception as exc:
+        success = False
+        replay_error = str(exc)
+        logger.warning(
+            "dead_letter_replay_failed",
+            extra={"dead_letter_id": item_id, "kind": entry.kind, "error": replay_error},
+        )
+
+    updated = dead_letter_queue.record_attempt(item_id, actor=actor, success=success, error=replay_error)
+    metrics.DEAD_LETTER_REPLAY_ATTEMPTS_TOTAL.labels(
+        kind=entry.kind, outcome="succeeded" if success else "failed"
+    ).inc()
+
+    return {
+        "success": success,
+        "item": updated.to_dict(),
+    }

--- a/app/ai-service/api/v1/router.py
+++ b/app/ai-service/api/v1/router.py
@@ -17,6 +17,7 @@ from api.v1 import (
     fraud,
     artifacts,
     uploads,
+    dead_letter,
 )
 
 v1_router = APIRouter(prefix="/v1")
@@ -29,3 +30,4 @@ v1_router.include_router(humanitarian.router)
 v1_router.include_router(fraud.router)
 v1_router.include_router(artifacts.router)
 v1_router.include_router(uploads.router)
+v1_router.include_router(dead_letter.router)

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -55,6 +55,11 @@ class Settings(BaseSettings):
     load_shed_memory_threshold_percent: float = 90.0
     load_shed_max_celery_queue_depth: int = 100
 
+    # Dead-letter replay settings
+    dead_letter_max_replay_attempts: int = 5
+    dead_letter_replay_cooldown_seconds: float = 10.0
+    dead_letter_replay_rate_limit: str = "10/minute"
+
     # Cache TTL settings (in seconds)
     cache_ttl_task_status: int = 30  # Short TTL for responsive polling
     cache_ttl_artifact_access: int = 60  # 1 minute for artifact metadata

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -18,6 +18,18 @@ REQUESTS_SHED_TOTAL = Counter(
 )
 CELERY_QUEUE_DEPTH = Gauge('celery_queue_depth', 'Pending tasks in the Celery default queue')
 
+# Dead-letter queue metrics
+DEAD_LETTER_ITEMS_TOTAL = Counter(
+    'dead_letter_items_total',
+    'Items added to the dead-letter queue',
+    ['kind'],
+)
+DEAD_LETTER_REPLAY_ATTEMPTS_TOTAL = Counter(
+    'dead_letter_replay_attempts_total',
+    'Dead-letter replay attempts',
+    ['kind', 'outcome'],
+)
+
 # AI Model metrics
 MODEL_LOAD_TIME = Histogram('model_load_time_seconds', 'Model load time in seconds', ['model_name'])
 INFERENCE_LATENCY = Histogram('inference_latency_seconds', 'Inference latency in seconds', ['task_type'])

--- a/app/ai-service/services/dead_letter.py
+++ b/app/ai-service/services/dead_letter.py
@@ -1,0 +1,237 @@
+"""
+Dead-letter queue for failed callback deliveries and exhausted async jobs.
+
+Operators need a safe way to recover from transient outages (a flaky backend
+webhook endpoint, a Redis blip, a downstream provider hiccup) without manual
+patching. This module tracks items that failed terminally - a webhook
+delivery that kept 4xx/5xx-ing, or a Celery task that exhausted its retry
+budget - and exposes replay controls with an audit trail and a rate limit so
+replay cannot be used to hammer a downstream system or loop forever.
+
+Storage is in-memory (module-level singleton), matching the pattern already
+used for Celery task status in ``tasks.task_results`` - acceptable because
+dead-letter items are an operational recovery aid, not a system of record.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, Dict, List, Literal, Optional
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+DeadLetterKind = Literal["callback", "async_job"]
+DeadLetterStatus = Literal["pending", "succeeded", "exhausted"]
+
+
+class DeadLetterError(Exception):
+    """Raised for invalid dead-letter operations."""
+
+
+@dataclass
+class ReplayAttempt:
+    """A single audited replay attempt."""
+
+    attempt: int
+    actor: str
+    outcome: Literal["succeeded", "failed"]
+    timestamp: float
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "attempt": self.attempt,
+            "actor": self.actor,
+            "outcome": self.outcome,
+            "timestamp": self.timestamp,
+            "error": self.error,
+        }
+
+
+@dataclass
+class DeadLetterEntry:
+    """A single dead-lettered item awaiting operator replay."""
+
+    id: str
+    kind: DeadLetterKind
+    task_id: str
+    payload: Dict[str, Any]
+    error: str
+    task_type: Optional[str] = None
+    status: DeadLetterStatus = "pending"
+    attempts: int = 0
+    max_attempts: int = 5
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    last_attempt_at: Optional[float] = None
+    audit_log: List[ReplayAttempt] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "task_id": self.task_id,
+            "task_type": self.task_type,
+            "payload": self.payload,
+            "error": self.error,
+            "status": self.status,
+            "attempts": self.attempts,
+            "max_attempts": self.max_attempts,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_attempt_at": self.last_attempt_at,
+            "audit_log": [a.to_dict() for a in self.audit_log],
+        }
+
+
+class DeadLetterQueue:
+    """Thread-safe in-memory dead-letter store with rate-limited replay."""
+
+    def __init__(self, max_attempts: int, cooldown_seconds: float):
+        self.max_attempts = max_attempts
+        self.cooldown_seconds = cooldown_seconds
+        self._entries: Dict[str, DeadLetterEntry] = {}
+        self._lock = Lock()
+
+    @staticmethod
+    def make_id(kind: DeadLetterKind, task_id: str) -> str:
+        """Deterministic ID so re-adding the same failed task updates it in place."""
+        return f"{kind}:{task_id}"
+
+    def add(
+        self,
+        kind: DeadLetterKind,
+        task_id: str,
+        payload: Dict[str, Any],
+        error: str,
+        task_type: Optional[str] = None,
+    ) -> DeadLetterEntry:
+        """Record a terminally-failed callback delivery or async job."""
+        entry_id = self.make_id(kind, task_id)
+        with self._lock:
+            existing = self._entries.get(entry_id)
+            now = time.time()
+            if existing is not None:
+                existing.error = error
+                existing.payload = payload
+                existing.task_type = task_type or existing.task_type
+                existing.status = "pending"
+                existing.updated_at = now
+                logger.warning(
+                    "dead_letter_item_updated",
+                    extra={"dead_letter_id": entry_id, "kind": kind, "task_id": task_id},
+                )
+                return existing
+
+            entry = DeadLetterEntry(
+                id=entry_id,
+                kind=kind,
+                task_id=task_id,
+                payload=payload,
+                error=error,
+                task_type=task_type,
+                max_attempts=self.max_attempts,
+            )
+            self._entries[entry_id] = entry
+            logger.warning(
+                "dead_letter_item_added",
+                extra={"dead_letter_id": entry_id, "kind": kind, "task_id": task_id},
+            )
+            return entry
+
+    def list(
+        self,
+        kind: Optional[DeadLetterKind] = None,
+        status: Optional[DeadLetterStatus] = None,
+    ) -> List[DeadLetterEntry]:
+        with self._lock:
+            items = list(self._entries.values())
+        if kind is not None:
+            items = [i for i in items if i.kind == kind]
+        if status is not None:
+            items = [i for i in items if i.status == status]
+        return sorted(items, key=lambda i: i.created_at, reverse=True)
+
+    def get(self, entry_id: str) -> Optional[DeadLetterEntry]:
+        with self._lock:
+            return self._entries.get(entry_id)
+
+    def check_replayable(self, entry_id: str) -> DeadLetterEntry:
+        """
+        Validate that an item may be replayed right now.
+
+        Raises DeadLetterError with a machine-readable code in one of:
+        ``not_found``, ``already_succeeded``, ``exhausted``, ``rate_limited``.
+        """
+        with self._lock:
+            entry = self._entries.get(entry_id)
+            if entry is None:
+                raise DeadLetterError("not_found")
+            if entry.status == "succeeded":
+                raise DeadLetterError("already_succeeded")
+            if entry.status == "exhausted":
+                raise DeadLetterError("exhausted")
+            if (
+                entry.last_attempt_at is not None
+                and (time.time() - entry.last_attempt_at) < self.cooldown_seconds
+            ):
+                raise DeadLetterError("rate_limited")
+            return entry
+
+    def record_attempt(
+        self, entry_id: str, actor: str, success: bool, error: Optional[str] = None
+    ) -> DeadLetterEntry:
+        """Append an audited replay attempt and update entry status."""
+        with self._lock:
+            entry = self._entries.get(entry_id)
+            if entry is None:
+                raise DeadLetterError("not_found")
+
+            now = time.time()
+            entry.attempts += 1
+            entry.last_attempt_at = now
+            entry.updated_at = now
+            entry.audit_log.append(
+                ReplayAttempt(
+                    attempt=entry.attempts,
+                    actor=actor,
+                    outcome="succeeded" if success else "failed",
+                    timestamp=now,
+                    error=None if success else error,
+                )
+            )
+
+            if success:
+                entry.status = "succeeded"
+            elif entry.attempts >= entry.max_attempts:
+                entry.status = "exhausted"
+            else:
+                entry.status = "pending"
+
+            logger.info(
+                "dead_letter_replay_recorded",
+                extra={
+                    "dead_letter_id": entry_id,
+                    "attempt": entry.attempts,
+                    "outcome": entry.status,
+                    "actor": actor,
+                },
+            )
+            return entry
+
+    def clear(self) -> None:
+        """Test helper - drop all entries."""
+        with self._lock:
+            self._entries.clear()
+
+
+dead_letter_queue = DeadLetterQueue(
+    max_attempts=settings.dead_letter_max_replay_attempts,
+    cooldown_seconds=settings.dead_letter_replay_cooldown_seconds,
+)

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -18,6 +18,7 @@ from services.load_shedder import ensure_queue_capacity
 from services.pii_scrubber import PIIScrubberService
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.ocr_job import run_ocr_from_base64
+from services.dead_letter import dead_letter_queue
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -92,12 +93,28 @@ def get_process_heavy_inference_task():
                 update_task_status(task_id, 'retrying', error=str(exc))
                 raise self.retry(exc=exc, countdown=retry_delay)
 
-            error_msg = str(exc)
-            update_task_status(task_id, 'failed', error=error_msg)
-            send_webhook_notification(task_id, 'failed', error=error_msg)
+            handle_task_retries_exhausted(task_id, payload, str(exc))
             raise
-    
+
     return process_heavy_inference_task
+
+
+def handle_task_retries_exhausted(task_id: str, payload: Dict[str, Any], error_msg: str) -> None:
+    """
+    Finalize a task that has exhausted its Celery retry budget: mark it
+    failed, notify the backend, and dead-letter it so an operator can
+    replay it later without waiting on another transient-failure window.
+    """
+    update_task_status(task_id, 'failed', error=error_msg)
+    send_webhook_notification(task_id, 'failed', error=error_msg)
+    dead_letter_queue.add(
+        kind="async_job",
+        task_id=task_id,
+        payload=payload,
+        error=error_msg,
+        task_type=payload.get('type') if isinstance(payload, dict) else None,
+    )
+    metrics.DEAD_LETTER_ITEMS_TOTAL.labels(kind="async_job").inc()
 
 # Task status storage (in production, use Redis with proper TTL)
 task_results: Dict[str, Dict[str, Any]] = {}
@@ -177,25 +194,87 @@ def send_webhook_notification(task_id: str, status: str, result: Any = None, err
 
         def send_notification() -> None:
             try:
-                with httpx.Client(timeout=10.0) as client:
-                    response = client.post(
-                        settings.backend_webhook_url,
-                        content=body_bytes,
-                        headers=headers,
-                    )
-                    if response.status_code >= 400:
-                        logger.error(
-                            f"Webhook notification failed: {response.status_code} - {response.text}"
-                        )
-                    else:
-                        logger.info(f"Webhook notification sent for task {task_id}")
+                deliver_webhook(body_bytes, headers)
+                logger.info(f"Webhook notification sent for task {task_id}")
             except Exception as exc:
                 logger.error(f"Failed to send webhook notification: {exc}")
+                dead_letter_queue.add(
+                    kind="callback",
+                    task_id=task_id,
+                    payload={"status": status, "result": result, "error": error},
+                    error=str(exc),
+                )
+                metrics.DEAD_LETTER_ITEMS_TOTAL.labels(kind="callback").inc()
 
         thread = threading.Thread(target=send_notification, daemon=True)
         thread.start()
     except Exception as exc:
         logger.error(f"Error setting up webhook notification thread: {exc}")
+
+
+def deliver_webhook(body_bytes: bytes, headers: Dict[str, str]) -> None:
+    """
+    Synchronously POST a webhook body to the configured backend URL.
+
+    Raises on any non-2xx response or connection failure. Shared by the
+    fire-and-forget notification path and dead-letter replay so both
+    paths agree on what counts as a delivery failure.
+    """
+    with httpx.Client(timeout=10.0) as client:
+        response = client.post(
+            settings.backend_webhook_url,
+            content=body_bytes,
+            headers=headers,
+        )
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Webhook delivery failed: {response.status_code} - {response.text}"
+            )
+
+
+def replay_callback_delivery(task_id: str, payload: Dict[str, Any]) -> None:
+    """
+    Rebuild and resend a dead-lettered callback payload.
+
+    Args:
+        task_id: The AI task the callback belongs to.
+        payload: The dead-letter entry's stored payload, containing the
+            original ``status``, ``result``, and ``error`` fields.
+
+    Raises:
+        RuntimeError: If the webhook URL is not configured or delivery fails.
+    """
+    if not settings.backend_webhook_url:
+        raise RuntimeError("Backend webhook URL not configured, cannot replay callback")
+
+    callback_payload = AiCallbackPayload.build(
+        task_id=task_id,
+        status=CallbackStatus(payload.get("status")),
+        result=payload.get("result"),
+        error=payload.get("error"),
+    )
+
+    body_bytes = callback_payload.to_json_bytes()
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if settings.webhook_secret:
+        headers["x-webhook-signature"] = callback_payload.sign(settings.webhook_secret)
+
+    deliver_webhook(body_bytes, headers)
+
+
+def replay_async_job(task_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Re-run a dead-lettered async job synchronously.
+
+    Reuses the same processing implementation the Celery worker calls, so a
+    successful replay leaves the task in the same terminal 'completed' state
+    (and fires the same completion webhook) as if it had succeeded on the
+    original attempt.
+
+    Raises:
+        Exception: Whatever the underlying task processing raised.
+    """
+    return process_heavy_inference_impl(None, task_id, payload)
 
 
 def process_heavy_inference_impl(self, task_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/ai-service/tests/test_dead_letter.py
+++ b/app/ai-service/tests/test_dead_letter.py
@@ -1,0 +1,303 @@
+"""
+Tests for dead-letter capture and replay (Issue #776).
+
+Coverage
+--------
+* DeadLetterQueue service: add/list/get, dedupe, replay-eligibility checks,
+  audit trail, exhaustion, and per-item cooldown rate limiting.
+* tasks.py integration: a failed webhook callback and a Celery task that
+  exhausts its retry budget both land in the dead-letter queue.
+* API: list/get/replay endpoints, including role authorization, replay
+  success, replay exhaustion, and cooldown rate limiting (429).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import metrics
+import tasks
+import threading
+from config import settings
+from services.dead_letter import DeadLetterError, DeadLetterQueue, dead_letter_queue
+
+
+@pytest.fixture(autouse=True)
+def mock_healthy_resources():
+    with patch.object(metrics, "check_system_resources", return_value=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def clear_dead_letter_queue():
+    dead_letter_queue.clear()
+    yield
+    dead_letter_queue.clear()
+
+
+@pytest.fixture()
+def client():
+    import main
+
+    return TestClient(main.app, follow_redirects=False)
+
+
+def _run_thread_synchronously(monkeypatch):
+    """Make ``threading.Thread(...).start()`` run its target inline."""
+
+    class _SyncThread:
+        def __init__(self, target=None, daemon=None, **kwargs):
+            self._target = target
+
+        def start(self):
+            if self._target:
+                self._target()
+
+    monkeypatch.setattr(threading, "Thread", _SyncThread)
+
+
+# ---------------------------------------------------------------------------
+# DeadLetterQueue service
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterQueueService:
+    def test_add_and_get(self):
+        queue = DeadLetterQueue(max_attempts=3, cooldown_seconds=0)
+        entry = queue.add(kind="callback", task_id="t-1", payload={"status": "failed"}, error="boom")
+
+        assert entry.id == "callback:t-1"
+        assert entry.status == "pending"
+        assert entry.attempts == 0
+        assert queue.get(entry.id) is entry
+
+    def test_add_is_idempotent_per_task_and_kind(self):
+        queue = DeadLetterQueue(max_attempts=3, cooldown_seconds=0)
+        queue.add(kind="async_job", task_id="t-1", payload={"a": 1}, error="first failure")
+        second = queue.add(kind="async_job", task_id="t-1", payload={"a": 2}, error="second failure")
+
+        assert len(queue.list()) == 1
+        assert second.error == "second failure"
+        assert second.payload == {"a": 2}
+
+    def test_list_filters_by_kind_and_status(self):
+        queue = DeadLetterQueue(max_attempts=3, cooldown_seconds=0)
+        queue.add(kind="callback", task_id="c-1", payload={}, error="e")
+        queue.add(kind="async_job", task_id="j-1", payload={}, error="e")
+
+        assert len(queue.list(kind="callback")) == 1
+        assert len(queue.list(kind="async_job")) == 1
+        assert len(queue.list(status="pending")) == 2
+        assert len(queue.list(status="succeeded")) == 0
+
+    def test_check_replayable_raises_not_found(self):
+        queue = DeadLetterQueue(max_attempts=3, cooldown_seconds=0)
+        with pytest.raises(DeadLetterError) as exc:
+            queue.check_replayable("missing")
+        assert str(exc.value) == "not_found"
+
+    def test_replay_success_marks_succeeded(self):
+        queue = DeadLetterQueue(max_attempts=3, cooldown_seconds=0)
+        entry = queue.add(kind="callback", task_id="t-1", payload={}, error="boom")
+
+        queue.check_replayable(entry.id)
+        updated = queue.record_attempt(entry.id, actor="operator-1", success=True)
+
+        assert updated.status == "succeeded"
+        assert updated.attempts == 1
+        assert updated.audit_log[0].actor == "operator-1"
+        assert updated.audit_log[0].outcome == "succeeded"
+
+        # Already-succeeded items can't be replayed again.
+        with pytest.raises(DeadLetterError) as exc:
+            queue.check_replayable(entry.id)
+        assert str(exc.value) == "already_succeeded"
+
+    def test_replay_exhaustion_after_max_attempts(self):
+        queue = DeadLetterQueue(max_attempts=2, cooldown_seconds=0)
+        entry = queue.add(kind="callback", task_id="t-1", payload={}, error="boom")
+
+        queue.check_replayable(entry.id)
+        queue.record_attempt(entry.id, actor="op", success=False, error="still failing")
+        assert queue.get(entry.id).status == "pending"
+
+        queue.check_replayable(entry.id)
+        updated = queue.record_attempt(entry.id, actor="op", success=False, error="still failing")
+        assert updated.status == "exhausted"
+        assert updated.attempts == 2
+
+        with pytest.raises(DeadLetterError) as exc:
+            queue.check_replayable(entry.id)
+        assert str(exc.value) == "exhausted"
+
+    def test_cooldown_rate_limits_rapid_replays(self):
+        queue = DeadLetterQueue(max_attempts=5, cooldown_seconds=60)
+        entry = queue.add(kind="callback", task_id="t-1", payload={}, error="boom")
+
+        queue.check_replayable(entry.id)
+        queue.record_attempt(entry.id, actor="op", success=False, error="still failing")
+
+        with pytest.raises(DeadLetterError) as exc:
+            queue.check_replayable(entry.id)
+        assert str(exc.value) == "rate_limited"
+
+
+# ---------------------------------------------------------------------------
+# tasks.py integration - capture on failure
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterCapture:
+    def test_webhook_delivery_failure_is_dead_lettered(self, monkeypatch):
+        _run_thread_synchronously(monkeypatch)
+        monkeypatch.setattr(settings, "backend_webhook_url", "http://backend.test/webhook")
+
+        mock_response = MagicMock(status_code=500, text="upstream error")
+        with patch("httpx.Client.post", return_value=mock_response):
+            tasks.send_webhook_notification("task-webhook-1", "completed", result={"ok": True})
+
+        entry = dead_letter_queue.get("callback:task-webhook-1")
+        assert entry is not None
+        assert entry.kind == "callback"
+        assert entry.status == "pending"
+        assert entry.payload["status"] == "completed"
+        assert entry.payload["result"] == {"ok": True}
+
+    def test_successful_webhook_delivery_is_not_dead_lettered(self, monkeypatch):
+        _run_thread_synchronously(monkeypatch)
+        monkeypatch.setattr(settings, "backend_webhook_url", "http://backend.test/webhook")
+
+        mock_response = MagicMock(status_code=200, text="ok")
+        with patch("httpx.Client.post", return_value=mock_response):
+            tasks.send_webhook_notification("task-webhook-2", "completed", result={"ok": True})
+
+        assert dead_letter_queue.get("callback:task-webhook-2") is None
+
+    def test_task_retry_exhaustion_is_dead_lettered(self, monkeypatch):
+        monkeypatch.setattr(settings, "backend_webhook_url", None)  # keep this test focused on the DLQ
+        payload = {"type": "model_inference", "data": {}}
+
+        tasks.handle_task_retries_exhausted("task-async-1", payload, "provider unreachable")
+
+        entry = dead_letter_queue.get("async_job:task-async-1")
+        assert entry is not None
+        assert entry.kind == "async_job"
+        assert entry.task_type == "model_inference"
+        assert entry.error == "provider unreachable"
+        assert entry.payload == payload
+
+        status = tasks.get_task_status("task-async-1")
+        assert status["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestDeadLetterAPI:
+    def _seed_callback_entry(self, task_id="task-api-1"):
+        return dead_letter_queue.add(
+            kind="callback",
+            task_id=task_id,
+            payload={"status": "completed", "result": {"ok": True}, "error": None},
+            error="connection refused",
+        )
+
+    def test_list_requires_authorized_role(self, client):
+        response = client.get("/v1/ai/dead-letter")
+        assert response.status_code == 403
+
+    def test_list_returns_items_for_authorized_role(self, client):
+        self._seed_callback_entry()
+
+        response = client.get("/v1/ai/dead-letter", headers={"X-User-Role": "operator"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["items"][0]["kind"] == "callback"
+
+    def test_get_missing_item_returns_404(self, client):
+        response = client.get(
+            "/v1/ai/dead-letter/callback:does-not-exist",
+            headers={"X-User-Role": "admin"},
+        )
+        assert response.status_code == 404
+
+    def test_replay_requires_authorized_role(self, client):
+        entry = self._seed_callback_entry()
+
+        response = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "reviewer"},
+        )
+
+        assert response.status_code == 403
+
+    def test_replay_success_updates_item_and_audit_log(self, client, monkeypatch):
+        entry = self._seed_callback_entry()
+        monkeypatch.setattr(tasks, "replay_callback_delivery", lambda task_id, payload: None)
+
+        response = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "operator", "X-User-Id": "op-42"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["item"]["status"] == "succeeded"
+        assert data["item"]["audit_log"][0]["actor"] == "op-42"
+        assert data["item"]["audit_log"][0]["outcome"] == "succeeded"
+
+    def test_replay_exhaustion_returns_409_after_max_attempts(self, client, monkeypatch):
+        monkeypatch.setattr(dead_letter_queue, "max_attempts", 1)
+        monkeypatch.setattr(dead_letter_queue, "cooldown_seconds", 0)
+
+        entry = self._seed_callback_entry()
+
+        def always_fails(task_id, payload):
+            raise RuntimeError("still down")
+
+        monkeypatch.setattr(tasks, "replay_callback_delivery", always_fails)
+
+        first = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "operator", "X-User-Id": "op-1"},
+        )
+        assert first.status_code == 200
+        assert first.json()["item"]["status"] == "exhausted"
+
+        second = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "operator", "X-User-Id": "op-1"},
+        )
+        assert second.status_code == 409
+        assert second.json()["error"]["code"] == "exhausted"
+
+    def test_replay_cooldown_returns_429(self, client, monkeypatch):
+        monkeypatch.setattr(dead_letter_queue, "max_attempts", 5)
+        monkeypatch.setattr(dead_letter_queue, "cooldown_seconds", 60)
+
+        entry = self._seed_callback_entry()
+
+        def always_fails(task_id, payload):
+            raise RuntimeError("still down")
+
+        monkeypatch.setattr(tasks, "replay_callback_delivery", always_fails)
+
+        first = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "operator", "X-User-Id": "op-1"},
+        )
+        assert first.status_code == 200
+
+        second = client.post(
+            f"/v1/ai/dead-letter/{entry.id}/replay",
+            headers={"X-User-Role": "operator", "X-User-Id": "op-1"},
+        )
+        assert second.status_code == 429
+        assert second.json()["error"]["code"] == "rate_limited"
+        assert "Retry-After" in second.headers


### PR DESCRIPTION
## Summary

Closes #776.

Failed webhook callback deliveries (the AI service POSTing task results back
to the backend) and async jobs that exhaust their Celery retry budget were
previously just logged and dropped. This adds a dead-letter queue with
operator-triggered replay controls so these can be recovered from transient
outages without manual patching.

- **`services/dead_letter.py`** - thread-safe in-memory `DeadLetterQueue`:
  add/list/get, per-item replay cooldown, max-attempt exhaustion, and a full
  audit log per entry (actor, outcome, error, timestamp).
- **`tasks.py`** - wired capture into both failure points: a webhook
  callback that keeps 4xx/5xx-ing, and a Celery task that exhausts
  `task_max_retries`. Extracted a shared synchronous `deliver_webhook`
  helper plus `replay_callback_delivery` / `replay_async_job` so replay
  reuses the exact same delivery/processing logic as the original attempt.
- **`api/v1/dead_letter.py`** - new endpoints:
  - `GET /v1/ai/dead-letter` - list items, filterable by `kind`/`status`
  - `GET /v1/ai/dead-letter/{id}` - item detail with full audit log
  - `POST /v1/ai/dead-letter/{id}/replay` - replay a single item, gated to
    `admin`/`operator` roles (`X-User-Role` header, matching the existing
    artifact-access convention), rate-limited via a per-item cooldown plus
    a `slowapi` request rate limit, returns 404/409/429 as appropriate.
- Metrics (`dead_letter_items_total`, `dead_letter_replay_attempts_total`)
  and config knobs (`dead_letter_max_replay_attempts`,
  `dead_letter_replay_cooldown_seconds`, `dead_letter_replay_rate_limit`).
- Documented the new endpoints in `app/ai-service/README.md`.

## Test plan

- [x] `tests/test_dead_letter.py` (17 new tests): service-layer add/list/get
      + dedupe, replay success/exhaustion/cooldown state transitions,
      capture-on-webhook-failure and capture-on-retry-exhaustion
      integration, and API-level role auth / 404 / 409 / 429 behavior.
- [x] Full `pytest` suite run locally - no regressions in any test that
      touches callbacks, tasks, or webhooks.
- [x] `flake8 --select=E9,F63,F7,F82` clean on all changed/new files.

🌊 Stellar Wave application: db5b62b6-0439-4946-9f6b-6b66e27617f6