### PR TITLE
feat(ai-service): invalidate cached AI responses on artifact/model-version change

### DIFF
--- a/app/ai-service/api/v1/artifacts.py
+++ b/app/ai-service/api/v1/artifacts.py
@@ -33,6 +33,11 @@ class AccessModeRequest(BaseModel):
     mode: Literal["signed_url", "proxy"] = "signed_url"
 
 
+class CacheInvalidationResponse(BaseModel):
+    artifact_id: str
+    invalidated_entries: int
+
+
 def _create_error_response(code: str, status_code: int, detail: str) -> tuple:
     """Create standardized error response with logging."""
     logger.warning(
@@ -267,3 +272,51 @@ async def download_artifact_with_token(
             "mime_type", "application/octet-stream"
         ),
     )
+
+
+@router.post(
+    "/ai/verification-artifacts/{artifact_id}/invalidate-cache",
+    response_model=CacheInvalidationResponse,
+)
+async def invalidate_artifact_cache(
+    artifact_id: str,
+    x_user_role: str = Header(default="", alias="X-User-Role"),
+):
+    """
+    Explicitly invalidate cached data tied to a verification artifact.
+
+    Call this after an artifact's content has been updated in place (same
+    artifact_id, new bytes) so stale artifact-access checks and AI
+    verification responses that referenced it aren't served from cache.
+    Restricted to admin/operator roles since it's a mutating operation.
+    """
+    if x_user_role not in {"admin", "operator"}:
+        response, _ = _create_error_response(
+            "forbidden_role",
+            403,
+            f"User role '{x_user_role}' is not authorized to invalidate cache",
+        )
+        return response
+
+    from main import app
+    from services.cache_invalidation import get_invalidation_helper
+
+    cache = getattr(app.state, "cache", None)
+    if not cache or not cache.enabled:
+        return CacheInvalidationResponse(artifact_id=artifact_id, invalidated_entries=0)
+
+    helper = get_invalidation_helper(cache)
+    deleted = helper.invalidate_artifact_access(
+        artifact_id
+    ) + helper.invalidate_verification_by_artifact(artifact_id)
+
+    logger.info(
+        "artifact_cache_invalidated",
+        extra={
+            "event": "artifact_cache_invalidated",
+            "artifact_id": artifact_id,
+            "invalidated_entries": deleted,
+        },
+    )
+
+    return CacheInvalidationResponse(artifact_id=artifact_id, invalidated_entries=deleted)

--- a/app/ai-service/api/v1/humanitarian.py
+++ b/app/ai-service/api/v1/humanitarian.py
@@ -7,14 +7,60 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter
 
+from config import settings
 from schemas.common import ResultEnvelope
 from schemas.humanitarian import (
     HumanitarianVerificationRequest,
 )
+from services.cache import cached_response
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["humanitarian"])
+
+
+@cached_response(
+    prefix="humanitarian_verification",
+    ttl_seconds=settings.cache_ttl_verification,
+    key_tags=["model_version", "artifact_tag"],
+)
+async def _verify_claim_cached(
+    aid_claim: str,
+    supporting_evidence: List[str],
+    context_factors: Dict[str, Any],
+    provider_preference: str,
+    timeout: Optional[float],
+    model_version: str,
+    artifact_tag: str,
+) -> Dict[str, Any]:
+    """
+    Cacheable wrapper around HumanitarianVerificationService.verify_claim.
+
+    `model_version` and `artifact_tag` don't affect the underlying provider
+    call, but embedding them in the cache key ensures a stale response isn't
+    served after the configured model/provider changes, or after an evidence
+    artifact referenced by the claim is updated (see
+    CacheInvalidationHelper.invalidate_verification_by_artifact/_model_version).
+    """
+    import main as _main
+
+    try:
+        return _main.humanitarian_verification_service.verify_claim(
+            aid_claim=aid_claim,
+            supporting_evidence=supporting_evidence,
+            context_factors=context_factors,
+            provider_preference=provider_preference,
+            timeout=timeout,
+        )
+    except TypeError as exc:
+        if "timeout" in str(exc):
+            return _main.humanitarian_verification_service.verify_claim(
+                aid_claim=aid_claim,
+                supporting_evidence=supporting_evidence,
+                context_factors=context_factors,
+                provider_preference=provider_preference,
+            )
+        raise
 
 
 @router.post("/ai/humanitarian/verify", response_model=ResultEnvelope[Dict[str, Any]])
