### PR TITLE
feat(ai-service): introduce LLM provider abstraction for swappable mo…

### DIFF
--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -6,13 +6,10 @@ from typing import Any, Dict, List, Optional
 import time
 import metrics
 
-import httpx
-
 from config import settings
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
-from services.test_provider import TestProvider
-from exceptions import AIServiceError
+from services.providers import LLMProvider, get_llm_providers
 
 logger = logging.getLogger(__name__)
 
@@ -20,21 +17,17 @@ logger = logging.getLogger(__name__)
 class HumanitarianVerificationService:
     """Runs humanitarian verification against configured LLM providers."""
 
-    def __init__(self):
+    def __init__(self, providers: Optional[List[LLMProvider]] = None):
         self.prompt_engine = HumanitarianPromptEngine()
-        self.test_provider = TestProvider()
-        self.breakers = {
-            "openai": CircuitBreaker(
-                name="openai",
-                failure_threshold=settings.circuit_breaker_failure_threshold,
-                recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
-            ),
-            "groq": CircuitBreaker(
-                name="groq",
-                failure_threshold=settings.circuit_breaker_failure_threshold,
-                recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
-            ),
-        }
+        self.providers = providers or get_llm_providers()
+        self.breakers: Dict[str, CircuitBreaker] = {}
+        for p in self.providers:
+            if p.name not in self.breakers:
+                self.breakers[p.name] = CircuitBreaker(
+                    name=p.name,
+                    failure_threshold=settings.circuit_breaker_failure_threshold,
+                    recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
+                )
 
     def verify_claim(
         self,
@@ -60,30 +53,29 @@ class HumanitarianVerificationService:
                 context_factors=context,
             )
 
-            providers = self._provider_attempt_order(provider_preference)
-            if not providers:
+            ordered = self._provider_attempt_order(provider_preference)
+            if not ordered:
                 raise RuntimeError("No LLM providers configured for humanitarian verification")
 
             errors: List[str] = []
 
-            for provider in providers:
-                breaker = self.breakers.get(provider)
+            for provider in ordered:
+                breaker = self.breakers.get(provider.name)
                 if breaker and not breaker.allow_request():
-                    logger.warning("Circuit breaker is OPEN for provider=%s. Skipping.", provider)
-                    errors.append(f"provider={provider}, error=Circuit breaker is OPEN")
+                    logger.warning("Circuit breaker is OPEN for provider=%s. Skipping.", provider.name)
+                    errors.append(f"provider={provider.name}, error=Circuit breaker is OPEN")
                     continue
 
-                model = self._get_model_for_provider(provider)
+                model = self._get_model_for_provider(provider.name)
                 for prompt_variant, prompt in (("primary", primary_prompt), ("fallback", fallback_prompt)):
                     try:
                         logger.info(
                             "Attempting humanitarian verification with provider=%s model=%s prompt=%s",
-                            provider,
+                            provider.name,
                             model,
                             prompt_variant,
                         )
