### PR TITLE
feat(#775): add redaction preview diff endpoint

### DIFF
--- a/app/ai-service/api/v1/redaction_preview.py
+++ b/app/ai-service/api/v1/redaction_preview.py
@@ -1,0 +1,61 @@
+"""
+v1 redaction preview diff endpoint.
+
+Returns a structured diff showing which segments of the input text would be
+scrubbed before a final anonymization action is committed.  The original
+content is never logged; the RedactionFilter on the logging pipeline provides
+an additional safety net.
+"""
+
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+
+from schemas.anonymization import RedactionPreviewRequest, RedactionPreviewResult
+from schemas.common import ResultEnvelope
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["anonymization"])
+
+
+@router.post("/ai/redaction-preview", response_model=ResultEnvelope[RedactionPreviewResult])
+async def redaction_preview(request: RedactionPreviewRequest) -> ResultEnvelope[RedactionPreviewResult]:
+    """Preview what content would be scrubbed before committing anonymization.
+
+    Returns a segment-level diff: ``"text"`` segments are safe passages
+    kept as-is; ``"redaction"`` segments carry the replacement token and PII
+    label for spans that would be masked.  The fully anonymized text is
+    included for convenience.
+
+    **Logging safety**: The handler never logs the raw input text.  Any
+    accidental leakage is caught by the ``RedactionFilter`` installed on the
+    application logger.
+    """
+    import main as _main
+    from main import correlation_id_var
+
+    logger.info("Processing redaction preview request")
+
+    try:
+        raw: Dict[str, Any] = _main.pii_scrubber_service.preview(request.text)
+        result = RedactionPreviewResult(**raw)
+
+        total = result.pii_summary.get("total", 0)
+        reasons = (
+            [f"Preview covers {len(result.segments)} segment(s) with {total} redaction(s)."]
+            if total > 0
+            else ["No PII detected; output matches input."]
+        )
+
+        return ResultEnvelope[RedactionPreviewResult](
+            result=result,
+            confidence=None,
+            reasons=reasons,
+            anchor_metadata=request.anchor_metadata,
+            trace_id=correlation_id_var.get() or None,
+        )
+    except Exception as e:
+        logger.error("Redaction preview failed: %s", str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to generate redaction preview")

--- a/app/ai-service/api/v1/router.py
+++ b/app/ai-service/api/v1/router.py
@@ -13,6 +13,7 @@ from api.v1 import (
     inference,
     proof_of_life,
     anonymize,
+    redaction_preview,
     humanitarian,
     fraud,
     artifacts,
@@ -26,6 +27,7 @@ v1_router.include_router(ocr.router)
 v1_router.include_router(inference.router)
 v1_router.include_router(proof_of_life.router)
 v1_router.include_router(anonymize.router)
+v1_router.include_router(redaction_preview.router)
 v1_router.include_router(humanitarian.router)
 v1_router.include_router(fraud.router)
 v1_router.include_router(artifacts.router)

--- a/app/ai-service/schemas/anonymization.py
+++ b/app/ai-service/schemas/anonymization.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 from schemas.common import AnchorMetadata
@@ -105,6 +105,130 @@ class AnonymizeResponse(BaseModel):
                         "campaign_ref": "campaign-2024-001",
                         "claim_id": "claim-abc123",
                     },
+                }
+            ]
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Redaction Preview Diff
+# ---------------------------------------------------------------------------
+
+
+class RedactionPreviewRequest(BaseModel):
+    """Request body for the redaction preview diff endpoint."""
+
+    text: str = Field(
+        min_length=1,
+        description="Input text to preview redactions for.",
+        examples=["John Doe from New York on 2024-01-01 requested aid"],
+    )
+    anchor_metadata: Optional[AnchorMetadata] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "text": "John Doe from New York on 2024-01-01 requested aid",
+                    "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"},
+                }
+            ]
+        }
+    }
+
+
+class RedactionDiffSegment(BaseModel):
+    """A single segment in the redaction preview diff.
+
+    ``type`` is ``"text"`` for safe passages that would be kept as-is, or
+    ``"redaction"`` for spans that would be replaced by a token.  The
+    ``content`` field always holds the *original* text so the caller can
+    reconstruct the full input.  ``replacement`` and ``pii_type`` are only
+    populated for redaction segments.
+    """
+
+    type: Literal["text", "redaction"] = Field(
+        description="Segment kind: 'text' for safe passages, 'redaction' for PII spans.",
+    )
+    content: str = Field(
+        description="Original text of this segment.",
+    )
+    start: int = Field(
+        ge=0,
+        description="Character offset (inclusive) in the original input.",
+    )
+    end: int = Field(
+        ge=0,
+        description="Character offset (exclusive) in the original input.",
+    )
+    replacement: Optional[str] = Field(
+        None,
+        description="Token that would replace this segment (e.g. '[RECIPIENT_NAME]'). Only set for redaction segments.",
+        examples=["[RECIPIENT_NAME]"],
+    )
+    pii_type: Optional[str] = Field(
+        None,
+        description="PII category detected (e.g. 'PERSON', 'LOCATION'). Only set for redaction segments.",
+        examples=["PERSON"],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "type": "text",
+                    "content": "On 15 Jan 2025, ",
+                    "start": 0,
+                    "end": 17,
+                },
+                {
+                    "type": "redaction",
+                    "content": "Mary Johnson",
+                    "start": 17,
+                    "end": 29,
+                    "replacement": "[RECIPIENT_NAME]",
+                    "pii_type": "PERSON",
+                },
+            ]
+        }
+    }
+
+
+class RedactionPreviewResult(BaseModel):
+    """Payload nested inside the ResultEnvelope for redaction preview responses."""
+
+    segments: List[RedactionDiffSegment] = Field(
+        description="Ordered list of text and redaction segments covering the full input.",
+    )
+    original_length: int = Field(
+        ge=0,
+        examples=[50],
+        description="Character length of the original input.",
+    )
+    redacted_text: str = Field(
+        examples=["[RECIPIENT_NAME] from [LOCATION] on [EVENT_DATE] requested aid"],
+        description="Fully anonymized text that would be produced by the anonymize endpoint.",
+    )
+    pii_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}],
+        description="Count of detected PII items grouped by category.",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "segments": [
+                        {"type": "text", "content": "On 15 Jan 2025, ", "start": 0, "end": 17},
+                        {"type": "redaction", "content": "Mary Johnson", "start": 17, "end": 29, "replacement": "[RECIPIENT_NAME]", "pii_type": "PERSON"},
+                        {"type": "text", "content": " received aid in ", "start": 29, "end": 45},
+                        {"type": "redaction", "content": "Maiduguri Camp", "start": 45, "end": 59, "replacement": "[LOCATION]", "pii_type": "LOCATION"},
+                    ],
+                    "original_length": 60,
+                    "redacted_text": "On 15 Jan 2025, [RECIPIENT_NAME] received aid in [LOCATION].",
+                    "pii_summary": {"names": 1, "locations": 1, "dates": 0, "total": 2},
                 }
             ]
         }

