### PR TITLE
feat(i18n): improve language selector UX and add missing-key guardrails

### DIFF
--- a/app/frontend/src/components/LanguageSelector.tsx
+++ b/app/frontend/src/components/LanguageSelector.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter, usePathname } from 'next/navigation';
 import { useLocale } from 'next-intl';
-import { useTransition } from 'react';
-import { Globe } from 'lucide-react';
+import { useEffect, useTransition } from 'react';
+import { Globe, Loader2 } from 'lucide-react';
 import { useLocaleStore } from '@/lib/localeStore';
 import type { Locale } from '@/i18n';
 
@@ -17,21 +17,33 @@ export function LanguageSelector() {
   const router = useRouter();
   const pathname = usePathname();
   const currentLocale = useLocale() as Locale;
-  const { setLocale } = useLocaleStore();
+  const { locale: storedLocale, setLocale } = useLocaleStore();
   const [isPending, startTransition] = useTransition();
+
+  // On mount: if the user previously chose a different locale, restore it by
+  // navigating to the stored locale's path so the URL and store stay in sync.
+  useEffect(() => {
+    if (storedLocale && storedLocale !== currentLocale) {
+      startTransition(() => {
+        const segments = pathname.split('/');
+        segments[1] = storedLocale;
+        router.replace(segments.join('/'));
+      });
+    }
+    // Only run on mount — exhaustive-deps intentionally omitted for storedLocale
+    // and currentLocale because we only want the initial sync, not a reactive loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleLocaleChange = (newLocale: Locale) => {
     if (newLocale === currentLocale) return;
 
     startTransition(() => {
-      // Update the locale in the store
       setLocale(newLocale);
 
-      // Navigate to the new locale - replace the current locale in the path
       const segments = pathname.split('/');
-      segments[1] = newLocale; // Replace the locale segment
-      const newPath = segments.join('/');
-      router.push(newPath);
+      segments[1] = newLocale;
+      router.push(segments.join('/'));
     });
   };
 
@@ -50,10 +62,21 @@ export function LanguageSelector() {
           </option>
         ))}
       </select>
-      <Globe
-        size={16}
-        className="absolute right-2 top-1/2 transform -translate-y-1/2 text-slate-500 dark:text-slate-400 pointer-events-none"
-      />
+
+      {/* Show a spinner while navigating, globe icon otherwise */}
+      {isPending ? (
+        <Loader2
+          size={16}
+          className="absolute right-2 top-1/2 -translate-y-1/2 animate-spin text-blue-500 pointer-events-none"
+          aria-hidden="true"
+        />
+      ) : (
+        <Globe
+          size={16}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400 pointer-events-none"
+          aria-hidden="true"
+        />
+      )}
     </div>
   );
 }