-                        raw_content = self._call_provider(
-                            provider=provider,
+                        raw_content = provider.call(
                             model=model,
                             system_prompt=prompt["system"],
                             user_prompt=prompt["user"],
@@ -93,7 +85,7 @@ class HumanitarianVerificationService:
                         if breaker:
                             breaker.record_success()
                         return {
-                            "provider": provider,
+                            "provider": provider.name,
                             "model": model,
                             "prompt_variant": prompt_variant,
                             "verification": parsed,
@@ -102,7 +94,7 @@ class HumanitarianVerificationService:
                     except Exception as exc:
                         if breaker:
                             breaker.record_failure()
-                        err = f"provider={provider}, model={model}, prompt={prompt_variant}, error={exc}"
+                        err = f"provider={provider.name}, model={model}, prompt={prompt_variant}, error={exc}"
                         errors.append(err)
                         logger.warning("Humanitarian verification attempt failed: %s", err)
 
@@ -111,184 +103,36 @@ class HumanitarianVerificationService:
             latency = time.time() - start_time
             metrics.PIPELINE_STEP_LATENCY.labels(step_name='verify').observe(latency)
 
-    def _provider_attempt_order(self, provider_preference: str) -> List[str]:
-        available: List[str] = []
-        if settings.test_provider_mode:
-            available.append("test")
-        if settings.openai_api_key:
-            available.append("openai")
-        if settings.groq_api_key:
-            available.append("groq")
-
+    def _provider_attempt_order(self, provider_preference: str) -> List[LLMProvider]:
+        """Return providers ordered so the preferred one (if available) is first."""
         preference = (provider_preference or "auto").lower()
-        if preference == "test" and settings.test_provider_mode:
-            return [preference]
-        if preference in ("openai", "groq", "test") and preference in available:
-            return [preference] + [provider for provider in available if provider != preference]
-        return available
+        if preference == "auto" or not self.providers:
+            return list(self.providers)
+
+        ordered: List[LLMProvider] = []
+        rest: List[LLMProvider] = []
+        for p in self.providers:
+            if p.name == preference:
+                ordered.append(p)
+            else:
+                rest.append(p)
+        return ordered + rest
 
     def all_providers_unavailable(self) -> bool:
         """Return True when every configured LLM provider circuit is open."""
-        if settings.test_provider_mode:
-            return False
+        for p in self.providers:
+            if p.name not in self.breakers or self.breakers[p.name].allow_request():
+                return False
+        return len(self.providers) > 0
 
-        providers = []
-        if settings.openai_api_key:
-            providers.append("openai")
-        if settings.groq_api_key:
-            providers.append("groq")
-        if not providers:
-            return False
-
-        return all(
-            provider in self.breakers and not self.breakers[provider].allow_request()
-            for provider in providers
-        )
-
-    def _get_model_for_provider(self, provider: str) -> str:
-        if provider == "test":
+    def _get_model_for_provider(self, provider_name: str) -> str:
+        if provider_name == "test":
             return "test-provider/fixture"
-        if provider == "openai":
+        if provider_name == "openai":
             return settings.openai_model
-        if provider == "groq":
+        if provider_name == "groq":
             return settings.groq_model
-        raise ValueError(f"Unsupported provider: {provider}")
-
-    def _call_provider(
-        self,
-        provider: str,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
-        timeout: Optional[float] = None,
-    ) -> str:
-        if provider == "test":
-            return self._call_test(model, system_prompt, user_prompt)
-        if provider == "openai":
-            return self._call_openai(model, system_prompt, user_prompt, timeout)
-        if provider == "groq":
-            return self._call_groq(model, system_prompt, user_prompt, timeout)
-        raise ValueError(f"Unsupported provider: {provider}")
-
-    def _call_openai(
-        self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
-        timeout: Optional[float] = None,
-    ) -> str:
-        if not settings.openai_api_key:
-            raise RuntimeError("OpenAI API key is not configured")
-        return self._call_chat_completion_api(
-            base_url="https://api.openai.com/v1/chat/completions",
-            api_key=settings.openai_api_key,
-            model=model,
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            timeout=timeout,
-        )
-
-    def _call_groq(
-        self,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
-        timeout: Optional[float] = None,
-    ) -> str:
-        if not settings.groq_api_key:
-            raise RuntimeError("Groq API key is not configured")
-        return self._call_chat_completion_api(
-            base_url="https://api.groq.com/openai/v1/chat/completions",
-            api_key=settings.groq_api_key,
-            model=model,
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            timeout=timeout,
-        )
-
-    def _call_chat_completion_api(
-        self,
-        base_url: str,
-        api_key: str,
-        model: str,
-        system_prompt: str,
-        user_prompt: str,
-        timeout: Optional[float] = None,
-    ) -> str:
-        if settings.ai_deterministic_mode:
-            logger.info("Deterministic AI mode enabled: returning stable response")
-            return self._get_deterministic_response(model, system_prompt, user_prompt)
-
-        payload = {
-            "model": model,
-            "temperature": 0.1,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-        }
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
-
-        req_timeout = timeout if timeout is not None else float(settings.llm_timeout_seconds)
-        provider_name = "openai" if "openai" in base_url else "groq"
-
-        try:
-            with httpx.Client(timeout=req_timeout) as client:
-                response = client.post(base_url, json=payload, headers=headers)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.TimeoutException as exc:
-            logger.error("LLM provider %s request timed out after %s seconds", provider_name, req_timeout)
-            raise AIServiceError(
-                message=f"LLM request timed out after {req_timeout}s",
-                code="AI_TIMEOUT",
-                details={"provider": provider_name, "timeout_seconds": req_timeout},
-            ) from exc
-        except httpx.HTTPStatusError as exc:
-            logger.error("LLM provider %s returned status %s: %s", provider_name, exc.response.status_code, exc.response.text)
-            raise AIServiceError(
-                message=f"LLM request failed with status {exc.response.status_code}",
-                code="AI_PROVIDER_ERROR",
-                details={"provider": provider_name, "status_code": exc.response.status_code},
-            ) from exc
-        except Exception as exc:
-            logger.error("LLM provider %s connection or unexpected error: %s", provider_name, str(exc))
-            raise AIServiceError(
-                message=f"LLM connection error: {str(exc)}",
-                code="AI_CONNECTION_ERROR",
-                details={"provider": provider_name},
-            ) from exc
-
-        try:
-            content = data["choices"][0]["message"]["content"]
-        except (KeyError, IndexError, TypeError) as exc:
-            raise RuntimeError(f"Unexpected LLM response format: {data}") from exc
-
-        if not content:
-            raise RuntimeError("LLM returned empty content")
-
-        return str(content)
-
-    def _call_test(self, model: str, system_prompt: str, user_prompt: str) -> str:
-        response = self.test_provider.get_response(
-            endpoint="humanitarian",
-            request_data={
-                "system_prompt": system_prompt,
-                "user_prompt": user_prompt,
-            },
-        )
-        return json.dumps(response, separators=(",", ":"), sort_keys=True)
-
-    def _get_deterministic_response(self, model: str, system_prompt: str, user_prompt: str) -> str:
-        stable_response = {
-            "verdict": "credible",
-            "confidence": 0.74,
-            "summary": "Deterministic verification output for testing",
-        }
-        return json.dumps(stable_response, separators=(",", ":"), sort_keys=True)
+        raise ValueError(f"Unsupported provider: {provider_name}")
 
     def _parse_json_response(self, content: str) -> Dict[str, Any]:
         normalized = content.strip()

--- a/app/ai-service/services/providers/__init__.py
+++ b/app/ai-service/services/providers/__init__.py
@@ -1,0 +1,69 @@
+"""
+Provider factory — assembles available LLM providers based on active configuration.
+
+Usage::
+
+    from services.providers import get_llm_providers
+    providers = get_llm_providers(provider_preference="auto")
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from config import settings
+from services.providers.base import LLMProvider
+from services.providers.openai_provider import OpenAIProvider
+from services.providers.groq_provider import GroqProvider
+from services.providers.test_llm_provider import TestLLMProvider
+
+
+def get_llm_providers(provider_preference: str = "auto") -> List[LLMProvider]:
+    """Return available LLM providers ordered by preference.
+
+    When ``provider_preference`` is ``"auto"`` (the default) the list
+    respects the natural priority: test > openai > groq.  Passing an
+    explicit provider name moves that provider to the front of the list
+    (if available).
+
+    Providers that lack their required API key are **excluded** from the
+    returned list, so callers can safely iterate without checking keys
+    themselves.
+    """
+    available: List[LLMProvider] = []
+
+    # Test provider — always eligible when test_provider_mode is on
+    if settings.test_provider_mode:
+        available.append(TestLLMProvider())
+
+    # OpenAI
+    if settings.openai_api_key:
+        available.append(OpenAIProvider())
+
+    # Groq
+    if settings.groq_api_key:
+        available.append(GroqProvider())
+
+    pref = (provider_preference or "auto").lower()
+
+    if pref == "auto":
+        return available
+
+    # Promote the requested provider to the front
+    ordered: List[LLMProvider] = []
+    for p in available:
+        if p.name == pref:
+            ordered.insert(0, p)
+        else:
+            ordered.append(p)
+
+    return ordered
+
+
+__all__ = [
+    "LLMProvider",
+    "OpenAIProvider",
+    "GroqProvider",
+    "TestLLMProvider",
+    "get_llm_providers",
+]

--- a/app/ai-service/services/providers/base.py
+++ b/app/ai-service/services/providers/base.py
@@ -1,0 +1,191 @@
+"""
+Abstract base class for LLM providers.
+
+Defines the contract that all LLM providers must implement:
+- ``name``: unique provider identifier (e.g. "openai", "groq")
+- ``call(model, system_prompt, user_prompt, timeout) -> str``: invoke the model
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import httpx
+
+from config import settings
+from exceptions import AIServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class LLMProvider(ABC):
+    """Abstract contract for an LLM provider.
+
+    Subclasses need only supply a ``name``, ``_base_url``, and ``_api_key``
+    (or implement ``call`` directly for non-HTTP providers).
+    """
+
+    # ------------------------------------------------------------------
+    # Subclass contract
+    # ------------------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique short identifier, e.g. ``"openai"``, ``"groq"``."""
+
+    @property
+    @abstractmethod
+    def _base_url(self) -> str:
+        """Chat-completions endpoint URL."""
+
+    @property
+    @abstractmethod
+    def _api_key(self) -> Optional[str]:
+        """API key for authentication, or ``None`` if not available."""
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def call(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Invoke the provider and return the raw text response.
+
+        The default implementation uses an OpenAI-compatible chat-completions
+        API.  Providers with a different protocol should override this method.
+        """
+        api_key = self._api_key
+        if not api_key:
+            raise RuntimeError(f"{self.name} API key is not configured")
+
+        return self._call_chat_completion_api(
+            base_url=self._base_url,
+            api_key=api_key,
+            provider_name=self.name,
+            model=model,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Shared helpers for OpenAI-compatible providers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _call_chat_completion_api(
+        *,
+        base_url: str,
+        api_key: str,
+        provider_name: str,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Make an OpenAI-compatible chat-completions request.
+
+        Centralises HTTP boilerplate, deterministic-mode short-circuit,
+        timeout handling, and error wrapping so concrete providers stay
+        focused on configuration.
+        """
+        if settings.ai_deterministic_mode:
+            logger.info(
+                "Deterministic AI mode enabled: returning stable response for %s",
+                provider_name,
+            )
+            return LLMProvider._get_deterministic_response()
+
+        payload = {
+            "model": model,
+            "temperature": 0.1,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        req_timeout = (
+            timeout if timeout is not None else float(settings.llm_timeout_seconds)
+        )
+
+        try:
+            with httpx.Client(timeout=req_timeout) as client:
+                response = client.post(base_url, json=payload, headers=headers)
+                response.raise_for_status()
+                data = response.json()
+        except httpx.TimeoutException as exc:
+            logger.error(
+                "LLM provider %s request timed out after %s seconds",
+                provider_name,
+                req_timeout,
+            )
+            raise AIServiceError(
+                message=f"LLM request timed out after {req_timeout}s",
+                code="AI_TIMEOUT",
+                details={
+                    "provider": provider_name,
+                    "timeout_seconds": req_timeout,
+                },
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            logger.error(
+                "LLM provider %s returned status %s: %s",
+                provider_name,
+                exc.response.status_code,
+                exc.response.text,
+            )
+            raise AIServiceError(
+                message=f"LLM request failed with status {exc.response.status_code}",
+                code="AI_PROVIDER_ERROR",
+                details={
+                    "provider": provider_name,
+                    "status_code": exc.response.status_code,
+                },
+            ) from exc
+        except Exception as exc:
+            logger.error(
+                "LLM provider %s connection or unexpected error: %s",
+                provider_name,
+                str(exc),
+            )
+            raise AIServiceError(
+                message=f"LLM connection error: {str(exc)}",
+                code="AI_CONNECTION_ERROR",
+                details={"provider": provider_name},
+            ) from exc
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(
+                f"Unexpected LLM response format from {provider_name}: {data}"
+            ) from exc
+
+        if not content:
+            raise RuntimeError(f"{provider_name} returned empty content")
+
+        return str(content)
+
+    @staticmethod
+    def _get_deterministic_response() -> str:
+        """Return a stable JSON response for deterministic/test mode."""
+        stable = {
+            "verdict": "credible",
+            "confidence": 0.74,
+            "summary": "Deterministic verification output for testing",
+        }
+        return json.dumps(stable, separators=(",", ":"), sort_keys=True)

--- a/app/ai-service/services/providers/groq_provider.py
+++ b/app/ai-service/services/providers/groq_provider.py
@@ -1,0 +1,37 @@
+"""
+Groq provider — OpenAI-compatible LLM provider backed by Groq Cloud.
+
+Requires ``GROQ_API_KEY`` to be set in the environment or ``.env`` file.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from config import settings
+from services.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class GroqProvider(LLMProvider):
+    """LLM provider backed by the Groq Cloud API (OpenAI-compatible)."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._key = api_key if api_key is not None else settings.groq_api_key
+
+    # ------------------------------------------------------------------
+    # LLMProvider contract
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "groq"
+
+    @property
+    def _base_url(self) -> str:
+        return "https://api.groq.com/openai/v1/chat/completions"
+
+    @property
+    def _api_key(self) -> str | None:
+        return self._key

--- a/app/ai-service/services/providers/openai_provider.py
+++ b/app/ai-service/services/providers/openai_provider.py
@@ -1,0 +1,44 @@
+"""
+OpenAI provider — the **reference implementation** for ``LLMProvider``.
+
+Uses the OpenAI Chat Completions API.  Requires ``OPENAI_API_KEY``
+to be set in the environment or ``.env`` file.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from config import settings
+from services.providers.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """LLM provider backed by the OpenAI Chat Completions API.
+
+    This is the canonical reference implementation.  Other chat-completion-
+    compatible providers (e.g. Groq, Together, Anyscale) can follow the
+    exact same pattern, changing only ``name``, ``_base_url``, and the
+    API-key configuration.
+    """
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self._key = api_key if api_key is not None else settings.openai_api_key
+
+    # ------------------------------------------------------------------
+    # LLMProvider contract
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "openai"
+
+    @property
+    def _base_url(self) -> str:
+        return "https://api.openai.com/v1/chat/completions"
+
+    @property
+    def _api_key(self) -> str | None:
+        return self._key

--- a/app/ai-service/services/providers/test_llm_provider.py
+++ b/app/ai-service/services/providers/test_llm_provider.py
@@ -1,0 +1,65 @@
+"""
+Test / fixture LLM provider.
+
+Returns deterministic, fixture-driven responses without external API calls.
+Used when ``TEST_PROVIDER_MODE=true`` or when no real API keys are configured.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from services.providers.base import LLMProvider
+from services.test_provider import TestProvider
+
+logger = logging.getLogger(__name__)
+
+
+class TestLLMProvider(LLMProvider):
+    """LLM provider that returns fixture-driven results from ``TestProvider``.
+
+    Does **not** require any API keys and always produces the same output
+    for the same input — ideal for CI, staging, and deterministic testing.
+    """
+
+    def __init__(self) -> None:
+        self._test = TestProvider()
+
+    # ------------------------------------------------------------------
+    # LLMProvider contract
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "test"
+
+    @property
+    def _base_url(self) -> str:
+        return ""  # not used
+
+    @property
+    def _api_key(self) -> Optional[str]:
+        return None  # not required
+
+    # ------------------------------------------------------------------
+    # Override — does NOT use the HTTP helper
+    # ------------------------------------------------------------------
+
+    def call(
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        timeout: Optional[float] = None,
+    ) -> str:
+        _ = model, timeout  # unused in fixture mode
+        response = self._test.get_response(
+            endpoint="humanitarian",
+            request_data={
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+            },
+        )
+        return json.dumps(response, separators=(",", ":"), sort_keys=True)

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -1,9 +1,28 @@
 import pytest
+from unittest.mock import patch, MagicMock
 
 from config import settings
 from services.humanitarian_verification import HumanitarianVerificationService
+from services.providers.base import LLMProvider
 import metrics
-from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Mock provider helper
+# ---------------------------------------------------------------------------
+
+def _mock_provider(name, call_fn):
+    """Return an LLMProvider stub whose .call() delegates to *call_fn*."""
+    p = MagicMock(spec=LLMProvider)
+    p.name = name
+    p.call.side_effect = lambda model, system_prompt, user_prompt, timeout=None: call_fn(
+        model, system_prompt, user_prompt, timeout
+    )
+    return p
+
+
+def _mock_openai_provider(call_fn):
+    return _mock_provider("openai", call_fn)
 
 
 class TestHumanitarianVerificationService:
@@ -17,21 +36,15 @@ class TestHumanitarianVerificationService:
         
         calls = []
 
-        def fake_attempt_order(provider_preference):
-            return ["openai"]
-
-        def fake_model(provider):
-            return "test-model"
-
-        def fake_call_provider(provider, model, system_prompt, user_prompt, timeout=None):
-            calls.append((provider, model, system_prompt, user_prompt))
+        def fake_call(model, system_prompt, user_prompt, timeout=None):
+            calls.append((model, system_prompt, user_prompt))
             if len(calls) == 1:
                 raise RuntimeError("primary model failure")
             return '{"verdict":"inconclusive","confidence":0.4,"summary":"insufficient evidence"}'
 
-        monkeypatch.setattr(self.service, "_provider_attempt_order", fake_attempt_order)
-        monkeypatch.setattr(self.service, "_get_model_for_provider", fake_model)
-        monkeypatch.setattr(self.service, "_call_provider", fake_call_provider)
+        mock_provider = _mock_openai_provider(fake_call)
+        monkeypatch.setattr(self.service, "providers", [mock_provider])
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda p: "test-model")
 
         result = self.service.verify_claim(
             aid_claim="Aid package reached all households.",
@@ -49,7 +62,7 @@ class TestHumanitarianVerificationService:
         mock_observe.assert_called_once()
 
     def test_verify_claim_fails_when_no_provider_configured(self, monkeypatch):
-        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda provider_preference: [])
+        monkeypatch.setattr(self.service, "providers", [])
 
         with pytest.raises(RuntimeError):
             self.service.verify_claim(
@@ -69,8 +82,11 @@ class TestHumanitarianVerificationService:
         monkeypatch.setattr(settings, "ai_deterministic_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", "test-api-key")
 
-        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda provider_preference: ["openai"])
-        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda provider: "test-model")
+        mock_provider = _mock_openai_provider(
+            lambda model, sp, up, t=None: LLMProvider._get_deterministic_response()
+        )
+        monkeypatch.setattr(self.service, "providers", [mock_provider])
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda p: "test-model")
 
         result = self.service.verify_claim(
             aid_claim="Aid package reached all households.",
@@ -91,8 +107,11 @@ class TestHumanitarianVerificationService:
         monkeypatch.setattr(settings, "ai_deterministic_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", "test-api-key")
 
-        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda provider_preference: ["openai"])
-        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda provider: "test-model")
+        mock_provider = _mock_openai_provider(
+            lambda model, sp, up, t=None: LLMProvider._get_deterministic_response()
+        )
+        monkeypatch.setattr(self.service, "providers", [mock_provider])
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda p: "test-model")
 
         first_result = self.service.verify_claim(
             aid_claim="Emergency medical supplies delivered.",
@@ -113,21 +132,24 @@ class TestHumanitarianVerificationService:
 class TestTestProvider:
     """Tests for the fixture-driven test provider mode."""
 
-    def setup_method(self):
-        self.service = HumanitarianVerificationService()
-
-    def test_test_provider_returns_stable_results_across_runs(self, monkeypatch):
+    def _make_service_with_test_provider(self, monkeypatch):
+        """Create a service wired to the TestLLMProvider."""
         monkeypatch.setattr(settings, "test_provider_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", None)
         monkeypatch.setattr(settings, "groq_api_key", None)
+        from services.providers import get_llm_providers
+        return HumanitarianVerificationService(providers=get_llm_providers())
 
-        first = self.service.verify_claim(
+    def test_test_provider_returns_stable_results_across_runs(self, monkeypatch):
+        service = self._make_service_with_test_provider(monkeypatch)
+
+        first = service.verify_claim(
             aid_claim="Food distribution reached 500 households in the flood-affected region.",
             supporting_evidence=["WFP distribution log #A-42"],
             context_factors={"disaster_type": "flooding"},
             provider_preference="auto",
         )
-        second = self.service.verify_claim(
+        second = service.verify_claim(
             aid_claim="Food distribution reached 500 households in the flood-affected region.",
             supporting_evidence=["WFP distribution log #A-42"],
             context_factors={"disaster_type": "flooding"},
@@ -137,11 +159,9 @@ class TestTestProvider:
         assert first == second
 
     def test_test_provider_provider_string_in_response(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
+        service = self._make_service_with_test_provider(monkeypatch)
 
-        result = self.service.verify_claim(
+        result = service.verify_claim(
             aid_claim="Medical supplies delivered to clinic.",
             supporting_evidence=["delivery receipt"],
             context_factors={},
@@ -152,14 +172,11 @@ class TestTestProvider:
         assert result["model"] == "test-provider/fixture"
 
     def test_test_provider_verdict_is_valid(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
-
+        service = self._make_service_with_test_provider(monkeypatch)
         known_verdicts = {"credible", "inconclusive", "not_credible"}
 
         for i in range(12):
-            result = self.service.verify_claim(
+            result = service.verify_claim(
                 aid_claim=f"Test claim number {i} with unique content to exercise different fixtures.",
                 supporting_evidence=[f"doc_{i}"],
                 context_factors={"iteration": i},
@@ -171,13 +188,10 @@ class TestTestProvider:
             )
 
     def test_test_provider_different_inputs_can_produce_different_results(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
-
+        service = self._make_service_with_test_provider(monkeypatch)
         results = set()
         for i in range(20):
-            result = self.service.verify_claim(
+            result = service.verify_claim(
                 aid_claim=f"Unique aid claim description with varying details {i}.",
                 supporting_evidence=[f"evidence_{i}"],
                 context_factors={"seed": i},
@@ -191,12 +205,9 @@ class TestTestProvider:
         )
 
     def test_test_provider_confidence_in_expected_range(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
-
+        service = self._make_service_with_test_provider(monkeypatch)
         for i in range(10):
-            result = self.service.verify_claim(
+            result = service.verify_claim(
                 aid_claim=f"Confidence range check iteration {i}.",
                 supporting_evidence=[],
                 context_factors={},
@@ -208,11 +219,8 @@ class TestTestProvider:
             )
 
     def test_test_provider_does_not_require_api_keys(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
-
-        result = self.service.verify_claim(
+        service = self._make_service_with_test_provider(monkeypatch)
+        result = service.verify_claim(
             aid_claim="No API keys configured, but test provider should still work.",
             supporting_evidence=["test"],
             context_factors={},

--- a/app/ai-service/tests/test_providers.py
+++ b/app/ai-service/tests/test_providers.py
@@ -1,0 +1,189 @@
+"""Tests for the LLM provider abstraction."""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from config import settings
+from services.providers.base import LLMProvider
+from services.providers.openai_provider import OpenAIProvider
+from services.providers.groq_provider import GroqProvider
+from services.providers.test_llm_provider import TestLLMProvider
+from services.providers import get_llm_providers
+
+
+# ---------------------------------------------------------------------------
+# Base class contract
+# ---------------------------------------------------------------------------
+
+class TestLLMProviderContract:
+    """Verify the abstract base class enforces the contract."""
+
+    def test_cannot_instantiate_abstract_class(self):
+        with pytest.raises(TypeError):
+            LLMProvider()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self):
+        provider = OpenAIProvider(api_key="sk-test")
+        assert provider.name == "openai"
+        assert provider._base_url == "https://api.openai.com/v1/chat/completions"
+        assert provider._api_key == "sk-test"
+
+    def test_deterministic_response_is_valid_json(self):
+        raw = LLMProvider._get_deterministic_response()
+        parsed = json.loads(raw)
+        assert parsed["verdict"] == "credible"
+        assert parsed["confidence"] == 0.74
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — the reference implementation
+# ---------------------------------------------------------------------------
+
+class TestOpenAIProvider:
+    def test_name_is_openai(self):
+        p = OpenAIProvider(api_key="sk-test")
+        assert p.name == "openai"
+
+    def test_uses_settings_api_key_when_none_provided(self, monkeypatch):
+        monkeypatch.setattr(settings, "openai_api_key", "env-key")
+        p = OpenAIProvider()
+        assert p._api_key == "env-key"
+
+    def test_uses_constructor_api_key(self, monkeypatch):
+        monkeypatch.setattr(settings, "openai_api_key", "env-key")
+        p = OpenAIProvider(api_key="ctor-key")
+        assert p._api_key == "ctor-key"
+
+    def test_call_raises_without_api_key(self, monkeypatch):
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        p = OpenAIProvider(api_key=None)
+        with pytest.raises(RuntimeError, match="API key is not configured"):
+            p.call("gpt-4", "sys", "user")
+
+    @patch("httpx.Client.post")
+    def test_call_returns_content(self, mock_post, monkeypatch):
+        monkeypatch.setattr(settings, "ai_deterministic_mode", False)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Hello from AI"}}]
+        }
+        mock_post.return_value = mock_response
+
+        p = OpenAIProvider(api_key="sk-test")
+        result = p.call("gpt-4o-mini", "sys prompt", "user prompt")
+        assert result == "Hello from AI"
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider
+# ---------------------------------------------------------------------------
+
+class TestGroqProvider:
+    def test_name_is_groq(self):
+        p = GroqProvider(api_key="grq-test")
+        assert p.name == "groq"
+
+    def test_base_url(self):
+        p = GroqProvider(api_key="grq-test")
+        assert "groq.com" in p._base_url
+
+
+# ---------------------------------------------------------------------------
+# TestLLMProvider
+# ---------------------------------------------------------------------------
+
+class TestTestLLMProvider:
+    def test_name_is_test(self):
+        p = TestLLMProvider()
+        assert p.name == "test"
+
+    def test_call_returns_valid_json(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        p = TestLLMProvider()
+        result = p.call("any-model", "sys", "user")
+        parsed = json.loads(result)
+        assert isinstance(parsed, dict)
+
+    def test_call_is_deterministic(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        p = TestLLMProvider()
+        first = p.call("m", "sys", "hello world")
+        second = p.call("m", "sys", "hello world")
+        assert first == second
+
+    def test_does_not_use_http(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        p = TestLLMProvider()
+        assert p._base_url == ""
+        assert p._api_key is None
+        # Should not raise
+        result = p.call("m", "sys", "user")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+class TestGetLLMProviders:
+    def test_returns_test_when_test_mode(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        providers = get_llm_providers()
+        names = [p.name for p in providers]
+        assert "test" in names
+        assert "openai" not in names
+        assert "groq" not in names
+
+    def test_returns_openai_when_key_set(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", False)
+        monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        providers = get_llm_providers()
+        names = [p.name for p in providers]
+        assert "openai" in names
+        assert "test" not in names
+        assert "groq" not in names
+
+    def test_returns_multiple_when_multiple_configured(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+        monkeypatch.setattr(settings, "groq_api_key", "grq-test")
+
+        providers = get_llm_providers()
+        names = [p.name for p in providers]
+        assert len(providers) >= 3
+        assert "test" in names
+        assert "openai" in names
+        assert "groq" in names
+
+    def test_preference_moves_provider_to_front(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        providers = get_llm_providers(provider_preference="openai")
+        assert providers[0].name == "openai"
+
+    def test_unknown_preference_returns_all(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", True)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        providers = get_llm_providers(provider_preference="unknown")
+        assert len(providers) == 1
+        assert providers[0].name == "test"
+
+    def test_returns_empty_when_nothing_configured(self, monkeypatch):
+        monkeypatch.setattr(settings, "test_provider_mode", False)
+        monkeypatch.setattr(settings, "openai_api_key", None)
+        monkeypatch.setattr(settings, "groq_api_key", None)
+
+        providers = get_llm_providers()
+        assert len(providers) == 0

--- a/app/ai-service/tests/test_test_provider_stability.py
+++ b/app/ai-service/tests/test_test_provider_stability.py
@@ -7,6 +7,8 @@ from services.test_provider import TestProvider
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.ocr import OCRService
 from services.pii_scrubber import PIIScrubberService
+from services.providers.base import LLMProvider
+from services.providers.openai_provider import OpenAIProvider
 
 __test__ = True
 
@@ -58,7 +60,7 @@ class TestHumanitarianTestProviderStability:
     def test_deterministic_verify_claim_outputs_remain_stable(self, monkeypatch):
         monkeypatch.setattr(settings, "ai_deterministic_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", "test-api-key")
-        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda p: ["openai"])
+        monkeypatch.setattr(self.service, "providers", [OpenAIProvider(api_key="test-api-key")])
         monkeypatch.setattr(self.service, "_get_model_for_provider", lambda p: "test-model")
 
         first = self.service.verify_claim(
@@ -73,17 +75,22 @@ class TestHumanitarianTestProviderStability:
         )
         assert first == second
 
-    def test_test_provider_stable_across_runs(self, monkeypatch):
+    def _make_service_with_test_provider(self, monkeypatch):
         monkeypatch.setattr(settings, "test_provider_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", None)
         monkeypatch.setattr(settings, "groq_api_key", None)
+        from services.providers import get_llm_providers
+        return HumanitarianVerificationService(providers=get_llm_providers())
 
-        first = self.service.verify_claim(
+    def test_test_provider_stable_across_runs(self, monkeypatch):
+        service = self._make_service_with_test_provider(monkeypatch)
+
+        first = service.verify_claim(
             aid_claim="Food distribution reached 500 households.",
             supporting_evidence=["WFP log #A-42"],
             context_factors={"disaster": "flooding"},
         )
-        second = self.service.verify_claim(
+        second = service.verify_claim(
             aid_claim="Food distribution reached 500 households.",
             supporting_evidence=["WFP log #A-42"],
             context_factors={"disaster": "flooding"},
@@ -91,11 +98,9 @@ class TestHumanitarianTestProviderStability:
         assert first == second
 
     def test_test_provider_output_structure(self, monkeypatch):
-        monkeypatch.setattr(settings, "test_provider_mode", True)
-        monkeypatch.setattr(settings, "openai_api_key", None)
-        monkeypatch.setattr(settings, "groq_api_key", None)
+        service = self._make_service_with_test_provider(monkeypatch)
 
-        result = self.service.verify_claim(
+        result = service.verify_claim(
             aid_claim="Test claim.",
             supporting_evidence=["doc"],
             context_factors={},
@@ -216,7 +221,6 @@ class TestPIIscrubberTestProviderStability:
 
 class TestCrossEndpointStability:
     def setup_method(self):
-        self.humanitarian = HumanitarianVerificationService()
         self.ocr = OCRService()
         self.pii = PIIScrubberService()
 
@@ -224,10 +228,12 @@ class TestCrossEndpointStability:
         monkeypatch.setattr(settings, "test_provider_mode", True)
         monkeypatch.setattr(settings, "openai_api_key", None)
         monkeypatch.setattr(settings, "groq_api_key", None)
+        from services.providers import get_llm_providers
+        humanitarian = HumanitarianVerificationService(providers=get_llm_providers())
 
         from PIL import Image
 
-        h = self.humanitarian.verify_claim("Test claim.", ["doc"], {})
+        h = humanitarian.verify_claim("Test claim.", ["doc"], {})
         o = self.ocr.process_image(Image.new("RGB", (50, 50), color="white"))
         a = self.pii.anonymize("Test text.")
 


### PR DESCRIPTION
…del backends

Add a clean provider interface so LLM providers can be swapped without changing route logic or verification service internals.

New services/providers/ package:
- base.py: LLMProvider abstract base class with clear contract (name, call), shared OpenAI-compatible HTTP helper, and deterministic-mode support
- openai_provider.py: OpenAIProvider — the reference implementation
- groq_provider.py: GroqProvider — follows the same pattern
- test_llm_provider.py: TestLLMProvider — wraps existing TestProvider under the LLM contract
- __init__.py: get_llm_providers() factory that assembles available providers from settings, respecting preference ordering

Refactored HumanitarianVerificationService:
- Removed hardcoded _call_openai(), _call_groq(), _call_test(), _call_chat_completion_api(), _get_deterministic_response()
- Accepts List[LLMProvider] via constructor injection
- Circuit breakers initialized dynamically from provider names
- verify_claim() iterates providers and calls provider.call()

Tests:
- Updated existing tests to use mock providers instead of patching internal methods
- Added comprehensive test_providers.py covering contracts, each provider implementation, and the factory function

Closes #615

Closes #615 