@@ -28,24 +74,20 @@ async def verify_humanitarian_claim(
     logger.info("Processing humanitarian verification request")
 
     try:
-        try:
-            raw = _main.humanitarian_verification_service.verify_claim(
-                aid_claim=request.aid_claim,
-                supporting_evidence=request.supporting_evidence,
-                context_factors=request.context_factors,
-                provider_preference=request.provider_preference,
-                timeout=request.timeout,
-            )
-        except TypeError as exc:
-            if "timeout" in str(exc):
-                raw = _main.humanitarian_verification_service.verify_claim(
-                    aid_claim=request.aid_claim,
-                    supporting_evidence=request.supporting_evidence,
-                    context_factors=request.context_factors,
-                    provider_preference=request.provider_preference,
-                )
-            else:
-                raise exc
+        model_version = _main.humanitarian_verification_service.get_model_version(
+            request.provider_preference
+        )
+        artifact_tag = ",".join(sorted(request.artifact_ids)) if request.artifact_ids else ""
+
+        raw = await _verify_claim_cached(
+            aid_claim=request.aid_claim,
+            supporting_evidence=request.supporting_evidence,
+            context_factors=request.context_factors,
+            provider_preference=request.provider_preference,
+            timeout=request.timeout,
+            model_version=model_version,
+            artifact_tag=artifact_tag,
+        )
 
         verification: Dict[str, Any] = raw.get("verification") or {}
 

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
         BACKEND_WEBHOOK_URL: Webhook URL to notify NestJS backend when tasks complete
         PROOF_OF_LIFE_CONFIDENCE_THRESHOLD: Default threshold for liveness verification
         PROOF_OF_LIFE_MIN_FACE_SIZE: Minimum detected face size in pixels
+        CACHE_TTL_VERIFICATION: TTL for cached AI verification responses (artifact + model-version keyed)
     """
 
     # API Keys
@@ -63,6 +64,7 @@ class Settings(BaseSettings):
     # Cache TTL settings (in seconds)
     cache_ttl_task_status: int = 30  # Short TTL for responsive polling
     cache_ttl_artifact_access: int = 60  # 1 minute for artifact metadata
+    cache_ttl_verification: int = 120  # AI verification responses, keyed by claim/artifact/model version
 
     # Application settings
     app_env: Literal["development", "staging", "production", "test"] = "development"

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -38,6 +38,13 @@ PIPELINE_STEP_LATENCY = Histogram('pipeline_step_latency_seconds', 'Pipeline ste
 JOB_CANCELLED_TOTAL = Counter('job_cancelled_total', 'Total jobs cancelled', ['task_type'])
 JOB_EXPIRED_TOTAL = Counter('job_expired_total', 'Total jobs expired', ['task_type'])
 
+# Cache invalidation metrics
+CACHE_INVALIDATION_TOTAL = Counter(
+    'cache_invalidation_total',
+    'Cache invalidation operations performed',
+    ['reason'],
+)
+
 def check_system_resources(memory_threshold_percent: float = 90.0) -> bool:
     """
     Check if system RAM or VRAM is above threshold.

--- a/app/ai-service/schemas/humanitarian.py
+++ b/app/ai-service/schemas/humanitarian.py
@@ -9,6 +9,12 @@ class HumanitarianVerificationRequest(BaseModel):
     context_factors: Dict[str, Any] = Field(default_factory=dict, examples=[{"location": "Kano, Nigeria", "disaster_type": "flood"}])
     provider_preference: Literal["auto", "test", "openai", "groq"] = Field("auto", examples=["auto"])
     timeout: Optional[float] = Field(default=None, description="Request-level timeout in seconds for provider call", examples=[30.0])
+    artifact_ids: List[str] = Field(
+        default_factory=list,
+        description="IDs of evidence artifacts (see /ai/verification-artifacts) referenced by this claim. "
+        "Used to key the response cache so it can be explicitly invalidated when an artifact is updated.",
+        examples=[["artifact_abc123"]],
+    )
     anchor_metadata: Optional[AnchorMetadata] = None
 
     model_config = {

--- a/app/ai-service/services/cache.py
+++ b/app/ai-service/services/cache.py
@@ -6,7 +6,7 @@ Provides response caching for safe read operations with configurable TTL.
 import json
 import hashlib
 import logging
-from typing import Optional, Any, Callable
+from typing import Optional, Any, Callable, Dict, List
 from functools import wraps
 import redis
 from config import Settings
@@ -45,17 +45,27 @@ class CacheService:
             self.enabled = False
             self.client = None
 
-    def _generate_key(self, prefix: str, *args: Any, **kwargs: Any) -> str:
+    def _generate_key(
+        self,
+        prefix: str,
+        *args: Any,
+        tags: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> str:
         """
         Generate a deterministic cache key from function arguments.
 
         Args:
             prefix: Namespace prefix for the key
             *args: Positional arguments
+            tags: Optional named values (e.g. artifact_id, model_version) to embed
+                literally in the key, in addition to the arguments hash, so that
+                CacheInvalidationHelper can target entries by that value via a
+                Redis glob pattern rather than needing to know the full hash.
             **kwargs: Keyword arguments
 
         Returns:
-            SHA256 hash-based cache key
+            Cache key combining any literal tags with a SHA256 hash of the inputs
         """
         # Sort kwargs for consistent key generation
         sorted_kwargs = sorted(kwargs.items())
@@ -70,7 +80,28 @@ class CacheService:
         key_str = json.dumps(key_data, sort_keys=True, default=str)
         key_hash = hashlib.sha256(key_str.encode()).hexdigest()
 
-        return f"cache:ai:{prefix}:{key_hash}"
+        tag_segment = ""
+        if tags:
+            sanitized = [
+                f"{name}={self._sanitize_tag_value(value)}"
+                for name, value in sorted(tags.items())
+                if value not in (None, "")
+            ]
+            if sanitized:
+                tag_segment = ":" + ":".join(sanitized)
+
+        return f"cache:ai:{prefix}{tag_segment}:{key_hash}"
+
+    @staticmethod
+    def _sanitize_tag_value(value: Any) -> str:
+        """
+        Strip Redis glob-special and separator characters from a tag value so it
+        remains safely matchable with SCAN MATCH patterns.
+        """
+        text = str(value)
+        for ch in ("*", "?", "[", "]", ":"):
+            text = text.replace(ch, "_")
+        return text
 
     def get(self, key: str) -> Optional[Any]:
         """
@@ -167,21 +198,39 @@ class CacheService:
             return 0
 
 
-def cached_response(prefix: str, ttl_seconds: int):
+def cached_response(prefix: str, ttl_seconds: int, key_tags: Optional[List[str]] = None):
     """
     Decorator to cache function responses based on normalized inputs.
 
     Args:
         prefix: Cache key namespace prefix
         ttl_seconds: Time-to-live for cached responses
+        key_tags: Names of keyword arguments (e.g. "artifact_id", "model_version")
+            whose values should also be embedded literally in the cache key, so
+            CacheInvalidationHelper can target them by that value instead of
+            needing the full argument hash. Values are still part of the hashed
+            inputs regardless of whether they're listed here.
 
     Example:
         @cached_response(prefix="task_status", ttl_seconds=30)
         async def get_task_status(task_id: str):
             return await fetch_task_status(task_id)
+
+        @cached_response(
+            prefix="humanitarian_verification",
+            ttl_seconds=120,
+            key_tags=["model_version", "artifact_tag"],
+        )
+        async def verify(aid_claim: str, model_version: str, artifact_tag: str):
+            ...
     """
 
     def decorator(func: Callable):
+        def _resolve_tags(kwargs: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+            if not key_tags:
+                return None
+            return {name: kwargs.get(name) for name in key_tags if kwargs.get(name) is not None}
+
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
             # Get or create cache service instance
@@ -193,7 +242,7 @@ def cached_response(prefix: str, ttl_seconds: int):
                 return await func(*args, **kwargs)
 
             # Generate cache key
-            cache_key = cache._generate_key(prefix, *args, **kwargs)
+            cache_key = cache._generate_key(prefix, *args, tags=_resolve_tags(kwargs), **kwargs)
 
             # Try to retrieve from cache
             cached_value = cache.get(cache_key)
@@ -222,7 +271,7 @@ def cached_response(prefix: str, ttl_seconds: int):
                 return func(*args, **kwargs)
 
             # Generate cache key
-            cache_key = cache._generate_key(prefix, *args, **kwargs)
+            cache_key = cache._generate_key(prefix, *args, tags=_resolve_tags(kwargs), **kwargs)
 
             # Try to retrieve from cache
             cached_value = cache.get(cache_key)

--- a/app/ai-service/services/cache_invalidation.py
+++ b/app/ai-service/services/cache_invalidation.py
@@ -4,6 +4,7 @@ Cache invalidation helpers for AI service
 
 import logging
 from typing import Optional
+import metrics
 from services.cache import CacheService
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ class CacheInvalidationHelper:
         """
         pattern = f"cache:ai:task_status:*{task_id}*"
         deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="task_status").inc()
         if deleted > 0:
             logger.info(f"Invalidated {deleted} task status cache entries for task {task_id}")
         return deleted
@@ -43,6 +45,7 @@ class CacheInvalidationHelper:
         """
         pattern = "cache:ai:task_status:*"
         deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="task_status").inc()
         if deleted > 0:
             logger.info(f"Invalidated {deleted} task status cache entries")
         return deleted
@@ -59,8 +62,54 @@ class CacheInvalidationHelper:
         """
         pattern = f"cache:ai:artifact_access:*{artifact_id}*"
         deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="artifact_access").inc()
         if deleted > 0:
             logger.info(f"Invalidated {deleted} artifact access cache entries for {artifact_id}")
+        return deleted
+
+    def invalidate_verification_by_artifact(self, artifact_id: str) -> int:
+        """
+        Invalidate cached AI verification responses that referenced a given
+        evidence artifact, e.g. after the artifact's content has been updated.
+
+        Relies on the artifact ID being embedded literally in the cache key
+        (see `artifact_tag` in api/v1/humanitarian.py) rather than only being
+        part of the hashed inputs, so it can be matched without knowing the
+        exact hash of every request that referenced it.
+
+        Args:
+            artifact_id: The evidence artifact ID that changed
+
+        Returns:
+            Number of keys deleted
+        """
+        pattern = f"cache:ai:humanitarian_verification:*artifact_tag=*{artifact_id}*"
+        deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="artifact_updated").inc()
+        if deleted > 0:
+            logger.info(f"Invalidated {deleted} verification cache entries for artifact {artifact_id}")
+        return deleted
+
+    def invalidate_verification_by_model_version(self, provider: str, model: str) -> int:
+        """
+        Invalidate cached AI verification responses produced by a specific
+        provider/model pairing, e.g. after upgrading the configured model.
+
+        Args:
+            provider: The LLM provider (e.g. "openai", "groq")
+            model: The model identifier (e.g. "gpt-4o-mini")
+
+        Returns:
+            Number of keys deleted
+        """
+        model_version = CacheService._sanitize_tag_value(f"{provider}:{model}")
+        pattern = f"cache:ai:humanitarian_verification:*model_version={model_version}*"
+        deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="model_version_changed").inc()
+        if deleted > 0:
+            logger.info(
+                f"Invalidated {deleted} verification cache entries for model version {provider}:{model}"
+            )
         return deleted
 
     def invalidate_all(self) -> int:
