### PR TITLE
feat(onchain): add deployment registry schema, guide, and init args

### DIFF
--- a/app/onchain/deployments/README.md
+++ b/app/onchain/deployments/README.md
@@ -1,0 +1,80 @@
+# Deployment Registry
+
+This folder is the single source of truth for on-chain **AidEscrow** deployments.
+It records every deployed contract, the exact build it came from, and the
+configuration used to initialize it, so that the backend, frontend, mobile, CI,
+and contributors can all resolve the current (and historical) contract IDs from
+one place.
+
+## Files
+
+| File                    | Purpose                                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| `registry.json`         | Machine-readable index of all deployments (one entry per deploy).                              |
+| `registry.schema.json`  | JSON Schema (draft 2020-12) that `registry.json` must satisfy.                                 |
+| `testnet-YYYY-MM-DD.md` | Human-readable record for a single deployment (tx hashes, verification steps, explorer links). |
+
+`registry.json` is the authoritative, parseable list. Each entry links to its
+detailed `record` markdown for the full deploy narrative.
+
+## Registry format
+
+Each object in the `deployments` array has this shape (see `registry.schema.json`
+for the authoritative rules):
+
+    {
+      "network": "testnet",
+      "version": "0.1.0",
+      "contract_id": "C...",
+      "wasm_hash": "<64 hex chars>",
+      "deployer": "G...",
+      "init_args": { "admin": "G..." },
+      "deployed_at": "2026-06-03",
+      "git_commit": "<source commit sha or null>",
+      "version_tag": "v0.1.0-testnet",
+      "record": "deployments/testnet-2026-06-03.md"
+    }
+
+### Field reference
+
+| Field         | Type           | Description                                                                                        |
+| ------------- | -------------- | -------------------------------------------------------------------------------------------------- |
+| `network`     | string         | `testnet`, `futurenet`, or `mainnet`.                                                              |
+| `version`     | string         | Contract crate version (`Cargo.toml`), e.g. `0.1.0`.                                               |
+| `contract_id` | string         | Deployed contract ID (56-char `C...` strkey).                                                      |
+| `wasm_hash`   | string         | SHA-256 of the uploaded WASM (64 hex chars).                                                       |
+| `deployer`    | string         | Public key that uploaded and created the contract.                                                 |
+| `init_args`   | object         | Arguments passed to `init()`. Must include `admin`.                                                |
+| `deployed_at` | string         | Deploy date (`YYYY-MM-DD`) or ISO-8601 timestamp.                                                  |
+| `git_commit`  | string \| null | Source commit the build came from. `null` only for legacy entries recorded before commit tracking. |
+| `version_tag` | string         | Git release tag, e.g. `v0.1.0-testnet`.                                                            |
+| `record`      | string         | Path (relative to `app/onchain`) to the detailed record markdown.                                  |
+
+Entries are ordered oldest to newest; the **last** entry is the current
+deployment.
+
+## Adding a new deployment entry
+
+After you deploy (follow the testnet deploy runbook at
+`../DEPLOY_TESTNET_RUNBOOK.md`), append a new object to the `deployments` array.
+Gather the values like this:
+
+1. `contract_id` — printed by `make deploy` / `deploy.sh` (also saved to `.env`).
+2. `wasm_hash` — run `sha256sum target/wasm32v1-none/release/aid_escrow.wasm`.
+3. `deployer` — run `soroban keys address "$SECRET_KEY"`.
+4. `init_args.admin` — the `--admin` value passed to `initialize.sh`.
+5. `git_commit` — the exact source commit you built from: `git rev-parse HEAD`.
+6. `deployed_at` — today's date (`date +%F`) or a full ISO-8601 timestamp.
+7. `version` and `version_tag` — the crate version and its git tag.
+8. `record` — create `deployments/testnet-YYYY-MM-DD.md` for the full narrative
+   and point `record` at it.
+
+## Validating the registry
+
+The registry should always satisfy `registry.schema.json`. Validate it locally
+with any JSON Schema validator, for example:
+
+    npx ajv-cli validate -s app/onchain/deployments/registry.schema.json -d app/onchain/deployments/registry.json --spec=draft2020
+
+Many editors (VS Code) validate automatically thanks to the `$schema` reference
+at the top of `registry.json`.

