### PR TITLE
feat(ai-service): add guaranteed log redaction filter with tests

### DIFF
--- a/app/ai-service/logging_redaction.py
+++ b/app/ai-service/logging_redaction.py
@@ -1,0 +1,181 @@
+"""Guaranteed log redaction for the Soter AI service.
+
+This module provides a dependency-free ``logging.Filter`` that masks
+personally identifiable information (PII) and secrets *before* a log record
+is emitted, no matter which handler or formatter is attached. It is designed
+to sit on the same handler that already emits structured JSON logs in
+``main.py`` so that request/response payload logging paths can never leak
+sensitive values.
+
+Design goals:
+
+* **No third-party dependencies.** Redaction runs on the logging hot path, so
+  it relies only on the standard library (``re`` and ``logging``). The heavier
+  spaCy-based scrubber in ``services/pii_scrubber.py`` is intended for request
+  *payloads*, not for the synchronous logging path.
+* **Fail safe.** The filter never drops a record and never raises; if anything
+  goes wrong it falls back to the raw message string.
+* **Format agnostic.** Because redaction happens on the ``LogRecord`` itself
+  (message, positional args, and any ``extra`` string fields), the output is
+  masked whether the handler renders plain text or JSON.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Optional, Pattern
+
+__all__ = [
+    "REDACTION_PLACEHOLDER",
+    "redact",
+    "RedactionFilter",
+    "install_redaction_filter",
+]
+
+#: Text substituted in place of any detected sensitive value.
+REDACTION_PLACEHOLDER = "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# Key/value secrets such as ``api_key=abc123`` or ``"password": "hunter2"``.
+# Only the value is masked so the surrounding structure stays readable.
+_SECRET_KEY_PATTERN: Pattern[str] = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret"
+    r"|secret|password|passwd|pwd|authorization|auth[_-]?token|token)"
+    r"(\"?\s*[:=]\s*)(\"?)([^\s\"',}]+)(\"?)"
+)
+
+
+def _redact_secret_kv(match: "re.Match[str]") -> str:
+    key, sep, open_quote, _value, close_quote = match.groups()
+    return f"{key}{sep}{open_quote}{REDACTION_PLACEHOLDER}{close_quote}"
+
+
+# Standalone value patterns. Each match is replaced wholesale with the
+# placeholder. Order matters: more specific/secret patterns run first so a
+# broader pattern cannot partially match a token.
+_PATTERNS: List[Pattern[str]] = [
+    # Bearer authorization headers.
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]+"),
+    # JSON Web Tokens (header.payload.signature).
+    re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+"),
+    # OpenAI-style secret keys.
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    # Email addresses.
+    re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
+    # US Social Security numbers (3-2-4). The (?<![\w-]) / (?![\w-]) guards
+    # stop these numeric patterns from firing inside hyphenated alphanumeric
+    # tokens such as UUID correlation IDs or content hashes.
+    re.compile(r"(?<![\w-])\d{3}-\d{2}-\d{4}(?![\w-])"),
+    # Grouped 16-digit card numbers (e.g. 4111 1111 1111 1111).
+    re.compile(r"(?<![\w-])\d{4}(?:[ \-]?\d{4}){3}(?![\w-])"),
+    # American Express style 15-digit cards (4-6-5).
+    re.compile(r"(?<![\w-])\d{4}[ \-]?\d{6}[ \-]?\d{5}(?![\w-])"),
+    # Phone numbers (optional country code, 3-3-4 core).
+    re.compile(
+        r"(?<![\w-])(?:\+?\d{1,3}[ .\-]?)?(?:\(\d{3}\)|\d{3})[ .\-]?\d{3}"
+        r"[ .\-]?\d{4}(?![\w-])"
+    ),
+    # IPv4 addresses (strict octets to avoid matching version strings).
+    re.compile(
+        r"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}"
+        r"(?:25[0-5]|2[0-4]\d|1?\d?\d)\b"
+    ),
+]
+
+
+def redact(text: str) -> str:
+    """Return ``text`` with any detected PII or secrets masked.
+
+    The function is idempotent: redacting already-redacted text is a no-op
+    because the placeholder contains no characters that match a pattern.
+    """
+    if not text:
+        return text
+    result = _SECRET_KEY_PATTERN.sub(_redact_secret_kv, text)
+    for pattern in _PATTERNS:
+        result = pattern.sub(REDACTION_PLACEHOLDER, result)
+    return result
+
+
+# Standard ``LogRecord`` attributes that must not be treated as ``extra``
+# fields and should never be rewritten by the filter.
+_RESERVED_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+        "taskName",
+    }
+)
+
+
+class RedactionFilter(logging.Filter):
+    """A ``logging.Filter`` that masks PII/secrets on every record.
+
+    Attach it to a handler (preferred, so it covers every record flowing
+    through that handler) or to a logger. It rewrites the fully-rendered
+    message and any string values supplied via ``extra=...`` so that the
+    emitted output -- plain text or JSON -- is always redacted.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            # Fall back to the raw template if arg interpolation fails; we
+            # still redact it and never let the filter break logging.
+            message = str(record.msg)
+
+        record.msg = redact(message)
+        # Args are already folded into the message above; clearing them
+        # prevents a second (now redacted) interpolation pass.
+        record.args = None
+
+        for key, value in list(record.__dict__.items()):
+            if key in _RESERVED_ATTRS:
+                continue
+            if isinstance(value, str):
+                record.__dict__[key] = redact(value)
+
+        # Never drop a record.
+        return True
+
+
+def install_redaction_filter(
+    logger: Optional[logging.Logger] = None,
+) -> RedactionFilter:
+    """Attach a :class:`RedactionFilter` to every handler on ``logger``.
+
+    Defaults to the root logger. Returns the installed filter so callers can
+    reuse or remove it. Attaching to handlers (rather than the logger) ensures
+    records propagated from child loggers are also redacted.
+    """
+    target = logger if logger is not None else logging.getLogger()
+    redaction_filter = RedactionFilter()
+    for handler in target.handlers:
+        handler.addFilter(redaction_filter)
+    return redaction_filter