@@ -72,6 +121,7 @@ class CacheInvalidationHelper:
         """
         pattern = "cache:ai:*"
         deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="all").inc()
         logger.warning(f"Invalidated ALL AI cache entries ({deleted} keys)")
         return deleted
 

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -145,6 +145,21 @@ class HumanitarianVerificationService:
             for provider in providers
         )
 
+    def get_model_version(self, provider_preference: str = "auto") -> str:
+        """
+        Resolve the "provider:model" identifier for the primary provider that
+        would be attempted for a given preference, without making a request.
+
+        Used to key and invalidate the verification response cache so that
+        changing the configured model/provider naturally busts stale entries.
+        """
+        providers = self._provider_attempt_order(provider_preference)
+        if not providers:
+            return "none:none"
+        provider = providers[0]
+        model = self._get_model_for_provider(provider)
+        return f"{provider}:{model}"
+
     def _get_model_for_provider(self, provider: str) -> str:
         if provider == "test":
             return "test-provider/fixture"

--- a/app/ai-service/tests/test_artifact_access.py
+++ b/app/ai-service/tests/test_artifact_access.py
@@ -291,3 +291,64 @@ def test_all_authorized_roles_have_access(client: TestClient, artifact_fixture: 
         assert response.status_code == 200, f"Role {role} should have access"
         assert "download_url" in response.json()
 
+
+def test_invalidate_cache_rejects_missing_role(client: TestClient, artifact_fixture: str):
+    """Test that invalidate-cache requires an X-User-Role header."""
+    response = client.post(f"/v1/ai/verification-artifacts/{artifact_fixture}/invalidate-cache")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden_role"
+
+
+def test_invalidate_cache_rejects_reviewer_role(client: TestClient, artifact_fixture: str):
+    """Test that the reviewer role (read-only) cannot trigger cache invalidation."""
+    response = client.post(
+        f"/v1/ai/verification-artifacts/{artifact_fixture}/invalidate-cache",
+        headers={"X-User-Role": "reviewer"},
+    )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden_role"
+
+
+def test_invalidate_cache_allows_admin_role(client: TestClient, artifact_fixture: str):
+    """Test that admin can trigger cache invalidation and gets a structured response."""
+    response = client.post(
+        f"/v1/ai/verification-artifacts/{artifact_fixture}/invalidate-cache",
+        headers={"X-User-Role": "admin"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["artifact_id"] == artifact_fixture
+    assert isinstance(body["invalidated_entries"], int)
+
+
+def test_invalidate_cache_allows_operator_role(client: TestClient, artifact_fixture: str):
+    """Test that operator can trigger cache invalidation."""
+    response = client.post(
+        f"/v1/ai/verification-artifacts/{artifact_fixture}/invalidate-cache",
+        headers={"X-User-Role": "operator"},
+    )
+    assert response.status_code == 200
+
+
+def test_invalidate_cache_calls_invalidation_helper_when_cache_enabled(
+    client: TestClient, artifact_fixture: str
+):
+    """Test that a live cache is actually queried for both artifact-access and verification entries."""
+    from unittest.mock import Mock, patch
+
+    import main
+
+    mock_cache = Mock()
+    mock_cache.enabled = True
+    mock_cache.delete_pattern.return_value = 1
+
+    with patch.object(main.app.state, "cache", mock_cache, create=True):
+        response = client.post(
+            f"/v1/ai/verification-artifacts/{artifact_fixture}/invalidate-cache",
+            headers={"X-User-Role": "admin"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["invalidated_entries"] == 2
+    assert mock_cache.delete_pattern.call_count == 2
+

--- a/app/ai-service/tests/test_cache_invalidation.py
+++ b/app/ai-service/tests/test_cache_invalidation.py
@@ -1,0 +1,121 @@
+"""
+Tests for cache invalidation helpers.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+import metrics
+from services.cache import CacheService
+from services.cache_invalidation import CacheInvalidationHelper, get_invalidation_helper
+
+
+@pytest.fixture
+def mock_cache():
+    cache = Mock(spec=CacheService)
+    cache.delete_pattern.return_value = 2
+    return cache
+
+
+@pytest.fixture
+def helper(mock_cache):
+    return CacheInvalidationHelper(mock_cache)
+
+
+@pytest.fixture(autouse=True)
+def reset_invalidation_metric():
+    """CACHE_INVALIDATION_TOTAL is a module-level Counter; snapshot per-test."""
+    yield
+
+
+def _counter_value(reason: str) -> float:
+    return metrics.CACHE_INVALIDATION_TOTAL.labels(reason=reason)._value.get()
+
+
+class TestCacheInvalidationHelper:
+    def test_invalidate_task_status_uses_task_id_pattern(self, helper, mock_cache):
+        helper.invalidate_task_status("task-1")
+
+        mock_cache.delete_pattern.assert_called_once_with("cache:ai:task_status:*task-1*")
+
+    def test_invalidate_artifact_access_uses_artifact_id_pattern(self, helper, mock_cache):
+        helper.invalidate_artifact_access("artifact-1")
+
+        mock_cache.delete_pattern.assert_called_once_with("cache:ai:artifact_access:*artifact-1*")
+
+    def test_invalidate_verification_by_artifact_targets_artifact_tag(self, helper, mock_cache):
+        helper.invalidate_verification_by_artifact("artifact-1")
+
+        mock_cache.delete_pattern.assert_called_once_with(
+            "cache:ai:humanitarian_verification:*artifact_tag=*artifact-1*"
+        )
+
+    def test_invalidate_verification_by_artifact_returns_deleted_count(self, helper, mock_cache):
+        mock_cache.delete_pattern.return_value = 5
+
+        assert helper.invalidate_verification_by_artifact("artifact-1") == 5
+
+    def test_invalidate_verification_by_model_version_targets_sanitized_model_version(
+        self, helper, mock_cache
+    ):
+        helper.invalidate_verification_by_model_version("openai", "gpt-4o-mini")
+
+        mock_cache.delete_pattern.assert_called_once_with(
+            "cache:ai:humanitarian_verification:*model_version=openai_gpt-4o-mini*"
+        )
+
+    def test_invalidate_all_targets_every_ai_cache_entry(self, helper, mock_cache):
+        helper.invalidate_all()
+
+        mock_cache.delete_pattern.assert_called_once_with("cache:ai:*")
+
+    def test_invalidate_verification_by_artifact_records_metric(self, helper, mock_cache):
+        before = _counter_value("artifact_updated")
+
+        helper.invalidate_verification_by_artifact("artifact-1")
+
+        assert _counter_value("artifact_updated") == before + 1
+
+    def test_invalidate_verification_by_model_version_records_metric(self, helper, mock_cache):
+        before = _counter_value("model_version_changed")
+
+        helper.invalidate_verification_by_model_version("openai", "gpt-4o-mini")
+
+        assert _counter_value("model_version_changed") == before + 1
+
+    def test_invalidate_artifact_access_records_metric(self, helper, mock_cache):
+        before = _counter_value("artifact_access")
+
+        helper.invalidate_artifact_access("artifact-1")
+
+        assert _counter_value("artifact_access") == before + 1
+
+    def test_invalidate_task_status_records_metric(self, helper, mock_cache):
+        before = _counter_value("task_status")
+
+        helper.invalidate_task_status("task-1")
+
+        assert _counter_value("task_status") == before + 1
+
+    def test_invalidate_all_records_metric(self, helper, mock_cache):
+        before = _counter_value("all")
+
+        helper.invalidate_all()
+
+        assert _counter_value("all") == before + 1
+
+
+class TestGetInvalidationHelper:
+    def test_returns_helper_wrapping_provided_cache_service(self, mock_cache):
+        helper = get_invalidation_helper(mock_cache)
+
+        assert isinstance(helper, CacheInvalidationHelper)
+        assert helper.cache is mock_cache
+
+    def test_raises_when_no_cache_available_on_app_state(self):
+        with patch("main.app") as mock_app:
+            mock_app.state = Mock(spec=[])
+
+            with pytest.raises(RuntimeError):
+                get_invalidation_helper()

