### PR TITLE
feat(#740): add realtime review queue refresh indicators

### DIFF
--- a/app/frontend/src/components/verification-review/QueueFreshnessBar.tsx
+++ b/app/frontend/src/components/verification-review/QueueFreshnessBar.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+/**
+ * QueueFreshnessBar
+ *
+ * Shows:
+ *  - Last refresh timestamp ("Updated 12 seconds ago" / exact time when stale)
+ *  - Animated spinner while a background refetch is in progress
+ *  - Refresh latency badge (e.g. "142 ms")
+ *  - Error state when the last fetch failed
+ *  - Manual "Refresh" button
+ *
+ * Designed to be placed above or below the ReviewQueue list so reviewers
+ * always know how fresh their view is.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  RefreshCw,
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Wifi,
+  WifiOff,
+} from 'lucide-react';
+import type { QueueRefreshStatus } from '@/hooks/useVerificationInbox';
+
+interface QueueFreshnessBarProps {
+  status: QueueRefreshStatus;
+  /** Auto-refresh interval in ms (informational only, used to decide "stale" threshold) */
+  autoRefreshMs?: number;
+}
+
+/** Format a duration as a short human-readable string. */
+function formatAge(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 5) return 'just now';
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  return `${h}h ago`;
+}
+
+/** Format an exact time as HH:MM:SS. */
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+/** Format latency with appropriate precision. */
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+export function QueueFreshnessBar({
+  status,
+  autoRefreshMs = 30_000,
+}: QueueFreshnessBarProps) {
+  const { lastRefreshedAt, isRefreshing, latencyMs, hasError, refresh } = status;
+
+  // Tick every second to keep the relative timestamp live
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick(t => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const ageMs = lastRefreshedAt > 0 ? Date.now() - lastRefreshedAt : null;
+  // Consider data stale when it's older than 1.5× the auto-refresh interval
+  const isStale = ageMs !== null && ageMs > autoRefreshMs * 1.5;
+  const neverFetched = lastRefreshedAt === 0;
+
+  // ── Derive status label ───────────────────────────────────────────────────
+
+  let statusIcon: React.ReactNode;
+  let statusLabel: string;
+  let statusClass: string;
+
+  if (isRefreshing) {
+    statusIcon = (
+      <RefreshCw
+        size={13}
+        className="animate-spin text-blue-500 dark:text-blue-400"
+        aria-hidden="true"
+      />
+    );
+    statusLabel = 'Refreshing…';
+    statusClass = 'text-blue-600 dark:text-blue-400';
+  } else if (hasError) {
+    statusIcon = (
+      <WifiOff size={13} className="text-red-500 dark:text-red-400" aria-hidden="true" />
+    );
+    statusLabel = 'Refresh failed';
+    statusClass = 'text-red-600 dark:text-red-400';
+  } else if (neverFetched) {
+    statusIcon = (
+      <Clock size={13} className="text-gray-400 dark:text-gray-500" aria-hidden="true" />
+    );
+    statusLabel = 'Loading…';
+    statusClass = 'text-gray-500 dark:text-gray-400';
+  } else if (isStale) {
+    statusIcon = (
+      <AlertTriangle
+        size={13}
+        className="text-amber-500 dark:text-amber-400"
+        aria-hidden="true"
+      />
+    );
+    statusLabel = `Stale — updated ${formatAge(ageMs!)} (${formatTime(lastRefreshedAt)})`;
+    statusClass = 'text-amber-600 dark:text-amber-400';
+  } else {
+    statusIcon = (
+      <CheckCircle2
+        size={13}
+        className="text-green-500 dark:text-green-400"
+        aria-hidden="true"
+      />
+    );
+    statusLabel =
+      ageMs !== null
+        ? `Updated ${formatAge(ageMs)} (${formatTime(lastRefreshedAt)})`
+        : 'Up to date';
+    statusClass = 'text-green-700 dark:text-green-400';
+  }
+
+  // ── Connection pill ───────────────────────────────────────────────────────
+
+  const connectionPill = hasError ? (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300"
+      title="Last refresh attempt failed — data may be outdated"
+    >
+      <WifiOff size={10} aria-hidden="true" />
+      Offline
+    </span>
+  ) : (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300"
+      title="Connected — data is being refreshed automatically"
+    >
+      <Wifi size={10} aria-hidden="true" />
+      Live
+    </span>
+  );
+
+  return (
+    <div
+      className={`flex flex-wrap items-center justify-between gap-2 px-3 py-1.5 rounded-lg text-xs border transition-colors ${
+        hasError
+          ? 'bg-red-50 dark:bg-red-900/10 border-red-200 dark:border-red-800'
+          : isStale
+            ? 'bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-800'
+            : 'bg-gray-50 dark:bg-gray-800/50 border-gray-100 dark:border-gray-700'
+      }`}
+      role="status"
+      aria-live="polite"
+      aria-label={`Queue freshness: ${statusLabel}`}
+    >
+      {/* Left: icon + status text + connection pill */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className={`flex items-center gap-1 font-medium ${statusClass}`}>
+          {statusIcon}
+          <span>{statusLabel}</span>
+        </span>
+
+        {connectionPill}
+
+        {/* Latency badge */}
+        {latencyMs !== null && !neverFetched && (
+          <span
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+            title={`Last refresh took ${formatLatency(latencyMs)}`}
+            aria-label={`Last fetch latency: ${formatLatency(latencyMs)}`}
+          >
+            <Clock size={10} aria-hidden="true" />
+            {formatLatency(latencyMs)}
+          </span>
+        )}
+      </div>
+
+      {/* Right: refresh button */}
+      <button
+        onClick={refresh}
+        disabled={isRefreshing}
+        aria-label="Manually refresh the review queue"
+        className="flex items-center gap-1 px-2.5 py-1 rounded-md border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-[11px] font-medium"
+      >
+        <RefreshCw
+          size={11}
+          className={isRefreshing ? 'animate-spin' : ''}
+          aria-hidden="true"
+        />
+        Refresh
+      </button>
+    </div>
+  );
+}

--- a/app/frontend/src/components/verification-review/ReviewQueue.tsx
+++ b/app/frontend/src/components/verification-review/ReviewQueue.tsx
@@ -2,10 +2,22 @@
 
 import React, { useState } from 'react';
 import { format } from 'date-fns';
-import { ChevronLeft, ChevronRight, Inbox } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Inbox,
+  Loader2,
+  AlertCircle,
+  RefreshCw,
+} from 'lucide-react';
 import { StatusBadge, RiskBadge } from './StatusBadge';
 import { VerificationDetailPanel } from './VerificationDetailPanel';
-import { useInbox } from '@/hooks/useVerificationInbox';
+import { QueueFreshnessBar } from './QueueFreshnessBar';
+import {
+  useInboxWithLatency,
+  useQueueRefreshStatus,
+  useOptimisticItemState,
+} from '@/hooks/useVerificationInbox';
 import type { ReviewFilters, RiskLevel } from '@/types/verification-review';
 
 interface ReviewQueueProps {
@@ -14,114 +26,200 @@ interface ReviewQueueProps {
 }
 
 export function ReviewQueue({ filters, onPageChange }: ReviewQueueProps) {
-  const { data, isLoading, isError, error } = useInbox(filters);
+  const { data, isLoading, isError, error, isFetching } = useInboxWithLatency(filters);
+  const refreshStatus = useQueueRefreshStatus(filters);
+  const { pendingIds, failedIds } = useOptimisticItemState();
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
-  if (isLoading) {
+  // Initial hard load (no cached data yet)
+  if (isLoading && !data) {
     return (
-      <div className="space-y-2 animate-pulse">
-        {[1, 2, 3, 4, 5].map(i => (
-          <div
-            key={i}
-            className="h-16 rounded-lg bg-gray-100 dark:bg-gray-800"
-          />
-        ))}
+      <div className="space-y-3">
+        {/* Show a placeholder freshness bar while loading */}
+        <div className="h-8 rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        <div className="space-y-2 animate-pulse">
+          {[1, 2, 3, 4, 5].map(i => (
+            <div
+              key={i}
+              className="h-16 rounded-lg bg-gray-100 dark:bg-gray-800"
+            />
+          ))}
+        </div>
       </div>
     );
   }
 
-  if (isError) {
+  if (isError && !data) {
     return (
-      <div className="p-6 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-sm text-red-700 dark:text-red-300">
-        Failed to load queue: {(error as Error).message}
+      <div className="space-y-3">
+        <div className="p-6 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 text-sm text-red-700 dark:text-red-300">
+          Failed to load queue: {(error as Error).message}
+        </div>
+        <button
+          onClick={refreshStatus.refresh}
+          className="flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          <RefreshCw size={14} aria-hidden="true" />
+          Retry
+        </button>
       </div>
     );
   }
 
   if (!data || data.items.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-gray-400 dark:text-gray-500 gap-3">
-        <Inbox size={36} strokeWidth={1.5} />
-        <p className="text-sm">
-          No verification cases match the current filters.
-        </p>
+      <div className="space-y-3">
+        <QueueFreshnessBar status={refreshStatus} />
+        <div className="flex flex-col items-center justify-center py-16 text-gray-400 dark:text-gray-500 gap-3">
+          <Inbox size={36} strokeWidth={1.5} />
+          <p className="text-sm">
+            No verification cases match the current filters.
+          </p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex gap-4 min-h-0">
-      {/* List */}
-      <div className="flex-1 min-w-0 space-y-2">
-        {data.items.map(item => (
-          <button
-            key={item.id}
-            onClick={() =>
-              setSelectedId(item.id === selectedId ? null : item.id)
-            }
-            className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
-              selectedId === item.id
-                ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                : 'border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-gray-200 dark:hover:border-gray-700'
-            }`}
-          >
-            <div className="flex items-center justify-between gap-3 flex-wrap">
-              <div className="flex items-center gap-2 min-w-0">
-                <span className="font-mono text-xs text-gray-400 dark:text-gray-500 truncate max-w-[140px]">
-                  {item.id}
-                </span>
-                <StatusBadge status={item.status} />
-                {item.riskLevel && (
-                  <RiskBadge level={item.riskLevel as RiskLevel} />
-                )}
-              </div>
-              <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
-                {format(new Date(item.createdAt), 'dd MMM yyyy')}
-              </span>
-            </div>
-            {item.nextStepMessage && (
-              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
-                {item.nextStepMessage}
-              </p>
-            )}
-          </button>
-        ))}
+    <div className="space-y-3">
+      {/* ── Freshness bar ─────────────────────────────────────────────── */}
+      <QueueFreshnessBar status={refreshStatus} />
 
-        {/* Pagination */}
-        {data.totalPages > 1 && (
-          <div className="flex items-center justify-between pt-2">
-            <span className="text-xs text-gray-500 dark:text-gray-400">
-              Page {data.page} of {data.totalPages} · {data.total} total
-            </span>
-            <div className="flex gap-1">
+      {/* ── Background-refetch shimmer on the list ────────────────────── */}
+      {isFetching && !isLoading && (
+        <div className="flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400">
+          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+          <span>Syncing…</span>
+        </div>
+      )}
+
+      <div className="flex gap-4 min-h-0">
+        {/* ── Queue list ──────────────────────────────────────────────── */}
+        <div className="flex-1 min-w-0 space-y-2">
+          {data.items.map(item => {
+            const isPending = pendingIds.has(item.id);
+            const isFailed = failedIds.has(item.id);
+
+            return (
               <button
-                onClick={() => onPageChange(data.page - 1)}
-                disabled={data.page <= 1}
-                className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                key={item.id}
+                onClick={() =>
+                  setSelectedId(item.id === selectedId ? null : item.id)
+                }
+                disabled={isPending}
+                aria-busy={isPending}
+                aria-label={`Verification ${item.id}${isPending ? ' — action in progress' : ''}${isFailed ? ' — action failed' : ''}`}
+                className={[
+                  'w-full text-left px-4 py-3 rounded-lg border transition-colors relative',
+                  isPending
+                    ? 'border-blue-300 dark:border-blue-700 bg-blue-50/60 dark:bg-blue-900/10 cursor-wait opacity-80'
+                    : isFailed
+                      ? 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/10'
+                      : selectedId === item.id
+                        ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
+                        : 'border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 hover:border-gray-200 dark:hover:border-gray-700',
+                ].join(' ')}
               >
-                <ChevronLeft size={14} />
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                    <span className="font-mono text-xs text-gray-400 dark:text-gray-500 truncate max-w-[140px]">
+                      {item.id}
+                    </span>
+                    <StatusBadge status={item.status} />
+                    {item.riskLevel && (
+                      <RiskBadge level={item.riskLevel as RiskLevel} />
+                    )}
+
+                    {/* Pending spinner */}
+                    {isPending && (
+                      <span
+                        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300"
+                        title="Action in progress…"
+                      >
+                        <Loader2
+                          size={10}
+                          className="animate-spin"
+                          aria-hidden="true"
+                        />
+                        Saving…
+                      </span>
+                    )}
+
+                    {/* Failed badge */}
+                    {isFailed && !isPending && (
+                      <span
+                        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-medium bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300"
+                        title="Action failed — data has been rolled back"
+                        role="alert"
+                      >
+                        <AlertCircle size={10} aria-hidden="true" />
+                        Failed
+                      </span>
+                    )}
+                  </div>
+
+                  <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                    {format(new Date(item.createdAt), 'dd MMM yyyy')}
+                  </span>
+                </div>
+
+                {item.nextStepMessage && (
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {item.nextStepMessage}
+                  </p>
+                )}
+
+                {/* Failed retry hint */}
+                {isFailed && !isPending && (
+                  <p
+                    className="mt-1 text-xs text-red-500 dark:text-red-400"
+                    role="alert"
+                  >
+                    Action failed — please try again.
+                  </p>
+                )}
               </button>
-              <button
-                onClick={() => onPageChange(data.page + 1)}
-                disabled={data.page >= data.totalPages}
-                className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronRight size={14} />
-              </button>
+            );
+          })}
+
+          {/* Pagination */}
+          {data.totalPages > 1 && (
+            <div className="flex items-center justify-between pt-2">
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Page {data.page} of {data.totalPages} · {data.total} total
+              </span>
+              <div className="flex gap-1">
+                <button
+                  onClick={() => onPageChange(data.page - 1)}
+                  disabled={data.page <= 1}
+                  aria-label="Previous page"
+                  className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronLeft size={14} />
+                </button>
+                <button
+                  onClick={() => onPageChange(data.page + 1)}
+                  disabled={data.page >= data.totalPages}
+                  aria-label="Next page"
+                  className="h-8 w-8 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  <ChevronRight size={14} />
+                </button>
+              </div>
             </div>
+          )}
+        </div>
+
+        {/* Detail panel */}
+        {selectedId && (
+          <div className="w-80 shrink-0 rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden flex flex-col">
+            <VerificationDetailPanel
+              verificationId={selectedId}
+              onClose={() => setSelectedId(null)}
+            />
           </div>
         )}
       </div>
-
-      {/* Detail panel */}
-      {selectedId && (
-        <div className="w-80 shrink-0 rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden flex flex-col">
-          <VerificationDetailPanel
-            verificationId={selectedId}
-            onClose={() => setSelectedId(null)}
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/app/frontend/src/hooks/useVerificationInbox.ts
+++ b/app/frontend/src/hooks/useVerificationInbox.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   fetchInbox,
@@ -35,6 +36,8 @@ export function useInbox(filters: Partial<ReviewFilters>) {
   return useQuery({
     queryKey: inboxKeys.list(filters),
     queryFn: () => fetchInbox(filters),
+    // Surface the most recent data while a background refetch is running
+    placeholderData: previousData => previousData,
   });
 }
 
@@ -43,6 +46,85 @@ export function useInboxStats() {
     queryKey: inboxKeys.stats(),
     queryFn: fetchStats,
     refetchInterval: 30_000, // refresh stats every 30s
+    // Keep previous data visible while the interval refetch runs
+    placeholderData: previousData => previousData,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Latency store — a virtual query key that holds the last fetch duration.
+// Components subscribe to it reactively through useOptimisticItemState-style reads.
+// ---------------------------------------------------------------------------
+
+const latencyStoreKey = ['verification-inbox', '__latency'] as const;
+
+function setLatency(qc: ReturnType<typeof useQueryClient>, ms: number) {
+  qc.setQueryData(latencyStoreKey, ms);
+}
+
+// ---------------------------------------------------------------------------
+// Refresh status hook — freshness + latency tracking for the queue list
+// ---------------------------------------------------------------------------
+export interface QueueRefreshStatus {
+  /** Timestamp of last successful data fetch (ms since epoch), or 0 if never */
+  lastRefreshedAt: number;
+  /** Whether a background or manual refetch is in flight */
+  isRefreshing: boolean;
+  /** Duration in ms of the most recent completed fetch, or null */
+  latencyMs: number | null;
+  /** Whether the last fetch ended in an error */
+  hasError: boolean;
+  /** Manually trigger a refetch of the inbox list */
+  refresh: () => void;
+}
+
+export function useQueueRefreshStatus(
+  filters: Partial<ReviewFilters>,
+): QueueRefreshStatus {
+  const qc = useQueryClient();
+
+  // Subscribe to latency store reactively
+  const latencyMs = useQuery({
+    queryKey: latencyStoreKey,
+    queryFn: () => null as number | null,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  }).data ?? null;
+
+  // Observe the live inbox query state (owned by useInbox above)
+  const state = qc.getQueryState(inboxKeys.list(filters));
+
+  const refresh = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: inboxKeys.list(filters) });
+  }, [qc, filters]);
+
+  return {
+    lastRefreshedAt: state?.dataUpdatedAt ?? 0,
+    isRefreshing: state?.fetchStatus === 'fetching',
+    latencyMs,
+    hasError: state?.status === 'error',
+    refresh,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Latency-aware inbox hook — wraps useInbox to record fetch duration.
+// Use this instead of useInbox on the ReviewQueue page to get latency tracking.
+// ---------------------------------------------------------------------------
+export function useInboxWithLatency(filters: Partial<ReviewFilters>) {
+  const qc = useQueryClient();
+  return useQuery({
+    queryKey: inboxKeys.list(filters),
+    queryFn: async () => {
+      const start = Date.now();
+      const result = await fetchInbox(filters);
+      setLatency(qc, Date.now() - start);
+      return result;
+    },
+    placeholderData: previousData => previousData,
   });
 }
 
@@ -60,6 +142,58 @@ export function useVerificationNotes(id: string) {
     queryFn: () => fetchNotes(id),
     enabled: !!id,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Optimistic item state store — tracks pending/failed item IDs in the cache
+// so any component can read them without prop-drilling.
+// ---------------------------------------------------------------------------
+
+/**
+ * Virtual query key used as a lightweight reactive store for optimistic UI
+ * states across all review actions.
+ */
+export const optimisticStateKey = ['verification-inbox', '__optimistic'] as const;
+
+export interface OptimisticItemState {
+  /** Items currently in-flight (action submitted, awaiting server response) */
+  pendingIds: Set<string>;
+  /** Items whose last action ended in an error (before the next refetch clears them) */
+  failedIds: Set<string>;
+}
+
+function getOptimisticState(qc: ReturnType<typeof useQueryClient>): OptimisticItemState {
+  return (
+    (qc.getQueryData(optimisticStateKey) as OptimisticItemState | undefined) ?? {
+      pendingIds: new Set(),
+      failedIds: new Set(),
+    }
+  );
+}
+
+function setOptimisticState(
+  qc: ReturnType<typeof useQueryClient>,
+  updater: (prev: OptimisticItemState) => OptimisticItemState,
+) {
+  qc.setQueryData(optimisticStateKey, updater(getOptimisticState(qc)));
+}
+
+/** Subscribe to the optimistic item state from any component. */
+export function useOptimisticItemState(): OptimisticItemState {
+  return (
+    (useQuery({
+      queryKey: optimisticStateKey,
+      queryFn: () => ({ pendingIds: new Set<string>(), failedIds: new Set<string>() }),
+      staleTime: Infinity,
+      gcTime: Infinity,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    }).data as OptimisticItemState | undefined) ?? {
+      pendingIds: new Set(),
+      failedIds: new Set(),
+    }
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -85,8 +219,18 @@ function useReviewMutation(
     }) => mutationFn(id, payload),
 
     // Optimistic: flip the item's status immediately in every cached list
+    // and mark the item as pending in the optimistic state store.
     onMutate: async ({ id }) => {
       await qc.cancelQueries({ queryKey: inboxKeys.all });
+
+      // Mark as pending, clear any previous failure for this item
+      setOptimisticState(qc, prev => {
+        const pendingIds = new Set(prev.pendingIds);
+        const failedIds = new Set(prev.failedIds);
+        pendingIds.add(id);
+        failedIds.delete(id);
+        return { pendingIds, failedIds };
+      });
 
       // Snapshot all list queries for rollback
       const snapshots = qc.getQueriesData<{ items: VerificationInboxItem[] }>({
@@ -106,20 +250,37 @@ function useReviewMutation(
         },
       );
 
-      return { snapshots };
+      return { snapshots, id };
     },
 
-    // Rollback on error
+    // Rollback on error and mark item as failed
     onError: (_err, _vars, context) => {
       if (context?.snapshots) {
         for (const [queryKey, data] of context.snapshots) {
           qc.setQueryData(queryKey, data);
         }
       }
+      if (context?.id) {
+        setOptimisticState(qc, prev => {
+          const pendingIds = new Set(prev.pendingIds);
+          const failedIds = new Set(prev.failedIds);
+          pendingIds.delete(context.id);
+          failedIds.add(context.id);
+          return { pendingIds, failedIds };
+        });
+      }
     },
 
-    // Always refetch to sync server truth
-    onSettled: () => {
+    // Always refetch to sync server truth; clear pending/failed on settle
+    onSettled: (_data, _err, vars) => {
+      const id = vars?.id;
+      if (id) {
+        setOptimisticState(qc, prev => {
+          const pendingIds = new Set(prev.pendingIds);
+          pendingIds.delete(id);
+          return { ...prev, pendingIds };
+        });
+      }
       void qc.invalidateQueries({ queryKey: inboxKeys.all });
     },
   });


### PR DESCRIPTION
- Add QueueFreshnessBar component: shows last refresh timestamp with live tick ('12s ago'), animated spinner during refetch, Live/Offline connection pill, fetch latency badge, and manual Refresh button. Turns amber when data is stale (>1.5× auto-refresh interval), red on error.

- Add useInboxWithLatency hook: wraps fetchInbox to record round-trip latency and store it reactively via a virtual RQ cache key so all subscribers update without prop-drilling.

- Add useQueueRefreshStatus hook: reads lastRefreshedAt (dataUpdatedAt), isRefreshing (fetchStatus), latencyMs, hasError, and exposes a manual refresh() function backed by query invalidation.

- Add useOptimisticItemState hook + store: tracks pendingIds / failedIds Sets in a virtual React Query cache entry. Mutations now mark items as pending on onMutate and as failed on onError, clearing on onSettled.

- Update ReviewQueue: uses useInboxWithLatency for latency tracking, renders QueueFreshnessBar above the list, shows a 'Syncing…' spinner row during background refetches, and renders per-item 'Saving…' (blue spinner badge) and 'Failed' (red alert badge + retry hint) UI. Items are disabled (aria-busy) while a review action is in flight.

- Add placeholderData to useInbox and useInboxStats so previous data remains visible during background refetches instead of blanking.

Closes #740 