--- a/app/onchain/deployments/registry.json
+++ b/app/onchain/deployments/registry.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./registry.schema.json",
   "schema_version": 1,
   "contract": "aid_escrow",
   "deployments": [
@@ -8,7 +9,11 @@
       "contract_id": "CDSBJ27PKTNFTRW6OKPCVXDRUSSRUIQUG6DW5PUTKLDXTDT23NQIS6JG",
       "wasm_hash": "24328e15b7c11c7ff07caeaf0328da591b3b63e84af57fa03623c10126eabc8d",
       "deployer": "GA5TBSBGERHVMEFBJGEM3KYMRLWO73Y2QRAV6P66GPEBOJ5ZMJUT7LLY",
+      "init_args": {
+        "admin": "GA5TBSBGERHVMEFBJGEM3KYMRLWO73Y2QRAV6P66GPEBOJ5ZMJUT7LLY"
+      },
       "deployed_at": "2026-06-03",
+      "git_commit": null,
       "version_tag": "v0.1.0-testnet",
       "record": "deployments/testnet-2026-06-03.md"
     }

--- a/app/onchain/deployments/registry.schema.json
+++ b/app/onchain/deployments/registry.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Pulsefy/Soter/app/onchain/deployments/registry.schema.json",
+  "title": "AidEscrow Deployment Registry",
+  "description": "Machine-readable source of truth for on-chain AidEscrow deployments (contract IDs and initialization configuration). One entry per deployment, ordered oldest to newest.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "contract", "deployments"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional relative path to this schema so editors can validate the registry."
+    },
+    "schema_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Version of this registry file format."
+    },
+    "contract": {
+      "type": "string",
+      "description": "Contract crate name, e.g. \"aid_escrow\"."
+    },
+    "deployments": {
+      "type": "array",
+      "description": "Deployment records, ordered oldest to newest.",
+      "items": { "$ref": "#/$defs/deployment" }
+    }
+  },
+  "$defs": {
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "network",
+        "version",
+        "contract_id",
+        "wasm_hash",
+        "deployer",
+        "init_args",
+        "deployed_at",
+        "git_commit",
+        "version_tag",
+        "record"
+      ],
+      "properties": {
+        "network": {
+          "type": "string",
+          "enum": ["testnet", "futurenet", "mainnet"],
+          "description": "Stellar network the contract was deployed to."
+        },
+        "version": {
+          "type": "string",
+          "description": "Contract crate version, e.g. \"0.1.0\"."
+        },
+        "contract_id": {
+          "type": "string",
+          "pattern": "^C[A-Z2-7]{55}$",
+          "description": "Deployed contract ID (56-character C... strkey)."
+        },
+        "wasm_hash": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 hash of the uploaded WASM (64 hex characters)."
+        },
+        "deployer": {
+          "type": "string",
+          "pattern": "^G[A-Z2-7]{55}$",
+          "description": "Public key of the deploying account (56-character G... strkey)."
+        },
+        "init_args": {
+          "type": "object",
+          "description": "Arguments passed to init() at deployment time.",
+          "required": ["admin"],
+          "additionalProperties": true,
+          "properties": {
+            "admin": {
+              "type": "string",
+              "pattern": "^G[A-Z2-7]{55}$",
+              "description": "Admin address set at initialization."
+            }
+          }
+        },
+        "deployed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}([T ].*)?$",
+          "description": "Deployment date (YYYY-MM-DD) or ISO-8601 timestamp."
+        },
+        "git_commit": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "Git commit SHA of the source build. Null for legacy entries recorded before commit tracking."
+        },
+        "version_tag": {
+          "type": "string",
+          "description": "Git tag for the release, e.g. \"v0.1.0-testnet\"."
+        },
+        "record": {
+          "type": "string",
+          "description": "Path (relative to app/onchain) to the human-readable deployment record markdown."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a machine-readable deployment registry for the `aid_escrow` contract on Soroban testnet, together with a JSON Schema (draft 2020-12) that validates every entry and a human-readable maintainer guide.

**Files added**
- `app/onchain/deployments/registry.json` – first testnet deployment record (contract ID, WASM hash, deployer, init args, date, version tag).
- `app/onchain/deployments/registry.schema.json` – JSON Schema; editors and CI can validate against it automatically via the `$schema` reference.
- `app/onchain/deployments/README.md` – contributor guide: file layout, field reference table, step-by-step instructions for future deployments, and validation command.

**Why**
Provides the canonical source of truth for on-chain contract IDs so backend, frontend, mobile, and CI all resolve current (and historical) contract addresses from one place.

Closes #410