--- a/app/ai-service/tests/test_cache_service.py
+++ b/app/ai-service/tests/test_cache_service.py
@@ -165,6 +165,50 @@ class TestCacheService:
 
         assert result is False
 
+    def test_generate_key_embeds_tags_literally(self, cache_service_with_mock_redis):
+        """Tags should appear in the key so pattern-based invalidation can target them"""
+        cache = cache_service_with_mock_redis
+
+        key = cache._generate_key(
+            "humanitarian_verification",
+            aid_claim="claim",
+            tags={"artifact_tag": "artifact-123", "model_version": "openai:gpt-4o-mini"},
+        )
+
+        assert "artifact_tag=artifact-123" in key
+        assert "model_version=openai:gpt-4o-mini" not in key  # colon is a tag separator, must be sanitized
+        assert "model_version=openai_gpt-4o-mini" in key
+        assert key.startswith("cache:ai:humanitarian_verification:")
+
+    def test_generate_key_tags_change_key_even_with_same_hash_inputs(self, cache_service_with_mock_redis):
+        """Two calls with identical hashed args but different tags must not collide"""
+        cache = cache_service_with_mock_redis
+
+        key1 = cache._generate_key("test", tags={"artifact_tag": "artifact-a"})
+        key2 = cache._generate_key("test", tags={"artifact_tag": "artifact-b"})
+
+        assert key1 != key2
+
+    def test_generate_key_omits_empty_or_none_tags(self, cache_service_with_mock_redis):
+        """Tags with no value shouldn't add noise to the key"""
+        cache = cache_service_with_mock_redis
+
+        key = cache._generate_key("test", tags={"artifact_tag": "", "model_version": None})
+
+        assert key == cache._generate_key("test", tags=None)
+
+    def test_generate_key_without_tags_is_unchanged(self, cache_service_with_mock_redis):
+        """Backward compatibility: no tags means the same key shape as before"""
+        cache = cache_service_with_mock_redis
+
+        key = cache._generate_key("task_status", "task-1")
+
+        assert key.startswith("cache:ai:task_status:")
+        assert key.count(":") == 3  # cache:ai:task_status:<hash>
+
+    def test_sanitize_tag_value_strips_glob_special_characters(self):
+        assert CacheService._sanitize_tag_value("a*b?c[d]e:f") == "a_b_c_d_e_f"
+
 
 class TestCachedResponseDecorator:
     @pytest.mark.asyncio