--- a/app/ai-service/main.py
+++ b/app/ai-service/main.py
@@ -11,6 +11,7 @@ import logging
 import uuid
 from contextvars import ContextVar
 from pythonjsonlogger import jsonlogger
+from logging_redaction import RedactionFilter
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Request, Response
 from fastapi.exceptions import RequestValidationError
@@ -76,6 +77,7 @@ json_formatter = jsonlogger.JsonFormatter(
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(json_formatter)
 stream_handler.addFilter(CorrelationIdFilter())
+stream_handler.addFilter(RedactionFilter())
 root_logger.addHandler(stream_handler)
 
 # Get logger for this module

--- a/app/ai-service/tests/test_logging_redaction.py
+++ b/app/ai-service/tests/test_logging_redaction.py
@@ -1,0 +1,142 @@
+"""Tests proving PII/secrets never reach the logs via RedactionFilter."""
+
+import io
+import logging
+import uuid
+
+import pytest
+
+from logging_redaction import (
+    REDACTION_PLACEHOLDER,
+    RedactionFilter,
+    install_redaction_filter,
+    redact,
+)
+
+# Representative sensitive values that must never survive redaction.
+PII_SAMPLES = {
+    "email": "jane.doe@example.com",
+    "phone": "+1 (415) 555-0132",
+    "ssn": "123-45-6789",
+    "credit_card": "4111 1111 1111 1111",
+    "amex": "3782 822463 10005",
+    "ipv4": "192.168.1.42",
+    "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3",
+    "openai_key": "sk-abcdefghijklmnopqrstuvwxyz012345",
+}
+
+
+def _make_logger(name):
+    """Return an isolated logger writing to an in-memory buffer.
+
+    A RedactionFilter is attached to the handler, mirroring how main.py
+    wires the filter onto its stream handler.
+    """
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    buffer = io.StringIO()
+    handler = logging.StreamHandler(buffer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(RedactionFilter())
+    logger.addHandler(handler)
+    return logger, buffer
+
+
+@pytest.mark.parametrize("label,value", list(PII_SAMPLES.items()))
+def test_redact_masks_each_pii_category(label, value):
+    masked = redact(f"payload contains {value} here")
+    assert value not in masked, f"{label} leaked: {masked!r}"
+    assert REDACTION_PLACEHOLDER in masked
+
+
+def test_secret_key_value_preserves_key():
+    masked = redact('{"password": "hunter2", "api_key": "abc123XYZ"}')
+    assert "hunter2" not in masked
+    assert "abc123XYZ" not in masked
+    # The keys themselves must remain so logs stay diagnosable.
+    assert "password" in masked
+    assert "api_key" in masked
+
+
+def test_non_pii_is_preserved():
+    line = "GET /api/v1/verify 200 latency=0.0042s version=1.0.0"
+    assert redact(line) == line
+
+
+def test_redact_is_idempotent():
+    once = redact("email jane.doe@example.com and ip 10.0.0.7")
+    assert redact(once) == once
+
+
+def test_filter_masks_message_in_captured_logs():
+    logger, buffer = _make_logger("soter.redaction.msg")
+    logger.info("user login email=jane.doe@example.com ssn 123-45-6789")
+    output = buffer.getvalue()
+    assert "jane.doe@example.com" not in output
+    assert "123-45-6789" not in output
+    assert REDACTION_PLACEHOLDER in output
+
+
+def test_filter_masks_percent_args():
+    logger, buffer = _make_logger("soter.redaction.args")
+    logger.warning("payment from card %s failed", "4111 1111 1111 1111")
+    output = buffer.getvalue()
+    assert "4111 1111 1111 1111" not in output
+    assert REDACTION_PLACEHOLDER in output
+
+
+def test_filter_masks_extra_fields():
+    logger, buffer = _make_logger("soter.redaction.extra")
+    logger.info("request received", extra={"client_ip": "192.168.1.42"})
+    # The record attribute itself is redacted, so any formatter that emits
+    # extra fields (e.g. JSON) is also safe.
+    output = buffer.getvalue()
+    assert "192.168.1.42" not in output
+
+
+def test_filter_never_drops_records():
+    logger, buffer = _make_logger("soter.redaction.keep")
+    logger.info("nothing sensitive here")
+    assert "nothing sensitive here" in buffer.getvalue()
+
+
+def test_no_pii_sample_survives_full_pipeline():
+    logger, buffer = _make_logger("soter.redaction.sweep")
+    for value in PII_SAMPLES.values():
+        logger.info("field=%s", value)
+    output = buffer.getvalue()
+    for value in PII_SAMPLES.values():
+        assert value not in output, f"leaked: {value!r}"
+
+
+# Digit-heavy UUIDs that must never be clipped by the numeric patterns.
+CORRELATION_IDS = [
+    "12345678-9012-3456-7890-123456789012",
+    "00000000-0000-0000-0000-000000000000",
+    "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+]
+
+
+@pytest.mark.parametrize("correlation_id", CORRELATION_IDS)
+def test_correlation_id_is_not_mangled(correlation_id):
+    # UUID correlation IDs must be preserved for traceability.
+    assert redact(correlation_id) == correlation_id
+
+
+def test_random_correlation_ids_survive():
+    for _ in range(200):
+        correlation_id = str(uuid.uuid4())
+        assert redact(correlation_id) == correlation_id
+
+
+def test_install_redaction_filter_attaches_to_handlers():
+    logger = logging.getLogger("soter.redaction.install")
+    logger.handlers.clear()
+    buffer = io.StringIO()
+    handler = logging.StreamHandler(buffer)
+    logger.addHandler(handler)
+    installed = install_redaction_filter(logger)
+    assert isinstance(installed, RedactionFilter)
+    assert installed in handler.filters


### PR DESCRIPTION
Adds a dependency-free logging.Filter that masks PII and secrets (emails, phone numbers, SSNs, card numbers, IPs, JWTs, API keys, and password/token key-values) on every log record, wired into the existing JSON stream handler so request/response logging paths cannot leak sensitive data. Correlation IDs are preserved. Includes tests asserting PII-like strings never appear in captured logs.

Closes #461