### PR TITLE
feat(mobile): add offline queue manual retry for failed and retrying …

### DIFF
--- a/app/mobile/src/__tests__/claimSubmissionQueue.test.tsx
+++ b/app/mobile/src/__tests__/claimSubmissionQueue.test.tsx
@@ -251,7 +251,35 @@ describe('syncQueue – retryFailedAction', () => {
     expect(stateAfter.items[0].lastError).toBeNull();
   });
 
-  it('does not change a non-failed item', async () => {
+  it('resets a retrying item back to pending', async () => {
+    const retryingItem = {
+      id: 'test-id-3',
+      type: 'claim-submission',
+      payload: { aidId: 'aid-4', claimId: 'claim-4', idempotencyKey: 'idem-retry-retrying' },
+      state: 'retrying',
+      retryCount: 2,
+      maxRetries: 5,
+      nextRetryAt: new Date(Date.now() + 100000).toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastError: 'network timeout',
+    };
+    await seedStorage([retryingItem]);
+
+    const { getSyncQueueState, retryFailedAction } = loadFreshQueue();
+
+    const stateBefore = await getSyncQueueState();
+    expect(stateBefore.items[0].state).toBe('retrying');
+
+    await retryFailedAction(stateBefore.items[0].id);
+
+    const stateAfter = await getSyncQueueState();
+    expect(stateAfter.items[0].state).toBe('pending');
+    expect(stateAfter.items[0].retryCount).toBe(0);
+    expect(stateAfter.items[0].lastError).toBeNull();
+  });
+
+  it('does not change a non-failed/non-retrying item', async () => {
     const pendingItem = {
       id: 'test-id-2',
       type: 'claim-submission',
@@ -344,13 +372,16 @@ describe('SubmissionStatusBadge', () => {
     expect(getByText('Failed')).toBeTruthy();
   });
 
-  it('shows retry button only in failed state', () => {
+  it('shows retry button in failed and retrying states', () => {
     const onRetry = jest.fn();
-    const { getByTestId } = render(<SubmissionStatusBadge state="failed" onRetry={onRetry} />);
-    expect(getByTestId('badge-retry-button')).toBeTruthy();
+    const { getByTestId: getByTestIdFailed } = render(<SubmissionStatusBadge state="failed" onRetry={onRetry} />);
+    expect(getByTestIdFailed('badge-retry-button')).toBeTruthy();
+
+    const { getByTestId: getByTestIdRetrying } = render(<SubmissionStatusBadge state="retrying" onRetry={onRetry} />);
+    expect(getByTestIdRetrying('badge-retry-button')).toBeTruthy();
   });
 
-  it('does not show retry button in non-failed states', () => {
+  it('does not show retry button in non-retryable states', () => {
     const onRetry = jest.fn();
     const { queryByTestId } = render(<SubmissionStatusBadge state="pending" onRetry={onRetry} />);
     expect(queryByTestId('badge-retry-button')).toBeNull();
@@ -366,6 +397,9 @@ describe('SubmissionStatusBadge', () => {
   it('does not show retry button when onRetry is not provided', () => {
     const { queryByTestId } = render(<SubmissionStatusBadge state="failed" />);
     expect(queryByTestId('badge-retry-button')).toBeNull();
+
+    const { queryByTestId: queryByTestIdRetrying } = render(<SubmissionStatusBadge state="retrying" />);
+    expect(queryByTestIdRetrying('badge-retry-button')).toBeNull();
   });
 });
 

--- a/app/mobile/src/components/SubmissionStatusBadge.tsx
+++ b/app/mobile/src/components/SubmissionStatusBadge.tsx
@@ -30,7 +30,7 @@ export const SubmissionStatusBadge: React.FC<Props> = ({ state, onRetry }) => {
         <MaterialCommunityIcons name={icon as any} size={14} color={fg} />
       )}
       <Text style={[styles.label, { color: fg }]}>{label}</Text>
-      {state === 'failed' && onRetry && (
+      {(state === 'failed' || state === 'retrying') && onRetry && (
         <TouchableOpacity
           onPress={onRetry}
           accessibilityRole="button"

--- a/app/mobile/src/screens/SubmissionQueueScreen.tsx
+++ b/app/mobile/src/screens/SubmissionQueueScreen.tsx
@@ -66,7 +66,7 @@ export const SubmissionQueueScreen: React.FC<Props> = () => {
 
   const renderItem = ({ item }: { item: QueuedSyncAction }) => {
     const actionLabel = ACTION_LABELS[item.type] ?? item.type;
-    const canRetry = item.state === 'failed';
+    const canRetry = item.state === 'failed' || item.state === 'retrying';
 
     return (
       <View style={styles.card}>

--- a/app/mobile/src/services/syncQueue.ts
+++ b/app/mobile/src/services/syncQueue.ts
@@ -638,7 +638,7 @@ export const retryFailedAction = async (actionId: string) => {
   await hydrateQueue();
   const now = new Date().toISOString();
   const items = queueState.items.map((item) =>
-    item.id === actionId && item.state === 'failed'
+    item.id === actionId && (item.state === 'failed' || item.state === 'retrying')
       ? { ...item, state: 'pending' as SyncActionState, retryCount: 0, nextRetryAt: now, lastError: null, updatedAt: now }
       : item,
   );


### PR DESCRIPTION
Closes #747 
This PR resolves the issue where field operators were unable to manually retry queued offline submissions that were in the intermediate retrying state (e.g. during a network backoff delay), forcing them to wait for the automatic backoff timer to expire.

We have expanded the manual retry controls to be available for both 'failed' and 'retrying' queue items, allowing operators to force an immediate retry of any eligible, non-submitted sync action.

Key Changes
Sync Queue Service (
syncQueue.ts
):

Modified retryFailedAction to target items in either 'failed' or 'retrying' states. When triggered, the item's state resets to 'pending', retryCount is set to 0, lastError is cleared, and nextRetryAt is set to now to force immediate processing upon the next flush.
Submission Queue Screen (
SubmissionQueueScreen.tsx
):

Updated canRetry to evaluate to true for items in either 'failed' or 'retrying' states.
Submission Status Badge (
SubmissionStatusBadge.tsx
):

Enabled rendering of the retry button (refresh icon) inside the badge when the status is either 'failed' or 'retrying'.
Unit Tests (
claimSubmissionQueue.test.tsx
):

Added a new unit test to verify that retryFailedAction correctly resets a 'retrying' item back to 'pending'.
Updated badge tests to assert that the retry button is visible in both 'failed' and 'retrying' states, and not shown when onRetry is absent or the status is 'pending'.
Verification Done
Ran npm run test -- src/__tests__/claimSubmissionQueue.test.tsx (Passed 19/19 tests).
Ran npm run test -- src/__tests__/evidenceUploadResumable.test.ts (Passed 6/6 tests).