@@ -271,3 +315,41 @@ class TestCachedResponseDecorator:
         assert call_count == 1
         mock_cache.get.assert_not_called()
         mock_cache.set.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cached_response_passes_key_tags_from_kwargs(self):
+        """key_tags should promote named kwargs into the literal `tags` used for the key"""
+        mock_cache = Mock()
+        mock_cache.enabled = True
+        mock_cache.get.return_value = None
+        mock_cache._generate_key = Mock(return_value="test_key")
+
+        @cached_response(prefix="test", ttl_seconds=60, key_tags=["artifact_tag", "model_version"])
+        async def test_func(aid_claim, artifact_tag, model_version):
+            return "result"
+
+        with patch("main.app") as mock_app:
+            mock_app.state.cache = mock_cache
+            await test_func(aid_claim="claim", artifact_tag="artifact-1", model_version="openai:gpt-4o-mini")
+
+        _, call_kwargs = mock_cache._generate_key.call_args
+        assert call_kwargs["tags"] == {"artifact_tag": "artifact-1", "model_version": "openai:gpt-4o-mini"}
+
+    @pytest.mark.asyncio
+    async def test_cached_response_without_key_tags_passes_no_tags(self):
+        """Existing decorated functions with no key_tags shouldn't get a tags dict"""
+        mock_cache = Mock()
+        mock_cache.enabled = True
+        mock_cache.get.return_value = None
+        mock_cache._generate_key = Mock(return_value="test_key")
+
+        @cached_response(prefix="test", ttl_seconds=60)
+        async def test_func(arg1):
+            return "result"
+
+        with patch("main.app") as mock_app:
+            mock_app.state.cache = mock_cache
+            await test_func("value1")
+
+        _, call_kwargs = mock_cache._generate_key.call_args
+        assert call_kwargs["tags"] is None

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -58,6 +58,17 @@ class TestHumanitarianVerificationService:
                 context_factors={},
             )
 