--- a/app/frontend/src/components/__tests__/LanguageSelector.test.tsx
+++ b/app/frontend/src/components/__tests__/LanguageSelector.test.tsx
@@ -1,0 +1,142 @@
+/** @jest-environment jsdom */
+/**
+ * Tests for LanguageSelector:
+ * - Locale persistence: restores stored locale on mount by redirecting
+ * - No redirect when stored locale already matches URL locale
+ * - Selecting a new locale saves it to the store and navigates
+ * - Same locale selection is a no-op
+ * - Renders all language options and reflects the active locale
+ */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { LanguageSelector } from '../LanguageSelector';
+
+// ─── Mock dependencies ────────────────────────────────────────────────────────
+
+const mockRouterReplace = jest.fn();
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockRouterReplace,
+    push: mockRouterPush,
+  }),
+  usePathname: () => '/en/dashboard',
+}));
+
+// Mocked locale — overridden per test where needed
+let mockCurrentLocale = 'en';
+jest.mock('next-intl', () => ({
+  useLocale: () => mockCurrentLocale,
+}));
+
+// Mocked store state — overridden per test where needed
+let mockStoredLocale = 'en';
+const mockSetLocale = jest.fn();
+jest.mock('@/lib/localeStore', () => ({
+  useLocaleStore: () => ({
+    locale: mockStoredLocale,
+    setLocale: mockSetLocale,
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderSelector() {
+  return render(<LanguageSelector />);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCurrentLocale = 'en';
+  mockStoredLocale = 'en';
+});
+
+describe('LanguageSelector — locale persistence on mount', () => {
+  it('redirects to the stored locale when it differs from the URL locale', async () => {
+    // Simulate: user previously selected 'fr', but the URL still shows 'en'
+    mockCurrentLocale = 'en';
+    mockStoredLocale = 'fr';
+
+    await act(async () => {
+      renderSelector();
+    });
+
+    // Should replace the URL locale segment with 'fr'
+    expect(mockRouterReplace).toHaveBeenCalledWith('/fr/dashboard');
+  });
+
+  it('does NOT redirect when stored locale matches the URL locale', async () => {
+    mockCurrentLocale = 'en';
+    mockStoredLocale = 'en';
+
+    await act(async () => {
+      renderSelector();
+    });
+
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+});
+
+describe('LanguageSelector — locale change', () => {
+  it('saves the new locale to the store when changed', () => {
+    mockCurrentLocale = 'en';
+    mockStoredLocale = 'en';
+
+    renderSelector();
+
+    const select = screen.getByRole('combobox', { name: /select language/i });
+    fireEvent.change(select, { target: { value: 'es' } });
+
+    expect(mockSetLocale).toHaveBeenCalledWith('es');
+  });
+
+  it('navigates to the new locale path when changed', () => {
+    mockCurrentLocale = 'en';
+    mockStoredLocale = 'en';
+
+    renderSelector();
+
+    const select = screen.getByRole('combobox', { name: /select language/i });
+    fireEvent.change(select, { target: { value: 'fr' } });
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/fr/dashboard');
+  });
+
+  it('does not navigate if the same locale is selected again', () => {
+    mockCurrentLocale = 'en';
+    mockStoredLocale = 'en';
+
+    renderSelector();
+
+    const select = screen.getByRole('combobox', { name: /select language/i });
+    // Selecting the already-active locale should be a no-op
+    fireEvent.change(select, { target: { value: 'en' } });
+
+    expect(mockSetLocale).not.toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+});
+
+describe('LanguageSelector — rendering', () => {
+  it('renders all three language options', () => {
+    renderSelector();
+
+    expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Español' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Français' })).toBeInTheDocument();
+  });
+
+  it('reflects the current locale as the selected option', () => {
+    mockCurrentLocale = 'fr';
+    mockStoredLocale = 'fr';
+
+    renderSelector();
+
+    const select = screen.getByRole('combobox', { name: /select language/i });
+    expect((select as HTMLSelectElement).value).toBe('fr');
+  });
+});

--- a/app/frontend/src/i18n.ts
+++ b/app/frontend/src/i18n.ts
@@ -21,5 +21,19 @@ export default getRequestConfig(async ({ requestLocale }) => {
   return {
     locale,
     messages: messages[locale as Locale],
+
+    // Log missing keys in development so translators can spot gaps quickly.
+    // In production this is a no-op; the fallback string is still shown to users.
+    onError(error) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('[i18n] missing translation key:', error.message);
+      }
+    },
+
+    // Return a readable placeholder instead of throwing so the UI stays usable
+    // when a key is absent (e.g. during active translation work).
+    getMessageFallback({ namespace, key }) {
+      return [namespace, key].filter(Boolean).join('.');
+    },
   };
 });

--- a/app/frontend/src/lib/__tests__/localeStore.test.ts
+++ b/app/frontend/src/lib/__tests__/localeStore.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for localeStore — verifies that locale selection is persisted and
+ * readable across separate calls (simulating session persistence).
+ */
+import { useLocaleStore } from '../localeStore';
+
+// Reset the store state between tests to prevent leakage.
+beforeEach(() => {
+  useLocaleStore.setState({ locale: 'en' });
+});
+
+describe('localeStore', () => {
+  it('defaults to "en"', () => {
+    const { locale } = useLocaleStore.getState();
+    expect(locale).toBe('en');
+  });
+
+  it('updates locale when setLocale is called', () => {
+    const { setLocale } = useLocaleStore.getState();
+    setLocale('fr');
+    expect(useLocaleStore.getState().locale).toBe('fr');
+  });
+
+  it('overwrites a previously stored locale', () => {
+    const { setLocale } = useLocaleStore.getState();
+    setLocale('es');
+    setLocale('fr');
+    expect(useLocaleStore.getState().locale).toBe('fr');
+  });
+
+  it('accepts all supported locales without error', () => {
+    const { setLocale } = useLocaleStore.getState();
+    // The store is typed to Locale — verify each valid value can be stored.
+    for (const locale of ['en', 'es', 'fr'] as const) {
+      setLocale(locale);
+      expect(useLocaleStore.getState().locale).toBe(locale);
+    }
+  });
+});


### PR DESCRIPTION
closes #593 
- Add onError handler to i18n.ts: logs missing translation keys to console.warn in development only, silent in production
- Add getMessageFallback: returns 'namespace.key' string so UI stays usable when a translation key is absent
- LanguageSelector: restore persisted locale on mount by redirecting to the stored locale's path if it differs from the URL locale
- LanguageSelector: replace Globe icon with Loader2 spinner while navigation transition is pending
- Add tests: localeStore (4) and LanguageSelector (7), all passing