--- a/app/ai-service/schemas/anonymization.py
+++ b/app/ai-service/schemas/anonymization.py
@@ -141,14 +141,14 @@ class RedactionPreviewRequest(BaseModel):
 class RedactionDiffSegment(BaseModel):
     """A single segment in the redaction preview diff.
 
-    ``type`` is ``"text"`` for safe passages that would be kept as-is, or
+    ``kind`` is ``"text"`` for safe passages that would be kept as-is, or
     ``"redaction"`` for spans that would be replaced by a token.  The
     ``content`` field always holds the *original* text so the caller can
     reconstruct the full input.  ``replacement`` and ``pii_type`` are only
     populated for redaction segments.
     """
 
-    type: Literal["text", "redaction"] = Field(
+    kind: Literal["text", "redaction"] = Field(
         description="Segment kind: 'text' for safe passages, 'redaction' for PII spans.",
     )
     content: str = Field(
@@ -177,13 +177,13 @@ class RedactionDiffSegment(BaseModel):
         "json_schema_extra": {
             "examples": [
                 {
-                    "type": "text",
+                    "kind": "text",
                     "content": "On 15 Jan 2025, ",
                     "start": 0,
                     "end": 17,
                 },
                 {
-                    "type": "redaction",
+                    "kind": "redaction",
                     "content": "Mary Johnson",
                     "start": 17,
                     "end": 29,
@@ -221,10 +221,10 @@ class RedactionPreviewResult(BaseModel):
             "examples": [
                 {
                     "segments": [
-                        {"type": "text", "content": "On 15 Jan 2025, ", "start": 0, "end": 17},
-                        {"type": "redaction", "content": "Mary Johnson", "start": 17, "end": 29, "replacement": "[RECIPIENT_NAME]", "pii_type": "PERSON"},
-                        {"type": "text", "content": " received aid in ", "start": 29, "end": 45},
-                        {"type": "redaction", "content": "Maiduguri Camp", "start": 45, "end": 59, "replacement": "[LOCATION]", "pii_type": "LOCATION"},
+                        {"kind": "text", "content": "On 15 Jan 2025, ", "start": 0, "end": 17},
+                        {"kind": "redaction", "content": "Mary Johnson", "start": 17, "end": 29, "replacement": "[RECIPIENT_NAME]", "pii_type": "PERSON"},
+                        {"kind": "text", "content": " received aid in ", "start": 29, "end": 45},
+                        {"kind": "redaction", "content": "Maiduguri Camp", "start": 45, "end": 59, "replacement": "[LOCATION]", "pii_type": "LOCATION"},
                     ],
                     "original_length": 60,
                     "redacted_text": "On 15 Jan 2025, [RECIPIENT_NAME] received aid in [LOCATION].",

--- a/app/ai-service/services/pii_scrubber.py
+++ b/app/ai-service/services/pii_scrubber.py
@@ -126,6 +126,84 @@ class PIIScrubberService:
             latency = time.time() - start_time
             metrics.PIPELINE_STEP_LATENCY.labels(step_name="scrub").observe(latency)
 
+    def preview(self, text: str) -> Dict[str, object]:
+        """Return a structured diff of what would be redacted.
+
+        Unlike :meth:`anonymize`, this method never mutates the input and
+        exposes per-span metadata so callers can render a visual diff without
+        committing the scrub.  The ``content`` field of each segment always
+        contains the *original* text, which is safe because the caller already
+        possesses it.
+        """
+        start_time = time.time()
+        try:
+            if not text:
+                return {
+                    "segments": [],
+                    "original_length": 0,
+                    "redacted_text": "",
+                    "pii_summary": {"names": 0, "locations": 0, "dates": 0, "emails": 0, "phones": 0, "ids": 0, "total": 0},
+                }
+
+            spans = self._detect_spans(text)
+            segments: List[Dict[str, object]] = []
+            cursor = 0
+
+            for span in spans:
+                if span.start > cursor:
+                    segments.append({
+                        "type": "text",
+                        "content": text[cursor:span.start],
+                        "start": cursor,
+                        "end": span.start,
+                    })
+
+                token_base = self.TOKEN_BASE_BY_LABEL.get(span.label, "REDACTED")
+                segments.append({
+                    "type": "redaction",
+                    "content": text[span.start:span.end],
+                    "start": span.start,
+                    "end": span.end,
+                    "replacement": f"[{token_base}]",
+                    "pii_type": span.label,
+                })
+                cursor = span.end
+
+            if cursor < len(text):
+                segments.append({
+                    "type": "text",
+                    "content": text[cursor:],
+                    "start": cursor,
+                    "end": len(text),
+                })
+
+            redacted_text, _ = self._mask_spans(text, spans)
+
+            names = sum(1 for s in spans if s.label == "PERSON")
+            locations = sum(1 for s in spans if s.label == "LOCATION")
+            dates = sum(1 for s in spans if s.label == "DATE")
+            emails = sum(1 for s in spans if s.label == "EMAIL")
+            phones = sum(1 for s in spans if s.label == "PHONE")
+            ids = sum(1 for s in spans if s.label == "ID")
+
+            return {
+                "segments": segments,
+                "original_length": len(text),
+                "redacted_text": redacted_text,
+                "pii_summary": {
+                    "names": names,
+                    "locations": locations,
+                    "dates": dates,
+                    "emails": emails,
+                    "phones": phones,
+                    "ids": ids,
+                    "total": len(spans),
+                },
+            }
+        finally:
+            latency = time.time() - start_time
+            metrics.PIPELINE_STEP_LATENCY.labels(step_name='preview').observe(latency)
+
     def _build_nlp(self) -> Language:
         nlp = spacy.blank("en")
         ruler = nlp.add_pipe("entity_ruler")

--- a/app/ai-service/services/pii_scrubber.py
+++ b/app/ai-service/services/pii_scrubber.py
@@ -152,7 +152,7 @@ class PIIScrubberService:
             for span in spans:
                 if span.start > cursor:
                     segments.append({
-                        "type": "text",
+                        "kind": "text",
                         "content": text[cursor:span.start],
                         "start": cursor,
                         "end": span.start,
@@ -160,7 +160,7 @@ class PIIScrubberService:
 
                 token_base = self.TOKEN_BASE_BY_LABEL.get(span.label, "REDACTED")
                 segments.append({
-                    "type": "redaction",
+                    "kind": "redaction",
                     "content": text[span.start:span.end],
                     "start": span.start,
                     "end": span.end,
@@ -171,10 +171,10 @@ class PIIScrubberService:
 
             if cursor < len(text):
                 segments.append({
-                    "type": "text",
-                    "content": text[cursor:],
-                    "start": cursor,
-                    "end": len(text),
+                        "kind": "text",
+                        "content": text[cursor:],
+                        "start": cursor,
+                        "end": len(text),
                 })
 
             redacted_text, _ = self._mask_spans(text, spans)

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -58,7 +58,7 @@ class TestPreviewSegments:
 
         assert len(result["segments"]) == 1
         seg = result["segments"][0]
-        assert seg["type"] == "text"
+        assert seg["kind"] == "text"
         assert seg["content"] == text
         assert seg["start"] == 0
         assert seg["end"] == len(text)
@@ -73,7 +73,7 @@ class TestPreviewSegments:
         text = "On 15 Jan 2025, Mary Johnson received aid in Maiduguri Camp."
         result = scrubber.preview(text)
 
-        redaction_segments = [s for s in result["segments"] if s["type"] == "redaction"]
+        redaction_segments = [s for s in result["segments"] if s["kind"] == "redaction"]
         assert len(redaction_segments) >= 2
         pii_types = {s["pii_type"] for s in redaction_segments}
         assert "PERSON" in pii_types
@@ -115,7 +115,7 @@ class TestPreviewSegments:
         text = "Contact Jane at jane@example.com for aid."
         result = scrubber.preview(text)
 
-        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        redactions = [s for s in result["segments"] if s["kind"] == "redaction"]
         assert any(s["pii_type"] == "EMAIL" for s in redactions)
         assert result["pii_summary"]["emails"] >= 1
 
@@ -123,7 +123,7 @@ class TestPreviewSegments:
         text = "Call +234 803 123 4567 for information."
         result = scrubber.preview(text)
 
-        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        redactions = [s for s in result["segments"] if s["kind"] == "redaction"]
         assert any(s["pii_type"] == "PHONE" for s in redactions)
         assert result["pii_summary"]["phones"] >= 1
 
@@ -132,7 +132,7 @@ class TestPreviewSegments:
         result = scrubber.preview(text)
 
         for seg in result["segments"]:
-            if seg["type"] == "redaction":
+            if seg["kind"] == "redaction":
                 assert seg["replacement"] is not None
                 assert seg["replacement"].startswith("[")
                 assert seg["replacement"].endswith("]")
@@ -206,14 +206,14 @@ class TestRedactionPreviewEndpoint:
             json={"text": "John Doe received aid in Maiduguri."},
         )
         for seg in response.json()["result"]["segments"]:
-            assert "type" in seg
-            assert seg["type"] in ("text", "redaction")
+            assert "kind" in seg
+            assert seg["kind"] in ("text", "redaction")
             assert "content" in seg
             assert "start" in seg
             assert "end" in seg
             assert seg["start"] >= 0
             assert seg["end"] >= seg["start"]
-            if seg["type"] == "redaction":
+            if seg["kind"] == "redaction":
                 assert "replacement" in seg
                 assert "pii_type" in seg
 
@@ -232,7 +232,7 @@ class TestRedactionPreviewEndpoint:
         )
         data = response.json()
         assert len(data["result"]["segments"]) == 1
-        assert data["result"]["segments"][0]["type"] == "text"
+        assert data["result"]["segments"][0]["kind"] == "text"
         assert data["result"]["pii_summary"]["total"] == 0
 
     def test_reasons_reflect_pii_detection(self, client):
@@ -268,7 +268,7 @@ class TestRedactionPreviewEndpoint:
         )
         result = response.json()["result"]
         redaction_count = sum(
-            1 for s in result["segments"] if s["type"] == "redaction"
+            1 for s in result["segments"] if s["kind"] == "redaction"
         )
         assert redaction_count == result["pii_summary"]["total"]
 
@@ -305,7 +305,7 @@ class TestPreviewEdgeCases:
         text = "Reported by Dr. Alice Brown."
         result = scrubber.preview(text)
 
-        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        redactions = [s for s in result["segments"] if s["kind"] == "redaction"]
         assert len(redactions) >= 1
         assert redactions[0]["pii_type"] == "PERSON"
 
@@ -313,7 +313,7 @@ class TestPreviewEdgeCases:
         text = "John Doe email jane@test.com in Lagos on 2024-01-01."
         result = scrubber.preview(text)
 
-        pii_types = {s["pii_type"] for s in result["segments"] if s["type"] == "redaction"}
+        pii_types = {s["pii_type"] for s in result["segments"] if s["kind"] == "redaction"}
         assert len(pii_types) >= 2
 
     def test_long_text_performance(self, scrubber):

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -1,0 +1,335 @@
+"""
+Tests for the redaction preview diff endpoint — issue #775.
+
+Covers:
+* PIIScrubberService.preview() segment generation and edge cases.
+* /v1/ai/redaction-preview endpoint response shape and behaviour.
+* Logging safety: raw PII must never appear in log output.
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import metrics
+from main import app
+from services.pii_scrubber import PIIScrubberService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_healthy_resources():
+    with patch.object(metrics, "check_system_resources", return_value=True):
+        yield
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(app, follow_redirects=True)
+
+
+@pytest.fixture()
+def scrubber():
+    return PIIScrubberService()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — PIIScrubberService.preview()
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewSegments:
+    def test_empty_text_returns_no_segments(self, scrubber):
+        result = scrubber.preview("")
+        assert result["segments"] == []
+        assert result["original_length"] == 0
+        assert result["redacted_text"] == ""
+        assert result["pii_summary"]["total"] == 0
+
+    def test_no_pii_returns_single_text_segment(self, scrubber):
+        text = "Camp distribution complete. All households received supplies."
+        result = scrubber.preview(text)
+
+        assert len(result["segments"]) == 1
+        seg = result["segments"][0]
+        assert seg["type"] == "text"
+        assert seg["content"] == text
+        assert seg["start"] == 0
+        assert seg["end"] == len(text)
+        assert result["pii_summary"]["total"] == 0
+        assert result["redacted_text"] == text
+
+    @patch("metrics.PIPELINE_STEP_LATENCY.labels")
+    def test_detects_name_location_date(self, mock_labels, scrubber):
+        mock_observe = MagicMock()
+        mock_labels.return_value.observe = mock_observe
+
+        text = "On 15 Jan 2025, Mary Johnson received aid in Maiduguri Camp."
+        result = scrubber.preview(text)
+
+        redaction_segments = [s for s in result["segments"] if s["type"] == "redaction"]
+        assert len(redaction_segments) >= 2
+        pii_types = {s["pii_type"] for s in redaction_segments}
+        assert "PERSON" in pii_types
+        assert "LOCATION" in pii_types
+        assert result["pii_summary"]["total"] >= 2
+
+        mock_labels.assert_called_with(step_name="preview")
+        mock_observe.assert_called_once()
+
+    def test_segments_cover_full_input(self, scrubber):
+        text = "John Doe from New York on 2024-07-12 reported delays."
+        result = scrubber.preview(text)
+
+        # Reconstruct input from segments
+        reconstructed = "".join(s["content"] for s in result["segments"])
+        assert reconstructed == text
+
+    def test_segments_are_contiguous(self, scrubber):
+        text = "Mary Johnson lives in Kano State and visited on 1 March 2025."
+        result = scrubber.preview(text)
+
+        for i in range(1, len(result["segments"])):
+            prev_end = result["segments"][i - 1]["end"]
+            curr_start = result["segments"][i]["start"]
+            assert curr_start == prev_end, (
+                f"Gap or overlap between segments {i-1} and {i}: "
+                f"prev_end={prev_end}, curr_start={curr_start}"
+            )
+
+    def test_redacted_text_matches_anonymize(self, scrubber):
+        text = "John Doe from New York on 2024-07-12 reported delays."
+        preview = scrubber.preview(text)
+        anonymize = scrubber.anonymize(text)
+
+        assert preview["redacted_text"] == anonymize["anonymized_text"]
+        assert preview["pii_summary"] == anonymize["pii_summary"]
+
+    def test_email_detection(self, scrubber):
+        text = "Contact Jane at jane@example.com for aid."
+        result = scrubber.preview(text)
+
+        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        assert any(s["pii_type"] == "EMAIL" for s in redactions)
+        assert result["pii_summary"]["emails"] >= 1
+
+    def test_phone_detection(self, scrubber):
+        text = "Call +234 803 123 4567 for information."
+        result = scrubber.preview(text)
+
+        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        assert any(s["pii_type"] == "PHONE" for s in redactions)
+        assert result["pii_summary"]["phones"] >= 1
+
+    def test_replacement_tokens_are_correct(self, scrubber):
+        text = "Mary Johnson from Kano on 2024-01-15."
+        result = scrubber.preview(text)
+
+        for seg in result["segments"]:
+            if seg["type"] == "redaction":
+                assert seg["replacement"] is not None
+                assert seg["replacement"].startswith("[")
+                assert seg["replacement"].endswith("]")
+
+    def test_original_length_matches_input(self, scrubber):
+        text = "Test text with Mary Doe in Lagos."
+        result = scrubber.preview(text)
+        assert result["original_length"] == len(text)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — logging safety
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewLoggingSafety:
+    def test_handler_does_not_log_raw_text(self, caplog, scrubber):
+        """The preview endpoint must not emit the raw input to logs."""
+        text = "John Doe lives at 10 Downing Street."
+        with caplog.at_level(logging.INFO, logger="api.v1.redaction_preview"):
+            # Simulate what the endpoint does (call preview, log info)
+            scrubber.preview(text)
+            logger = logging.getLogger("api.v1.redaction_preview")
+            logger.info("Processing redaction preview request")
+
+        for record in caplog.records:
+            assert "John Doe" not in record.getMessage()
+            assert "10 Downing Street" not in record.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests — /v1/ai/redaction-preview
+# ---------------------------------------------------------------------------
+
+
+class TestRedactionPreviewEndpoint:
+    def test_returns_200_with_valid_text(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "On 10 Jan 2025, Mary Doe received aid in Lagos."},
+        )
+        assert response.status_code == 200
+
+    def test_response_has_result_envelope_shape(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Jane Smith from Abuja on 1 March 2025."},
+        )
+        data = response.json()
+        assert "result" in data
+        assert "confidence" in data
+        assert "reasons" in data
+        assert "trace_id" in data
+
+    def test_result_has_segments_and_summary(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Mary Johnson from Kano on 2024-07-12."},
+        )
+        result = response.json()["result"]
+        assert "segments" in result
+        assert "original_length" in result
+        assert "redacted_text" in result
+        assert "pii_summary" in result
+        assert isinstance(result["segments"], list)
+        assert len(result["segments"]) > 0
+
+    def test_segments_have_valid_structure(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "John Doe received aid in Maiduguri."},
+        )
+        for seg in response.json()["result"]["segments"]:
+            assert "type" in seg
+            assert seg["type"] in ("text", "redaction")
+            assert "content" in seg
+            assert "start" in seg
+            assert "end" in seg
+            assert seg["start"] >= 0
+            assert seg["end"] >= seg["start"]
+            if seg["type"] == "redaction":
+                assert "replacement" in seg
+                assert "pii_type" in seg
+
+    def test_empty_text_returns_422(self, client):
+        response = client.post("/v1/ai/redaction-preview", json={"text": ""})
+        assert response.status_code == 422
+
+    def test_missing_text_returns_422(self, client):
+        response = client.post("/v1/ai/redaction-preview", json={})
+        assert response.status_code == 422
+
+    def test_no_pii_returns_single_text_segment(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Camp distribution complete. All supplies delivered."},
+        )
+        data = response.json()
+        assert len(data["result"]["segments"]) == 1
+        assert data["result"]["segments"][0]["type"] == "text"
+        assert data["result"]["pii_summary"]["total"] == 0
+
+    def test_reasons_reflect_pii_detection(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Mary Johnson from Kano on 2024-07-12."},
+        )
+        reasons = response.json()["reasons"]
+        assert len(reasons) >= 1
+        assert "redaction" in reasons[0].lower()
+
+    def test_no_pii_reasons(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "No sensitive data here."},
+        )
+        reasons = response.json()["reasons"]
+        assert any("No PII" in r for r in reasons)
+
+    def test_anchor_metadata_passthrough(self, client):
+        meta = {"campaign_ref": "camp-001", "claim_id": "cl-abc"}
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Mary Doe in Lagos.", "anchor_metadata": meta},
+        )
+        data = response.json()
+        assert data["anchor_metadata"] == meta
+
+    def test_pii_summary_counts_match_redaction_segments(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "Mary Johnson from Kano on 2024-07-12."},
+        )
+        result = response.json()["result"]
+        redaction_count = sum(
+            1 for s in result["segments"] if s["type"] == "redaction"
+        )
+        assert redaction_count == result["pii_summary"]["total"]
+
+    def test_anonymized_text_matches_anonymize_endpoint(self, client):
+        payload = {"text": "Jane Smith received aid in Abuja on 1 March 2025."}
+        preview_resp = client.post("/v1/ai/redaction-preview", json=payload)
+        anonymize_resp = client.post("/v1/ai/anonymize", json=payload)
+
+        assert preview_resp.status_code == 200
+        assert anonymize_resp.status_code == 200
+        assert (
+            preview_resp.json()["result"]["redacted_text"]
+            == anonymize_resp.json()["result"]["anonymized_text"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewEdgeCases:
+    def test_whitespace_only_text(self, client):
+        response = client.post(
+            "/v1/ai/redaction-preview",
+            json={"text": "   "},
+        )
+        assert response.status_code == 200
+        result = response.json()["result"]
+        assert result["pii_summary"]["total"] == 0
+        assert result["redacted_text"] == "   "
+
+    def test_single_name_detection(self, scrubber):
+        text = "Reported by Dr. Alice Brown."
+        result = scrubber.preview(text)
+
+        redactions = [s for s in result["segments"] if s["type"] == "redaction"]
+        assert len(redactions) >= 1
+        assert redactions[0]["pii_type"] == "PERSON"
+
+    def test_multiple_pii_types_in_one_sentence(self, scrubber):
+        text = "John Doe email jane@test.com in Lagos on 2024-01-01."
+        result = scrubber.preview(text)
+
+        pii_types = {s["pii_type"] for s in result["segments"] if s["type"] == "redaction"}
+        assert len(pii_types) >= 2
+
+    def test_long_text_performance(self, scrubber):
+        text = "Mary Johnson from Kano. " * 100
+        result = scrubber.preview(text)
+        assert len(result["segments"]) > 0
+        reconstructed = "".join(s["content"] for s in result["segments"])
+        assert reconstructed == text
+
+    def test_unicode_text_no_crash(self, scrubber):
+        text = "Distribución de ayuda en Maiduguri."
+        result = scrubber.preview(text)
+        assert result["original_length"] == len(text)
+
+    def test_special_characters(self, scrubber):
+        text = "Mary! @Doe #received $aid in Kano."
+        result = scrubber.preview(text)
+        reconstructed = "".join(s["content"] for s in result["segments"])
+        assert reconstructed == text


### PR DESCRIPTION
Closes #775
Problem
Before committing anonymization, clients currently have no way to inspect which segments of a text would be scrubbed and what they'd be replaced with. This forces a blind commit-then-hope pattern that risks over-redacting safe content or missing sensitive spans.
Solution
Adds a POST /v1/ai/redaction-preview endpoint that returns a structured segment-level diff of the input text. The client can inspect every span — safe text kept as-is, PII spans annotated with their replacement token and category — before deciding to call the existing /v1/ai/anonymize endpoint to commit.
Changes
services/pii_scrubber.py
- Added PIIScrubberService.preview(text) — reuses the existing _detect_spans pipeline but returns structured segment data instead of a masked string. Each segment carries type, content, start, end, and (for redactions) replacement + pii_type. Records latency under a preview step in the Prometheus histogram.
schemas/anonymization.py
- RedactionPreviewRequest — input schema (reuses AnchorMetadata passthrough).
- RedactionDiffSegment — typed union segment ("text" | "redaction") with char offsets and optional replacement/pii_type fields.
- RedactionPreviewResult — top-level result containing the segment list, original_length, fully anonymized redacted_text, and pii_summary.
api/v1/redaction_preview.py
- Async handler wrapped in ResultEnvelope[RedactionPreviewResult]. Never logs raw input text; the RedactionFilter on the application logger provides a second safety net. Emits structured reasons ("Preview covers N segment(s) with M redaction(s)").
api/v1/router.py
- Registered redaction_preview.router on the v1 sub-router.
tests/test_redaction_preview.py — 20+ test cases covering:
- Unit: segment contiguity, full-input reconstruction, empty input, PII category detection, replacement token format, parity with anonymize() output.
- Logging: raw PII must not appear in caplog records.
- Endpoint: 200 shape, 422 on empty/missing text, segment structure validation, reasons wording, anchor_metadata passthrough, cross-endpoint parity with /v1/ai/anonymize.
- Edge cases: whitespace-only input, single name, mixed PII types in one sentence, long repeated text, unicode, special characters.
Response shape
{
  "result": {
    "segments": [
      {"type": "text", "content": "On 10 Jan 2025, ", "start": 0, "end": 16},
      {"type": "redaction", "content": "Mary Doe", "start": 16, "end": 24, "replacement": "[RECIPIENT_NAME]", "pii_type": "PERSON"},
      {"type": "text", "content": " received aid in ", "start": 24, "end": 40},
      {"type": "redaction", "content": "Lagos", "start": 40, "end": 45, "replacement": "[LOCATION]", "pii_type": "LOCATION"}
    ],
    "original_length": 48,
    "redacted_text": "On 10 Jan 2025, [RECIPIENT_NAME] received aid in [LOCATION].",
    "pii_summary": {"names": 1, "locations": 1, "dates": 0, "emails": 0, "phones": 0, "ids": 0, "total": 2}
  },
  "confidence": null,
  "reasons": ["Preview covers 4 segment(s) with 2 redaction(s)."]
}
Acceptance criteria
- Response distinguishes original segments from scrubbed segments safely
- Preview does not leak raw sensitive content into logs
- Tests cover preview generation and edge cases
Verification
cd app/ai-service && pytest tests/test_redaction_preview.py -v