+    def test_get_model_version_resolves_provider_and_model(self, monkeypatch):
+        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda provider_preference: ["groq"])
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda provider: "llama-3.3-70b-versatile")
+
+        assert self.service.get_model_version("auto") == "groq:llama-3.3-70b-versatile"
+
+    def test_get_model_version_returns_none_when_no_provider_available(self, monkeypatch):
+        monkeypatch.setattr(self.service, "_provider_attempt_order", lambda provider_preference: [])
+
+        assert self.service.get_model_version("auto") == "none:none"
+
     def test_parse_json_response_supports_markdown_block(self):
         content = "```json\n{\"verdict\":\"credible\",\"confidence\":0.9}\n```"
         parsed = self.service._parse_json_response(content)


### PR DESCRIPTION
## Summary
- Cache keys for humanitarian AI verification responses now embed the resolved provider/model version and referenced evidence-artifact IDs (`services/cache.py`, `api/v1/humanitarian.py`), so an upgraded model or a re-sent claim with different evidence naturally produces a fresh key instead of serving a stale response.
- Adds an explicit invalidation path: `POST /ai/verification-artifacts/{artifact_id}/invalidate-cache` (admin/operator only) purges both the artifact-access cache and any verification responses tagged with that artifact, for the case where an artifact is updated in place under the same ID.
- Fixes the existing `CacheInvalidationHelper` pattern-matching methods (`invalidate_task_status`, `invalidate_artifact_access`) which previously targeted glob patterns that could never match a SHA256-hashed key; invalidation-relevant values (artifact id, model version) are now embedded literally in the key alongside the hash.
- Adds `cache_invalidation_total{reason=...}` Prometheus counter, incremented on every invalidation path (task_status, artifact_access, artifact_updated, model_version_changed, all).

Closes #768

## Test plan
- [x] `pytest -q` in `app/ai-service` — 372 passed, 5 pre-existing skips (unrelated: `pytest-asyncio` plugin not pinned in requirements, same skip count on `main`)
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] `python test_setup.py` — app imports/config/routes load cleanly, new `invalidate-cache` route listed
- [x] Added unit tests: tag-based cache key generation, `key_tags` decorator wiring, `CacheInvalidationHelper` pattern/metric coverage, `get_model_version`, and the new invalidate-cache endpoint (role checks + live-cache call-through)