### PR TITLE
fix(ui): theme and contrast audit across all app routes

### DIFF
--- a/app/frontend/src/app/[locale]/dashboard/page.tsx
+++ b/app/frontend/src/app/[locale]/dashboard/page.tsx
@@ -85,7 +85,7 @@ export default function AidDashboard() {
             <button className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
               Get Notified
             </button>
-            <button className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <button className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-700 dark:text-gray-200">
               Learn More
             </button>
           </div>

--- a/app/frontend/src/app/[locale]/help/page.tsx
+++ b/app/frontend/src/app/[locale]/help/page.tsx
@@ -26,7 +26,7 @@ export default function HelpPage() {
             <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
               Check package cards, filters, exports, and the map view. In mock mode, these views populate without a live backend.
             </p>
-            <Link href="/dashboard" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700">
+            <Link href="/dashboard" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
               Open dashboard
             </Link>
           </div>
@@ -36,7 +36,7 @@ export default function HelpPage() {
             <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
               Create a campaign manually or load sample values to explore import and review flows end to end.
             </p>
-            <Link href="/campaigns" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700">
+            <Link href="/campaigns" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
               Open campaigns
             </Link>
           </div>
@@ -46,7 +46,7 @@ export default function HelpPage() {
             <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
               Use sample evidence text or upload a small test image to see the verification wizard states and error handling.
             </p>
-            <Link href="/" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700">
+            <Link href="/" className="mt-4 inline-flex text-sm font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
               Open verification entry
             </Link>
           </div>

--- a/app/frontend/src/app/theme-contrast.test.ts
+++ b/app/frontend/src/app/theme-contrast.test.ts
@@ -38,6 +38,46 @@ describe('theme contrast CSS guardrails', () => {
   });
 });
 
+describe('ClaimReceipt dark-mode class coverage', () => {
+  const claimReceiptSource = fs.readFileSync(
+    path.join(process.cwd(), 'src/components/ClaimReceipt.tsx'),
+    'utf8',
+  );
+
+  const STATUS_KEYS = ['requested', 'verified', 'approved', 'disbursed', 'archived'];
+
+  it.each(STATUS_KEYS)(
+    'statusColors["%s"] contains dark:bg- and dark:text- variants',
+    (status) => {
+      const pattern = new RegExp(`${status}:\\s*['"\`]([^'"\`]+)['"\`]`);
+      const match = claimReceiptSource.match(pattern);
+      expect(match).not.toBeNull();
+      expect(match![1]).toMatch(/dark:bg-/);
+      expect(match![1]).toMatch(/dark:text-/);
+    },
+  );
+
+  it.each(STATUS_KEYS)(
+    'statusBadgeColors["%s"] contains dark:bg- and dark:text- variants',
+    (status) => {
+      expect(claimReceiptSource).toMatch(
+        new RegExp(`${status}:.*dark:bg-.*dark:text-`),
+      );
+    },
+  );
+
+  it('action buttons carry dark:bg-white/10 and dark:hover:bg-white/20', () => {
+    const occurrences = (claimReceiptSource.match(/dark:bg-white\/10/g) || []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+    const hoverOccurrences = (claimReceiptSource.match(/dark:hover:bg-white\/20/g) || []).length;
+    expect(hoverOccurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  it('FieldCopyButton carries text-current', () => {
+    expect(claimReceiptSource).toContain('text-current');
+  });
+});
+
 function readSourceFiles(dir: string): string[] {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
     const absolute = path.join(dir, entry.name);
@@ -53,3 +93,48 @@ function readSourceFiles(dir: string): string[] {
     return fs.readFileSync(absolute, 'utf8');
   });
 }
+
+describe('help/page.tsx dark-mode link coverage', () => {
+  const helpSource = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/[locale]/help/page.tsx'),
+    'utf8',
+  );
+
+  it('contains dark:hover:text-blue-300 on all three card links', () => {
+    const count = (helpSource.match(/dark:hover:text-blue-300/g) || []).length;
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  it('contains dark:text-blue-400 on all three card links', () => {
+    const count = (helpSource.match(/dark:text-blue-400/g) || []).length;
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('dashboard/page.tsx dark-mode button coverage', () => {
+  const dashboardSource = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/[locale]/dashboard/page.tsx'),
+    'utf8',
+  );
+
+  it('Learn More button carries explicit text-gray-700 and dark:text-gray-200', () => {
+    expect(dashboardSource).toContain('text-gray-700');
+    expect(dashboardSource).toContain('dark:text-gray-200');
+  });
+});
+
+describe('campaigns and verification-review dark-mode confirmation', () => {
+  it('campaigns/page.tsx contains at least one dark: variant', () => {
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'src/app/[locale]/campaigns/page.tsx'),
+      'utf8',
+    );
+    expect(src).toMatch(/dark:/);
+  });
+
+  it('verification-review components contain at least one dark: variant', () => {
+    const vrDir = path.join(process.cwd(), 'src/components/verification-review');
+    const combined = readSourceFiles(vrDir).join('\n');
+    expect(combined).toMatch(/dark:/);
+  });
+});

--- a/app/frontend/src/components/ClaimReceipt.tsx
+++ b/app/frontend/src/components/ClaimReceipt.tsx
@@ -41,7 +41,7 @@ function FieldCopyButton({ value, label }: { value: string; label: string }) {
       onClick={copy}
       aria-label={`Copy ${label}`}
       title={`Copy ${label}`}
-      className="ml-1 inline-flex items-center opacity-60 hover:opacity-100 transition-opacity"
+      className="ml-1 inline-flex items-center text-current opacity-60 hover:opacity-100 transition-opacity"
     >
       {copied ? <Check size={12} /> : <Copy size={12} />}
     </button>
@@ -58,19 +58,19 @@ export const ClaimReceipt: React.FC<ClaimReceiptProps> = ({
   const [sharing, setSharing] = React.useState(false);
 
   const statusColors = {
-    requested: 'bg-yellow-50 border-yellow-200 text-yellow-900',
-    verified: 'bg-blue-50 border-blue-200 text-blue-900',
-    approved: 'bg-green-50 border-green-200 text-green-900',
-    disbursed: 'bg-emerald-50 border-emerald-200 text-emerald-900',
-    archived: 'bg-gray-50 border-gray-200 text-gray-900',
+    requested: 'bg-yellow-50 border-yellow-200 text-yellow-900 dark:bg-yellow-950/40 dark:border-yellow-800 dark:text-yellow-200',
+    verified:  'bg-blue-50 border-blue-200 text-blue-900 dark:bg-blue-950/40 dark:border-blue-800 dark:text-blue-200',
+    approved:  'bg-green-50 border-green-200 text-green-900 dark:bg-green-950/40 dark:border-green-800 dark:text-green-200',
+    disbursed: 'bg-emerald-50 border-emerald-200 text-emerald-900 dark:bg-emerald-950/40 dark:border-emerald-800 dark:text-emerald-200',
+    archived:  'bg-gray-50 border-gray-200 text-gray-900 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-200',
   };
 
   const statusBadgeColors = {
-    requested: 'bg-yellow-100 text-yellow-800',
-    verified: 'bg-blue-100 text-blue-800',
-    approved: 'bg-green-100 text-green-800',
-    disbursed: 'bg-emerald-100 text-emerald-800',
-    archived: 'bg-gray-100 text-gray-800',
+    requested: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-200',
+    verified:  'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
+    approved:  'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200',
+    disbursed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200',
+    archived:  'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
   };
 
   const formattedDate = useMemo(() => {
@@ -246,7 +246,7 @@ ${claim.transactionHash ? `Transaction Hash: ${claim.transactionHash}` : ''}`.tr
         <button
           onClick={handleShare}
           disabled={sharing}
-          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 transition-colors disabled:opacity-50 text-sm font-medium"
+          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 dark:bg-white/10 dark:hover:bg-white/20 transition-colors disabled:opacity-50 text-sm font-medium"
           title="Share receipt"
         >
           <Share2 size={16} />
@@ -254,7 +254,7 @@ ${claim.transactionHash ? `Transaction Hash: ${claim.transactionHash}` : ''}`.tr
         </button>
         <button
           onClick={handleCopy}
-          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 transition-colors text-sm font-medium"
+          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 dark:bg-white/10 dark:hover:bg-white/20 transition-colors text-sm font-medium"
           title="Copy to clipboard"
         >
           {copied ? <Check size={16} /> : <Copy size={16} />}
@@ -262,7 +262,7 @@ ${claim.transactionHash ? `Transaction Hash: ${claim.transactionHash}` : ''}`.tr
         </button>
         <button
           onClick={handleDownload}
-          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 transition-colors text-sm font-medium"
+          className="flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-current bg-opacity-10 hover:bg-opacity-20 dark:bg-white/10 dark:hover:bg-white/20 transition-colors text-sm font-medium"
           title="Download receipt"
         >
           <Download size={16} />


### PR DESCRIPTION
closes #738 
- ClaimReceipt: add explicit dark: variants to statusColors (bg/border/text) and statusBadgeColors (bg/text) for all 5 status values (requested, verified, approved, disbursed, archived) — removes reliance on globals.css fallback rules which silently fail inside JS object literals
- ClaimReceipt: add dark:bg-white/10 dark:hover:bg-white/20 to all 3 action buttons (Share, Copy, Download) so they remain visible on dark card surfaces
- ClaimReceipt: add text-current to FieldCopyButton so icon inherits resolved dark-mode foreground from parent card container
- help/page.tsx: add dark:text-blue-400 dark:hover:text-blue-300 to all 3 card links — hover:text-blue-700 was not covered by the global fallback selector list, making link text invisible on hover in dark mode
- dashboard/page.tsx: add text-gray-700 dark:text-gray-200 to the Learn More button so it does not depend on the --foreground CSS variable being resolved
- theme-contrast.test.ts: extend with 4 new describe blocks covering ClaimReceipt color map coverage, help page link hover classes, dashboard button text classes, and confirmation that campaigns + verification-review routes already carry dark: variants