### PR TITLE
feat: enhance migration logic and add version transition error handling

### DIFF
--- a/app/onchain/Cargo.lock
+++ b/app/onchain/Cargo.lock
@@ -580,9 +580,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 
 [[package]]
 name = "ff"

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -75,6 +75,7 @@ pub enum Error {
     MismatchedArrays = 12,
     InsufficientSurplus = 13,
     ContractPaused = 14,
+    InvalidVersionTransition = 15,
 }
 
 // --- Contract Events (indexer-friendly; stable topics & payloads) ---
@@ -230,13 +231,21 @@ impl AidEscrow {
 
         let current_version = Self::get_version(env.clone());
 
-        // Perform version-specific migrations
+        if new_version == current_version {
+            return Ok(());
+        }
+
+        if new_version != current_version + 1 {
+            return Err(Error::InvalidVersionTransition);
+        }
+
+        // Perform version-specific migrations.
         match (current_version, new_version) {
             (1, 2) => {
-                // Future: Add migration logic for v1 -> v2
+                // Future: Add migration logic for v1 -> v2.
             }
             _ => {
-                // No-op for now, but structured for future use
+                // No-op for now, but structured for future use.
             }
         }
 
@@ -1030,20 +1039,20 @@ impl AidEscrow {
             let idx_key = (symbol_short!("pidx"), i);
             if let Some(pkg_id) = env.storage().persistent().get::<_, u64>(&idx_key) {
                 let pkg_key = (symbol_short!("pkg"), pkg_id);
-                if let Some(package) = env.storage().persistent().get::<_, Package>(&pkg_key)
-                    && package.token == token
-                {
-                    match package.status {
-                        PackageStatus::Created => {
-                            total_committed += package.amount;
-                        }
-                        PackageStatus::Claimed => {
-                            total_claimed += package.amount;
-                        }
-                        PackageStatus::Expired
-                        | PackageStatus::Cancelled
-                        | PackageStatus::Refunded => {
-                            total_expired_cancelled += package.amount;
+                if let Some(package) = env.storage().persistent().get::<_, Package>(&pkg_key) {
+                    if package.token == token {
+                        match package.status {
+                            PackageStatus::Created => {
+                                total_committed += package.amount;
+                            }
+                            PackageStatus::Claimed => {
+                                total_claimed += package.amount;
+                            }
+                            PackageStatus::Expired
+                            | PackageStatus::Cancelled
+                            | PackageStatus::Refunded => {
+                                total_expired_cancelled += package.amount;
+                            }
                         }
                     }
                 }
@@ -1067,10 +1076,10 @@ impl AidEscrow {
 
         for id in 0..count {
             let key = (symbol_short!("pkg"), id);
-            if let Some(package) = env.storage().persistent().get::<_, Package>(&key)
-                && package.recipient == recipient
-            {
-                matches += 1;
+            if let Some(package) = env.storage().persistent().get::<_, Package>(&key) {
+                if package.recipient == recipient {
+                    matches += 1;
+                }
             }
         }
 

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_migrate_preserves_state_across_version_bump.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_migrate_preserves_state_across_version_bump.1.json
@@ -1,12 +1,75 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "set_config",
+              "args": [
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "allowed_tokens"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_expires_in"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "min_amount"
+                      },
+                      "val": {
+                        "i128": "7"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "function_name": "pause",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -26,6 +89,9 @@
         }
       ]
     ],
+    [],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -60,6 +126,72 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",
@@ -113,7 +245,11 @@
                                 "symbol": "allowed_tokens"
                               },
                               "val": {
-                                "vec": []
+                                "vec": [
+                                  {
+                                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                  }
+                                ]
                               }
                             },
                             {
@@ -121,7 +257,7 @@
                                 "symbol": "max_expires_in"
                               },
                               "val": {
-                                "u64": "0"
+                                "u64": "3600"
                               }
                             },
                             {
@@ -129,10 +265,18 @@
                                 "symbol": "min_amount"
                               },
                               "val": {
-                                "i128": "1"
+                                "i128": "7"
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "paused"
+                        },
+                        "val": {
+                          "bool": true
                         }
                       },
                       {

--- a/app/onchain/contracts/aid_escrow/test_snapshots/test_migrate_rejects_non_sequential_versions_with_clear_error.1.json
+++ b/app/onchain/contracts/aid_escrow/test_snapshots/test_migrate_rejects_non_sequential_versions_with_clear_error.1.json
@@ -7,25 +7,6 @@
   "auth": [
     [],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "function_name": "migrate",
-              "args": [
-                {
-                  "u32": 2
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
     []
   ],
   "ledger": {
@@ -38,39 +19,6 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": "801925984706572462"
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": "801925984706572462"
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
       [
         {
           "contract_data": {
@@ -140,7 +88,7 @@
                           "symbol": "version"
                         },
                         "val": {
-                          "u32": 2
+                          "u32": 1
                         }
                       }
                     ]

--- a/app/onchain/contracts/aid_escrow/tests/versioning.rs
+++ b/app/onchain/contracts/aid_escrow/tests/versioning.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
-use aid_escrow::{AidEscrow, AidEscrowClient};
-use soroban_sdk::{Address, Env, testutils::Address as _};
+use aid_escrow::{AidEscrow, AidEscrowClient, Config};
+use soroban_sdk::{Address, Env, Vec, testutils::Address as _};
 
 #[test]
 fn test_version_set_on_init() {
@@ -20,26 +20,16 @@ fn test_version_set_on_init() {
 #[test]
 fn test_migrate_admin_only() {
     let env = Env::default();
+    env.mock_all_auths();
 
     let admin = Address::generate(&env);
     let contract_id = env.register(AidEscrow, ());
     let client = AidEscrowClient::new(&env, &contract_id);
 
-    env.mock_all_auths();
     client.init(&admin);
-
-    // Admin can migrate
-    env.mock_all_auths();
     client.migrate(&2);
-    assert_eq!(client.get_version(), 2);
 
-    // Non-admin cannot migrate (would fail auth check)
-    // This test verifies the function requires admin auth
-    env.mock_all_auths_allowing_non_root_auth();
-    let res = client.try_migrate(&3);
-    // Without proper auth, this should fail
-    // In mock_all_auths mode, it passes, but in real scenario only admin can call
-    assert!(res.is_ok()); // In mock mode, but structure is correct
+    assert_eq!(client.get_version(), 2);
 }
 
 #[test]
@@ -59,4 +49,46 @@ fn test_migrate_version_progression() {
 
     client.migrate(&3);
     assert_eq!(client.get_version(), 3);
+}
+
+#[test]
+fn test_migrate_preserves_state_across_version_bump() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+
+    client.init(&admin);
+
+    let config = Config {
+        min_amount: 7,
+        max_expires_in: 3600,
+        allowed_tokens: Vec::from_array(&env, [Address::generate(&env)]),
+    };
+    client.set_config(&config);
+    client.pause();
+
+    client.migrate(&2);
+
+    assert_eq!(client.get_version(), 2);
+    assert_eq!(client.get_config(), config);
+    assert!(client.is_paused());
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_migrate_rejects_non_sequential_versions_with_clear_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+
+    client.init(&admin);
+
+    let res = client.try_migrate(&3);
+    assert!(res.is_err(), "non-sequential migrations should fail loudly");
 }


### PR DESCRIPTION
#closes
#573 

PR Documentation
Summary
This PR adds a minimal upgrade/migration harness for the AidEscrow Soroban contract, ensuring version upgrades are validated and state-compatible across versions.

What changed
lib.rs
Added Error::InvalidVersionTransition
Updated migrate() to:
require admin authorization
allow same-version no-op
allow only sequential version bumps (current + 1)
reject unsupported jumps
retain the migration structure for future version-specific work
versioning.rs
Added / expanded tests covering:
initial contract version on init()
admin migration behavior
sequential version progression
preservation of state across a migration
rejection of non-sequential migration jumps
Why
Matches the assignment requirement to validate upgrade/migration rules
Provides a clear compatibility path for future contract versions
Makes migration failure output explicit and testable

#closes