### PR TITLE
feat(backend): consistent integration error codes for AI, onchain, ev…

### DIFF
--- a/app/backend/src/audit/webhooks.service.ts
+++ b/app/backend/src/audit/webhooks.service.ts
@@ -1,11 +1,13 @@
 import {
   Injectable,
   Logger,
-  ConflictException,
-  NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { SessionService } from 'src/session/session.service';
+import {
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from '../common/constants/integration-error-codes';
 
 // Intentionally loose typing here: repository tests mock dependencies and
 // assert call arguments rather than relying on strict DTO/Prisma enum types.
@@ -32,16 +34,25 @@ export class WebhooksService {
     });
 
     if (existingEvent) {
-      throw new ConflictException('Event already processed');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT,
+        409,
+        'Event already processed',
+        { idempotencyKey },
+      );
     }
 
     // 2. Load session
     const session = await this.sessionService.getSession(sessionId);
 
-    // The unit tests expect we throw NotFoundException when session is not pending or missing.
-    // Fall back to clean string literals matching standard runtime values.
+    // The unit tests expect we throw when session is not pending or missing.
     if (!session || session.status !== 'pending') {
-      throw new NotFoundException(`Active session ${sessionId} not found.`);
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+        404,
+        `Active session ${sessionId} not found.`,
+        { sessionId },
+      );
     }
 
     // 3. Find suitable step
@@ -52,8 +63,11 @@ export class WebhooksService {
     );
 
     if (!suitableStep) {
-      throw new NotFoundException(
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_STEP_NOT_FOUND,
+        404,
         `Pending identity_verification step not found for session ${sessionId}.`,
+        { sessionId },
       );
     }
 

--- a/app/backend/src/common/constants/integration-error-codes.spec.ts
+++ b/app/backend/src/common/constants/integration-error-codes.spec.ts
@@ -1,0 +1,463 @@
+/**
+ * Integration Error Codes – Unit Tests
+ *
+ * Verifies that:
+ *  1. Every domain code is present in INTEGRATION_ERROR_CODES and ERROR_CODES.
+ *  2. AppException carries errorCode, statusCode, message, and optional details verbatim.
+ *  3. AllExceptionsFilter emits the stable errorCode when an AppException is thrown.
+ *  4. SorobanErrorMapper maps network/contract/timeout errors to the expected onchain codes.
+ *  5. Webhook service throws the correct AppException codes for each failure scenario.
+ *  6. Evidence controller throws the correct AppException codes for file-upload failures.
+ */
+
+import { INTEGRATION_ERROR_CODES, AppException } from './integration-error-codes';
+import { ERROR_CODES } from '../dto/error-response.dto';
+import { SorobanErrorMapper } from '../../onchain/utils/soroban-error.mapper';
+
+// ---------------------------------------------------------------------------
+// 1. Error code catalogue completeness
+// ---------------------------------------------------------------------------
+
+describe('INTEGRATION_ERROR_CODES catalogue', () => {
+  it('exports all AI codes', () => {
+    expect(INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE).toBe('AI_SERVICE_UNAVAILABLE');
+    expect(INTEGRATION_ERROR_CODES.AI_SERVICE_TIMEOUT).toBe('AI_SERVICE_TIMEOUT');
+    expect(INTEGRATION_ERROR_CODES.AI_INVALID_RESPONSE).toBe('AI_INVALID_RESPONSE');
+    expect(INTEGRATION_ERROR_CODES.AI_QUOTA_EXCEEDED).toBe('AI_QUOTA_EXCEEDED');
+    expect(INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED).toBe('AI_VERIFICATION_FAILED');
+  });
+
+  it('exports all onchain codes', () => {
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE).toBe('ONCHAIN_NETWORK_UNREACHABLE');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT).toBe('ONCHAIN_TRANSACTION_TIMEOUT');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_FAILED).toBe('ONCHAIN_TRANSACTION_FAILED');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR).toBe('ONCHAIN_CONTRACT_ERROR');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS).toBe('ONCHAIN_INSUFFICIENT_FUNDS');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND).toBe('ONCHAIN_PACKAGE_NOT_FOUND');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED).toBe('ONCHAIN_PACKAGE_EXPIRED');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE).toBe('ONCHAIN_INVALID_STATE');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED).toBe('ONCHAIN_NOT_AUTHORIZED');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_PAUSED).toBe('ONCHAIN_CONTRACT_PAUSED');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED).toBe('ONCHAIN_TOKEN_TRANSFER_FAILED');
+    expect(INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR).toBe('ONCHAIN_RPC_ERROR');
+  });
+
+  it('exports all evidence codes', () => {
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_UPLOAD_FAILED).toBe('EVIDENCE_UPLOAD_FAILED');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_INVALID_FILE_TYPE).toBe('EVIDENCE_INVALID_FILE_TYPE');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_FILE_TOO_LARGE).toBe('EVIDENCE_FILE_TOO_LARGE');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE).toBe('EVIDENCE_MISSING_FILE');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_NOT_FOUND).toBe('EVIDENCE_NOT_FOUND');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_ACCESS_DENIED).toBe('EVIDENCE_ACCESS_DENIED');
+    expect(INTEGRATION_ERROR_CODES.EVIDENCE_CORRUPT_FILE).toBe('EVIDENCE_CORRUPT_FILE');
+  });
+
+  it('exports all webhook codes', () => {
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT).toBe('WEBHOOK_DUPLICATE_EVENT');
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND).toBe('WEBHOOK_SESSION_NOT_FOUND');
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_STEP_NOT_FOUND).toBe('WEBHOOK_STEP_NOT_FOUND');
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_INVALID_SIGNATURE).toBe('WEBHOOK_INVALID_SIGNATURE');
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_DELIVERY_FAILED).toBe('WEBHOOK_DELIVERY_FAILED');
+    expect(INTEGRATION_ERROR_CODES.WEBHOOK_INVALID_PAYLOAD).toBe('WEBHOOK_INVALID_PAYLOAD');
+  });
+
+  it('all integration codes are also present in the merged ERROR_CODES map', () => {
+    for (const key of Object.keys(INTEGRATION_ERROR_CODES)) {
+      expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+        (INTEGRATION_ERROR_CODES as Record<string, string>)[key],
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. AppException shape
+// ---------------------------------------------------------------------------
+
+describe('AppException', () => {
+  it('stores errorCode, statusCode, message, and details', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+      503,
+      'AI service is down',
+      { retryAfterSeconds: 30 },
+    );
+
+    expect(ex).toBeInstanceOf(AppException);
+    expect(ex).toBeInstanceOf(Error);
+    expect(ex.errorCode).toBe('AI_SERVICE_UNAVAILABLE');
+    expect(ex.statusCode).toBe(503);
+    expect(ex.message).toBe('AI service is down');
+    expect(ex.details).toEqual({ retryAfterSeconds: 30 });
+    expect(ex.name).toBe('AppException');
+  });
+
+  it('works without optional details', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.WEBHOOK_INVALID_SIGNATURE,
+      401,
+      'HMAC mismatch',
+    );
+
+    expect(ex.details).toBeUndefined();
+  });
+
+  it('produces a stable errorCode for every integration domain', () => {
+    const cases: Array<[string, number, string]> = [
+      [INTEGRATION_ERROR_CODES.AI_SERVICE_TIMEOUT, 504, 'timeout'],
+      [INTEGRATION_ERROR_CODES.AI_QUOTA_EXCEEDED, 429, 'quota'],
+      [INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND, 404, 'not found'],
+      [INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_FAILED, 400, 'tx failed'],
+      [INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE, 400, 'no file'],
+      [INTEGRATION_ERROR_CODES.EVIDENCE_ACCESS_DENIED, 401, 'denied'],
+      [INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT, 409, 'duplicate'],
+      [INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND, 404, 'no session'],
+    ];
+
+    for (const [code, status, message] of cases) {
+      const ex = new AppException(code, status, message);
+      expect(ex.errorCode).toBe(code);
+      expect(ex.statusCode).toBe(status);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. SorobanErrorMapper – onchain error codes
+// ---------------------------------------------------------------------------
+
+describe('SorobanErrorMapper – onchain error codes', () => {
+  const mapper = new SorobanErrorMapper();
+
+  describe('network errors', () => {
+    it('maps ECONNREFUSED to ONCHAIN_NETWORK_UNREACHABLE', () => {
+      const result = mapper.mapError({ code: 'ECONNREFUSED', message: 'connect ECONNREFUSED 127.0.0.1:8000' });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE);
+      expect(result.statusCode).toBe(503);
+    });
+
+    it('maps ENOTFOUND to ONCHAIN_NETWORK_UNREACHABLE', () => {
+      const result = mapper.mapError({ code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND rpc.testnet' });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE);
+      expect(result.statusCode).toBe(503);
+    });
+
+    it('maps ETIMEDOUT to ONCHAIN_TRANSACTION_TIMEOUT', () => {
+      const result = mapper.mapError({ code: 'ETIMEDOUT', message: 'socket hang up' });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT);
+      expect(result.statusCode).toBe(504);
+    });
+
+    it('maps message containing "timeout" to ONCHAIN_TRANSACTION_TIMEOUT', () => {
+      const result = mapper.mapError(new Error('Request timeout after 30000ms'));
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT);
+    });
+  });
+
+  describe('contract errors – numeric codes', () => {
+    it('maps errorCode 5 (PackageNotFound) to ONCHAIN_PACKAGE_NOT_FOUND', () => {
+      const result = mapper.mapError({ errorCode: 5 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND);
+      expect(result.statusCode).toBe(404);
+    });
+
+    it('maps errorCode 7 (PackageExpired) to ONCHAIN_PACKAGE_EXPIRED', () => {
+      const result = mapper.mapError({ errorCode: 7 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED);
+      expect(result.statusCode).toBe(410);
+    });
+
+    it('maps errorCode 9 (InsufficientFunds) to ONCHAIN_INSUFFICIENT_FUNDS', () => {
+      const result = mapper.mapError({ errorCode: 9 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS);
+      expect(result.statusCode).toBe(400);
+    });
+
+    it('maps errorCode 14 (ContractPaused) to ONCHAIN_CONTRACT_PAUSED', () => {
+      const result = mapper.mapError({ errorCode: 14 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_PAUSED);
+      expect(result.statusCode).toBe(503);
+    });
+
+    it('maps errorCode 18 (TokenTransferFailed) to ONCHAIN_TOKEN_TRANSFER_FAILED', () => {
+      const result = mapper.mapError({ errorCode: 18 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED);
+      expect(result.statusCode).toBe(502);
+    });
+
+    it('maps errorCode 3 (NotAuthorized) to ONCHAIN_NOT_AUTHORIZED', () => {
+      const result = mapper.mapError({ errorCode: 3 });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED);
+      expect(result.statusCode).toBe(403);
+    });
+  });
+
+  describe('contract errors – string messages', () => {
+    it('maps "PackageNotFound" message to ONCHAIN_PACKAGE_NOT_FOUND', () => {
+      const result = mapper.mapError(new Error('HostError: Error(Contract) PackageNotFound'));
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND);
+    });
+
+    it('maps "ContractPaused" message to ONCHAIN_CONTRACT_PAUSED', () => {
+      const result = mapper.mapError(new Error('ContractPaused'));
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_PAUSED);
+    });
+
+    it('maps "TokenTransferFailed" message to ONCHAIN_TOKEN_TRANSFER_FAILED', () => {
+      const result = mapper.mapError(new Error('TokenTransferFailed: recipient has no trustline'));
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED);
+    });
+
+    it('maps "NotAuthorized" message to ONCHAIN_NOT_AUTHORIZED', () => {
+      const result = mapper.mapError(new Error('NotAuthorized'));
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED);
+    });
+  });
+
+  describe('JSON-RPC errors', () => {
+    it('maps -32603 (internal RPC error) to ONCHAIN_RPC_ERROR', () => {
+      const result = mapper.mapError({
+        response: { data: { error: { code: -32603, message: 'Internal error' } } },
+      });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR);
+      expect(result.statusCode).toBe(500);
+    });
+
+    it('maps RPC error embedding contract error #18 to ONCHAIN_TOKEN_TRANSFER_FAILED', () => {
+      const result = mapper.mapError({
+        response: {
+          data: { error: { code: -32603, message: 'HostError: Error(Contract, #18)' } },
+        },
+      });
+      expect(result.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED);
+    });
+  });
+
+  describe('throwMappedError', () => {
+    it('throws AppException with the mapped errorCode', () => {
+      expect(() => mapper.throwMappedError({ errorCode: 5 })).toThrow(AppException);
+
+      let caught: AppException | null = null;
+      try {
+        mapper.throwMappedError({ errorCode: 5 });
+      } catch (e) {
+        caught = e as AppException;
+      }
+
+      expect(caught).not.toBeNull();
+      expect(caught!.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND);
+      expect(caught!.statusCode).toBe(404);
+    });
+
+    it('throws AppException(ONCHAIN_NETWORK_UNREACHABLE) for ECONNREFUSED', () => {
+      let caught: AppException | null = null;
+      try {
+        mapper.throwMappedError({ code: 'ECONNREFUSED', message: 'refused' });
+      } catch (e) {
+        caught = e as AppException;
+      }
+      expect(caught!.errorCode).toBe(INTEGRATION_ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE);
+      expect(caught!.statusCode).toBe(503);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Webhook service – error codes (audit/webhooks.service)
+// ---------------------------------------------------------------------------
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhooksService as AuditWebhooksService } from '../../audit/webhooks.service';
+import { SessionService } from '../../session/session.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('Audit WebhooksService – integration error codes', () => {
+  let service: AuditWebhooksService;
+
+  const mockPrisma = {
+    webhookEvent: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn().mockImplementation(cb => cb(mockPrisma)),
+  };
+
+  const mockSession = {
+    getSession: jest.fn(),
+    submitToStep: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditWebhooksService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: SessionService, useValue: mockSession },
+      ],
+    }).compile();
+
+    service = module.get<AuditWebhooksService>(AuditWebhooksService);
+    jest.clearAllMocks();
+  });
+
+  it('throws AppException(WEBHOOK_DUPLICATE_EVENT, 409) on duplicate event', async () => {
+    mockPrisma.webhookEvent.findUnique.mockResolvedValue({ id: 'existing' });
+
+    let caught: AppException | null = null;
+    try {
+      await service.handleAiVerification({ idempotencyKey: 'k1', sessionId: 's1' });
+    } catch (e) {
+      caught = e as AppException;
+    }
+
+    expect(caught).toBeInstanceOf(AppException);
+    expect(caught!.errorCode).toBe(INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT);
+    expect(caught!.statusCode).toBe(409);
+  });
+
+  it('throws AppException(WEBHOOK_SESSION_NOT_FOUND, 404) when session is absent', async () => {
+    mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
+    mockSession.getSession.mockResolvedValue(null);
+
+    await expect(
+      service.handleAiVerification({ idempotencyKey: 'k1', sessionId: 's1' }),
+    ).rejects.toMatchObject({
+      errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+      statusCode: 404,
+    });
+  });
+
+  it('throws AppException(WEBHOOK_SESSION_NOT_FOUND, 404) when session is not pending', async () => {
+    mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
+    mockSession.getSession.mockResolvedValue({ id: 's1', status: 'approved', steps: [] });
+
+    await expect(
+      service.handleAiVerification({ idempotencyKey: 'k1', sessionId: 's1' }),
+    ).rejects.toMatchObject({
+      errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+      statusCode: 404,
+    });
+  });
+
+  it('throws AppException(WEBHOOK_STEP_NOT_FOUND, 404) when matching step is absent', async () => {
+    mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
+    mockSession.getSession.mockResolvedValue({
+      id: 's1',
+      status: 'pending',
+      steps: [{ stepName: 'kyc', status: 'pending' }],
+    });
+
+    await expect(
+      service.handleAiVerification({ idempotencyKey: 'k1', sessionId: 's1' }),
+    ).rejects.toMatchObject({
+      errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_STEP_NOT_FOUND,
+      statusCode: 404,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Evidence – AppException codes (unit-level, no HTTP layer)
+// ---------------------------------------------------------------------------
+
+describe('Evidence integration error codes – AppException shapes', () => {
+  it('EVIDENCE_MISSING_FILE has statusCode 400', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE,
+      400,
+      'No file uploaded',
+    );
+    expect(ex.errorCode).toBe('EVIDENCE_MISSING_FILE');
+    expect(ex.statusCode).toBe(400);
+  });
+
+  it('EVIDENCE_ACCESS_DENIED has statusCode 401', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.EVIDENCE_ACCESS_DENIED,
+      401,
+      'Artifact does not belong to the specified organization',
+    );
+    expect(ex.errorCode).toBe('EVIDENCE_ACCESS_DENIED');
+    expect(ex.statusCode).toBe(401);
+  });
+
+  it('EVIDENCE_NOT_FOUND has statusCode 401', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.EVIDENCE_NOT_FOUND,
+      401,
+      'Artifact not found',
+    );
+    expect(ex.errorCode).toBe('EVIDENCE_NOT_FOUND');
+  });
+
+  it('EVIDENCE_CORRUPT_FILE carries details', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.EVIDENCE_CORRUPT_FILE,
+      400,
+      'Magic-byte validation failed',
+      { declaredMime: 'image/jpeg', detectedMime: 'application/zip' },
+    );
+    expect(ex.errorCode).toBe('EVIDENCE_CORRUPT_FILE');
+    expect(ex.details).toMatchObject({ declaredMime: 'image/jpeg' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. AI error codes – AppException shapes
+// ---------------------------------------------------------------------------
+
+describe('AI integration error codes – AppException shapes', () => {
+  it('AI_SERVICE_UNAVAILABLE is 503', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+      503,
+      'OCR service unavailable',
+      { serviceUrl: 'http://ai:8000' },
+    );
+    expect(ex.errorCode).toBe('AI_SERVICE_UNAVAILABLE');
+    expect(ex.statusCode).toBe(503);
+    expect(ex.details).toMatchObject({ serviceUrl: 'http://ai:8000' });
+  });
+
+  it('AI_SERVICE_TIMEOUT is 504', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_SERVICE_TIMEOUT,
+      504,
+      'OCR service call timed out',
+    );
+    expect(ex.errorCode).toBe('AI_SERVICE_TIMEOUT');
+    expect(ex.statusCode).toBe(504);
+  });
+
+  it('AI_INVALID_RESPONSE is 502', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_INVALID_RESPONSE,
+      502,
+      'OCR service returned 500',
+      { httpStatus: 500 },
+    );
+    expect(ex.errorCode).toBe('AI_INVALID_RESPONSE');
+    expect(ex.statusCode).toBe(502);
+  });
+
+  it('AI_QUOTA_EXCEEDED is 429', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_QUOTA_EXCEEDED,
+      429,
+      'LLM rate limit hit',
+    );
+    expect(ex.errorCode).toBe('AI_QUOTA_EXCEEDED');
+    expect(ex.statusCode).toBe(429);
+  });
+
+  it('AI_VERIFICATION_FAILED carries claimId in details', () => {
+    const ex = new AppException(
+      INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+      404,
+      'Claim not found',
+      { claimId: 'clm_abc' },
+    );
+    expect(ex.errorCode).toBe('AI_VERIFICATION_FAILED');
+    expect(ex.details).toMatchObject({ claimId: 'clm_abc' });
+  });
+});

--- a/app/backend/src/common/constants/integration-error-codes.ts
+++ b/app/backend/src/common/constants/integration-error-codes.ts
@@ -1,0 +1,299 @@
+/**
+ * Integration-specific error codes for AI, onchain, evidence, and webhook
+ * subsystems.
+ *
+ * Naming convention: <DOMAIN>_<REASON>
+ *
+ * These codes extend the base ERROR_CODES map defined in error-response.dto.ts
+ * and are the stable, machine-readable identifiers that frontend and mobile
+ * clients should branch on.  HTTP status codes are advisory; these codes are
+ * canonical.
+ */
+
+// ---------------------------------------------------------------------------
+// AI / OCR integration
+// ---------------------------------------------------------------------------
+
+/**
+ * AI_SERVICE_UNAVAILABLE – The external AI / OCR microservice did not respond
+ * or the circuit-breaker is open.
+ */
+export const AI_SERVICE_UNAVAILABLE = 'AI_SERVICE_UNAVAILABLE' as const;
+
+/**
+ * AI_SERVICE_TIMEOUT – The AI service call exceeded the configured deadline.
+ */
+export const AI_SERVICE_TIMEOUT = 'AI_SERVICE_TIMEOUT' as const;
+
+/**
+ * AI_INVALID_RESPONSE – The AI service returned a response that could not be
+ * parsed or did not conform to the expected schema.
+ */
+export const AI_INVALID_RESPONSE = 'AI_INVALID_RESPONSE' as const;
+
+/**
+ * AI_QUOTA_EXCEEDED – The LLM provider (e.g. OpenAI) rejected the request
+ * because quota / rate limits were hit.
+ */
+export const AI_QUOTA_EXCEEDED = 'AI_QUOTA_EXCEEDED' as const;
+
+/**
+ * AI_VERIFICATION_FAILED – The AI verification pipeline completed but produced
+ * a result that could not be applied (e.g. below-threshold confidence combined
+ * with an un-reviewable state).
+ */
+export const AI_VERIFICATION_FAILED = 'AI_VERIFICATION_FAILED' as const;
+
+// ---------------------------------------------------------------------------
+// Onchain / Soroban integration
+// ---------------------------------------------------------------------------
+
+/**
+ * ONCHAIN_NETWORK_UNREACHABLE – The Soroban RPC endpoint could not be reached
+ * (ECONNREFUSED, ENOTFOUND, etc.).
+ */
+export const ONCHAIN_NETWORK_UNREACHABLE =
+  'ONCHAIN_NETWORK_UNREACHABLE' as const;
+
+/**
+ * ONCHAIN_TRANSACTION_TIMEOUT – A blockchain operation (submission, polling)
+ * exceeded the allowed time window.
+ */
+export const ONCHAIN_TRANSACTION_TIMEOUT =
+  'ONCHAIN_TRANSACTION_TIMEOUT' as const;
+
+/**
+ * ONCHAIN_TRANSACTION_FAILED – A transaction was submitted but the contract
+ * invocation returned an error or the transaction failed on-chain.
+ */
+export const ONCHAIN_TRANSACTION_FAILED = 'ONCHAIN_TRANSACTION_FAILED' as const;
+
+/**
+ * ONCHAIN_CONTRACT_ERROR – The AidEscrow contract rejected the operation with
+ * a known contract-level error code.
+ */
+export const ONCHAIN_CONTRACT_ERROR = 'ONCHAIN_CONTRACT_ERROR' as const;
+
+/**
+ * ONCHAIN_INSUFFICIENT_FUNDS – The escrow does not have enough balance for the
+ * requested operation.
+ */
+export const ONCHAIN_INSUFFICIENT_FUNDS = 'ONCHAIN_INSUFFICIENT_FUNDS' as const;
+
+/**
+ * ONCHAIN_PACKAGE_NOT_FOUND – The referenced aid package does not exist in the
+ * contract storage.
+ */
+export const ONCHAIN_PACKAGE_NOT_FOUND = 'ONCHAIN_PACKAGE_NOT_FOUND' as const;
+
+/**
+ * ONCHAIN_PACKAGE_EXPIRED – The aid package's claim window has closed.
+ */
+export const ONCHAIN_PACKAGE_EXPIRED = 'ONCHAIN_PACKAGE_EXPIRED' as const;
+
+/**
+ * ONCHAIN_INVALID_STATE – The attempted state transition is not permitted for
+ * the current package state.
+ */
+export const ONCHAIN_INVALID_STATE = 'ONCHAIN_INVALID_STATE' as const;
+
+/**
+ * ONCHAIN_NOT_AUTHORIZED – The signing key does not have permission to execute
+ * the requested contract operation.
+ */
+export const ONCHAIN_NOT_AUTHORIZED = 'ONCHAIN_NOT_AUTHORIZED' as const;
+
+/**
+ * ONCHAIN_CONTRACT_PAUSED – The AidEscrow contract is administratively paused;
+ * all write operations are blocked.
+ */
+export const ONCHAIN_CONTRACT_PAUSED = 'ONCHAIN_CONTRACT_PAUSED' as const;
+
+/**
+ * ONCHAIN_TOKEN_TRANSFER_FAILED – The on-chain token transfer instruction
+ * failed (e.g. recipient's trustline missing, balance insufficient).
+ */
+export const ONCHAIN_TOKEN_TRANSFER_FAILED =
+  'ONCHAIN_TOKEN_TRANSFER_FAILED' as const;
+
+/**
+ * ONCHAIN_RPC_ERROR – The Soroban JSON-RPC layer returned an error that does
+ * not map to a more specific code above.
+ */
+export const ONCHAIN_RPC_ERROR = 'ONCHAIN_RPC_ERROR' as const;
+
+// ---------------------------------------------------------------------------
+// Evidence / file-upload integration
+// ---------------------------------------------------------------------------
+
+/**
+ * EVIDENCE_UPLOAD_FAILED – The evidence file could not be stored locally or
+ * encrypted before queuing.
+ */
+export const EVIDENCE_UPLOAD_FAILED = 'EVIDENCE_UPLOAD_FAILED' as const;
+
+/**
+ * EVIDENCE_INVALID_FILE_TYPE – The uploaded file's MIME type or extension is
+ * not on the allow-list.
+ */
+export const EVIDENCE_INVALID_FILE_TYPE = 'EVIDENCE_INVALID_FILE_TYPE' as const;
+
+/**
+ * EVIDENCE_FILE_TOO_LARGE – The uploaded file exceeds the configured size
+ * limit.
+ */
+export const EVIDENCE_FILE_TOO_LARGE = 'EVIDENCE_FILE_TOO_LARGE' as const;
+
+/**
+ * EVIDENCE_MISSING_FILE – The multipart request did not include the expected
+ * file field.
+ */
+export const EVIDENCE_MISSING_FILE = 'EVIDENCE_MISSING_FILE' as const;
+
+/**
+ * EVIDENCE_NOT_FOUND – The requested evidence item does not exist or is not
+ * owned by the requesting principal.
+ */
+export const EVIDENCE_NOT_FOUND = 'EVIDENCE_NOT_FOUND' as const;
+
+/**
+ * EVIDENCE_ACCESS_DENIED – The artifact token is invalid, expired, or does
+ * not match the requested artifact.
+ */
+export const EVIDENCE_ACCESS_DENIED = 'EVIDENCE_ACCESS_DENIED' as const;
+
+/**
+ * EVIDENCE_CORRUPT_FILE – Magic-byte validation revealed the file content does
+ * not match the declared MIME type.
+ */
+export const EVIDENCE_CORRUPT_FILE = 'EVIDENCE_CORRUPT_FILE' as const;
+
+// ---------------------------------------------------------------------------
+// Webhook / event-delivery integration
+// ---------------------------------------------------------------------------
+
+/**
+ * WEBHOOK_DUPLICATE_EVENT – The incoming webhook event has already been
+ * processed (idempotency guard hit).
+ */
+export const WEBHOOK_DUPLICATE_EVENT = 'WEBHOOK_DUPLICATE_EVENT' as const;
+
+/**
+ * WEBHOOK_SESSION_NOT_FOUND – The session referenced by the webhook payload
+ * does not exist or is not in an actionable state.
+ */
+export const WEBHOOK_SESSION_NOT_FOUND = 'WEBHOOK_SESSION_NOT_FOUND' as const;
+
+/**
+ * WEBHOOK_STEP_NOT_FOUND – The target verification step referenced by the
+ * webhook payload was not found in the session.
+ */
+export const WEBHOOK_STEP_NOT_FOUND = 'WEBHOOK_STEP_NOT_FOUND' as const;
+
+/**
+ * WEBHOOK_INVALID_SIGNATURE – The HMAC signature on the incoming webhook
+ * request failed verification.
+ */
+export const WEBHOOK_INVALID_SIGNATURE = 'WEBHOOK_INVALID_SIGNATURE' as const;
+
+/**
+ * WEBHOOK_DELIVERY_FAILED – An outbound webhook could not be delivered to the
+ * configured endpoint after all retries were exhausted.
+ */
+export const WEBHOOK_DELIVERY_FAILED = 'WEBHOOK_DELIVERY_FAILED' as const;
+
+/**
+ * WEBHOOK_INVALID_PAYLOAD – The webhook payload did not satisfy validation
+ * rules (missing fields, bad types, etc.).
+ */
+export const WEBHOOK_INVALID_PAYLOAD = 'WEBHOOK_INVALID_PAYLOAD' as const;
+
+// ---------------------------------------------------------------------------
+// Aggregated map – import this to extend ERROR_CODES
+// ---------------------------------------------------------------------------
+
+/**
+ * INTEGRATION_ERROR_CODES is the single source of truth for all
+ * integration-specific error codes.  It is merged into the central ERROR_CODES
+ * constant in error-response.dto.ts.
+ *
+ * @example
+ * import { INTEGRATION_ERROR_CODES } from './integration-error-codes';
+ * throw new AppException(INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE, 503,
+ *   'AI service is temporarily unavailable');
+ */
+export const INTEGRATION_ERROR_CODES = {
+  // AI
+  AI_SERVICE_UNAVAILABLE,
+  AI_SERVICE_TIMEOUT,
+  AI_INVALID_RESPONSE,
+  AI_QUOTA_EXCEEDED,
+  AI_VERIFICATION_FAILED,
+  // Onchain
+  ONCHAIN_NETWORK_UNREACHABLE,
+  ONCHAIN_TRANSACTION_TIMEOUT,
+  ONCHAIN_TRANSACTION_FAILED,
+  ONCHAIN_CONTRACT_ERROR,
+  ONCHAIN_INSUFFICIENT_FUNDS,
+  ONCHAIN_PACKAGE_NOT_FOUND,
+  ONCHAIN_PACKAGE_EXPIRED,
+  ONCHAIN_INVALID_STATE,
+  ONCHAIN_NOT_AUTHORIZED,
+  ONCHAIN_CONTRACT_PAUSED,
+  ONCHAIN_TOKEN_TRANSFER_FAILED,
+  ONCHAIN_RPC_ERROR,
+  // Evidence
+  EVIDENCE_UPLOAD_FAILED,
+  EVIDENCE_INVALID_FILE_TYPE,
+  EVIDENCE_FILE_TOO_LARGE,
+  EVIDENCE_MISSING_FILE,
+  EVIDENCE_NOT_FOUND,
+  EVIDENCE_ACCESS_DENIED,
+  EVIDENCE_CORRUPT_FILE,
+  // Webhooks
+  WEBHOOK_DUPLICATE_EVENT,
+  WEBHOOK_SESSION_NOT_FOUND,
+  WEBHOOK_STEP_NOT_FOUND,
+  WEBHOOK_INVALID_SIGNATURE,
+  WEBHOOK_DELIVERY_FAILED,
+  WEBHOOK_INVALID_PAYLOAD,
+} as const;
+
+export type IntegrationErrorCode = keyof typeof INTEGRATION_ERROR_CODES;
+
+// ---------------------------------------------------------------------------
+// AppException – typed exception that carries a stable errorCode
+// ---------------------------------------------------------------------------
+
+/**
+ * AppException is a typed NestJS-compatible exception that carries a stable
+ * `errorCode` (one of the integration codes or base ERROR_CODES values) so
+ * AllExceptionsFilter can emit it verbatim instead of inferring a code from
+ * the HTTP status.
+ *
+ * @example
+ * throw new AppException(
+ *   INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+ *   503,
+ *   'AI service is temporarily unavailable',
+ *   { retryAfterSeconds: 30 },
+ * );
+ */
+export class AppException extends Error {
+  readonly errorCode: string;
+  readonly statusCode: number;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    errorCode: string,
+    statusCode: number,
+    message: string,
+    details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'AppException';
+    this.errorCode = errorCode;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}

--- a/app/backend/src/common/dto/error-response.dto.ts
+++ b/app/backend/src/common/dto/error-response.dto.ts
@@ -1,4 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { INTEGRATION_ERROR_CODES } from '../constants/integration-error-codes';
+
+// Re-export integration codes so consumers only need one import path.
+export { INTEGRATION_ERROR_CODES } from '../constants/integration-error-codes';
+export {
+  AppException,
+  type IntegrationErrorCode,
+} from '../constants/integration-error-codes';
 
 /**
  * Standardized error response format for all API endpoints
@@ -56,9 +64,12 @@ export class ErrorResponseDto {
 }
 
 /**
- * Standard error codes for programmatic handling
+ * Standard error codes for programmatic handling.
+ * Integration-specific codes are merged in from INTEGRATION_ERROR_CODES so
+ * both the base and domain codes are accessible from a single constant.
  */
 export const ERROR_CODES = {
+  // Base codes
   VALIDATION_ERROR: 'VALIDATION_ERROR',
   NOT_FOUND: 'NOT_FOUND',
   UNAUTHORIZED: 'UNAUTHORIZED',
@@ -76,6 +87,8 @@ export const ERROR_CODES = {
   INVALID_OPERATION: 'INVALID_OPERATION',
   DEPENDENCY_FAILURE: 'DEPENDENCY_FAILURE',
   TIMEOUT: 'TIMEOUT',
+  // Integration codes (AI, onchain, evidence, webhook)
+  ...INTEGRATION_ERROR_CODES,
 } as const;
 
 export type ErrorCode = keyof typeof ERROR_CODES;

--- a/app/backend/src/common/filters/http-exception.filter.ts
+++ b/app/backend/src/common/filters/http-exception.filter.ts
@@ -14,6 +14,7 @@ import {
   ERROR_CODES,
   getErrorCodeFromStatus,
 } from '../dto/error-response.dto';
+import { AppException } from '../constants/integration-error-codes';
 
 export interface ErrorResponse {
   code: number;
@@ -49,7 +50,14 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     let errorResponse: ErrorResponse;
 
-    if (exception instanceof HttpException) {
+    if (exception instanceof AppException) {
+      errorResponse = this.handleAppException(
+        exception,
+        request,
+        traceId,
+        correlationId,
+      );
+    } else if (exception instanceof HttpException) {
       errorResponse = this.handleHttpException(
         exception,
         request,
@@ -96,6 +104,28 @@ export class AllExceptionsFilter implements ExceptionFilter {
     };
 
     response.status(finalResponse.code).json(finalResponse);
+  }
+
+  /**
+   * Handles AppException, which carries a stable domain errorCode that is
+   * emitted verbatim rather than being inferred from the HTTP status.
+   */
+  private handleAppException(
+    exception: AppException,
+    request: Request,
+    traceId?: string,
+    correlationId?: string,
+  ): ErrorResponse {
+    return {
+      code: exception.statusCode,
+      message: exception.message,
+      details: exception.details,
+      traceId,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      errorCode: exception.errorCode,
+      correlationId,
+    };
   }
 
   private handleHttpException(

--- a/app/backend/src/common/index.ts
+++ b/app/backend/src/common/index.ts
@@ -6,6 +6,7 @@
 
 // Constants
 export * from './constants/api-version.constants';
+export * from './constants/integration-error-codes';
 
 // Decorators
 export * from './decorators/deprecated.decorator';

--- a/app/backend/src/evidence/evidence.controller.ts
+++ b/app/backend/src/evidence/evidence.controller.ts
@@ -11,8 +11,6 @@ import {
   Request,
   HttpCode,
   HttpStatus,
-  BadRequestException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import { Request as ExpressRequest } from 'express';
 import { AnyFilesInterceptor } from '@nestjs/platform-express';
@@ -41,6 +39,10 @@ import {
   evidenceMulterOptions,
   validateUploadedFile,
 } from './file-validation';
+import {
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from '../common/constants/integration-error-codes';
 
 @ApiTags('Evidence Queue')
 @ApiBearerAuth('JWT-auth')
@@ -102,16 +104,24 @@ export class EvidenceController {
     files: Express.Multer.File[] | undefined,
   ): Express.Multer.File {
     if (!files || files.length === 0) {
-      throw new BadRequestException('No file uploaded');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE,
+        400,
+        'No file uploaded',
+      );
     }
     if (files.length > 1) {
-      throw new BadRequestException(
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE,
+        400,
         `Only a single file may be uploaded in the "${UPLOAD_FIELD}" field`,
       );
     }
     const file = files[0];
     if (file.fieldname !== UPLOAD_FIELD) {
-      throw new BadRequestException(
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE,
+        400,
         `Unexpected field "${file.fieldname}"; file must be sent in the "${UPLOAD_FIELD}" field`,
       );
     }
@@ -185,7 +195,11 @@ export class EvidenceController {
     @Request() req?: ExpressRequest,
   ) {
     if (!orgId) {
-      throw new BadRequestException('orgId is required');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_MISSING_FILE,
+        400,
+        'orgId is required',
+      );
     }
 
     const userId = req?.user?.apiKeyId || req?.user?.authType || 'system';
@@ -195,7 +209,9 @@ export class EvidenceController {
     const ownsArtifact =
       await this.artifactTokenService.validateArtifactOwnership(id, orgId);
     if (!ownsArtifact) {
-      throw new UnauthorizedException(
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_ACCESS_DENIED,
+        401,
         'Artifact does not belong to the specified organization',
       );
     }
@@ -251,7 +267,11 @@ export class EvidenceController {
 
     // Additional validation: ensure token artifact ID matches URL
     if (tokenPayload.artifactId !== id) {
-      throw new UnauthorizedException('Token artifact ID mismatch');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_ACCESS_DENIED,
+        401,
+        'Token artifact ID mismatch',
+      );
     }
 
     // Get artifact details from evidence service
@@ -259,7 +279,11 @@ export class EvidenceController {
     const artifactItem = artifact.find(item => item.id === id);
 
     if (!artifactItem) {
-      throw new UnauthorizedException('Artifact not found');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.EVIDENCE_NOT_FOUND,
+        401,
+        'Artifact not found',
+      );
     }
 
     return {

--- a/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
@@ -4,7 +4,7 @@ describe('SorobanErrorMapper', () => {
   const mapper = new SorobanErrorMapper();
 
   it('maps invalid token contract errors from numeric contract codes', () => {
-    expect(mapper.mapError({ errorCode: 17 })).toEqual({
+    expect(mapper.mapError({ errorCode: 17 })).toMatchObject({
       statusCode: 400,
       message: 'Invalid token contract address',
       details: {
@@ -15,7 +15,7 @@ describe('SorobanErrorMapper', () => {
   });
 
   it('maps reverted token transfers from numeric contract codes', () => {
-    expect(mapper.mapError({ errorCode: 18 })).toEqual({
+    expect(mapper.mapError({ errorCode: 18 })).toMatchObject({
       statusCode: 502,
       message: 'Token transfer failed',
       details: {

--- a/app/backend/src/onchain/utils/soroban-error.mapper.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.ts
@@ -1,7 +1,7 @@
 import {
-  BadRequestException,
-  InternalServerErrorException,
-} from '@nestjs/common';
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from '../../common/constants/integration-error-codes';
 
 /**
  * Maps Soroban contract errors to standardized backend error responses
@@ -13,29 +13,26 @@ export class SorobanErrorMapper {
    */
   private readonly contractErrors: Record<
     number,
-    { code: number; message: string }
+    { code: number; message: string; errorCode: string }
   > = {
-    1: { code: 400, message: 'Escrow not initialized' },
-    2: { code: 409, message: 'Escrow already initialized' },
-    3: { code: 403, message: 'Not authorized to perform this action' },
-    4: { code: 400, message: 'Invalid amount' },
-    5: { code: 404, message: 'Package not found' },
-    6: { code: 400, message: 'Package is not active' },
-    7: { code: 410, message: 'Package has expired' },
-    8: { code: 400, message: 'Package has not expired' },
-    9: { code: 400, message: 'Insufficient funds in escrow' },
-    10: { code: 409, message: 'Package ID already exists' },
-    11: { code: 400, message: 'Invalid state transition' },
-    12: {
-      code: 400,
-      message: 'Recipients and amounts arrays have different lengths',
-    },
-    13: { code: 400, message: 'Insufficient surplus funds' },
-    14: { code: 503, message: 'Contract is paused' },
-    15: { code: 400, message: 'Claim window has not started' },
-    16: { code: 400, message: 'Invalid claim proof' },
-    17: { code: 400, message: 'Invalid token contract address' },
-    18: { code: 502, message: 'Token transfer failed' },
+    1: { code: 400, message: 'Escrow not initialized', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    2: { code: 409, message: 'Escrow already initialized', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    3: { code: 403, message: 'Not authorized to perform this action', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED },
+    4: { code: 400, message: 'Invalid amount', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    5: { code: 404, message: 'Package not found', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND },
+    6: { code: 400, message: 'Package is not active', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+    7: { code: 410, message: 'Package has expired', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED },
+    8: { code: 400, message: 'Package has not expired', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+    9: { code: 400, message: 'Insufficient funds in escrow', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS },
+    10: { code: 409, message: 'Package ID already exists', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    11: { code: 400, message: 'Invalid state transition', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+    12: { code: 400, message: 'Recipients and amounts arrays have different lengths', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    13: { code: 400, message: 'Insufficient surplus funds', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS },
+    14: { code: 503, message: 'Contract is paused', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_PAUSED },
+    15: { code: 400, message: 'Claim window has not started', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+    16: { code: 400, message: 'Invalid claim proof', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    17: { code: 400, message: 'Invalid token contract address', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+    18: { code: 502, message: 'Token transfer failed', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED },
   };
 
   /**
@@ -44,6 +41,7 @@ export class SorobanErrorMapper {
   mapError(error: any): {
     statusCode: number;
     message: string;
+    errorCode: string;
     details?: Record<string, unknown>;
   } {
     // Handle RPC/Network errors
@@ -52,6 +50,7 @@ export class SorobanErrorMapper {
       return {
         statusCode: 503,
         message: 'Blockchain network unreachable',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE,
         details: {
           error_type: 'network_error',
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -77,6 +76,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: mapping.code,
           message: mapping.message,
+          errorCode: mapping.errorCode,
           details: {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             error_code: error.errorCode,
@@ -96,7 +96,16 @@ export class SorobanErrorMapper {
         message.includes('NotAuthorized') ||
         message.includes('PackageNotFound') ||
         message.includes('PackageExpired') ||
+        message.includes('PackageNotActive') ||
+        message.includes('PackageNotExpired') ||
+        message.includes('InsufficientFunds') ||
+        message.includes('InsufficientSurplus') ||
+        message.includes('PackageIdExists') ||
+        message.includes('InvalidState') ||
+        message.includes('MismatchedArrays') ||
+        message.includes('ContractPaused') ||
         message.includes('ClaimTooEarly') ||
+        message.includes('InvalidAmount') ||
         message.includes('InvalidProof') ||
         message.includes('InvalidToken') ||
         message.includes('TokenTransferFailed'))
@@ -110,6 +119,7 @@ export class SorobanErrorMapper {
       return {
         statusCode: 504,
         message: 'Blockchain operation timed out',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT,
         details: {
           error_type: 'timeout',
           original_error: message,
@@ -122,6 +132,7 @@ export class SorobanErrorMapper {
       return {
         statusCode: 400,
         message: 'Transaction submission failed',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TRANSACTION_FAILED,
         details: {
           error_type: 'transaction_error',
           original_error: message,
@@ -133,6 +144,7 @@ export class SorobanErrorMapper {
     return {
       statusCode: 500,
       message: 'An error occurred while communicating with the blockchain',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
       details: {
         error_type: 'unknown_error',
         original_message: message,
@@ -146,6 +158,7 @@ export class SorobanErrorMapper {
   private mapJsonRpcError(jsonRpcError: any): {
     statusCode: number;
     message: string;
+    errorCode: string;
     details?: Record<string, unknown>;
   } {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -164,6 +177,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: 400,
           message: 'Invalid request parameters',
+          errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
           details: { error_code: code, rpc_message: message },
         };
 
@@ -171,6 +185,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: 404,
           message: 'RPC method not available',
+          errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
           details: { error_code: code, rpc_message: message },
         };
 
@@ -178,6 +193,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: 500,
           message: 'Blockchain RPC internal error',
+          errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
           details: { error_code: code as number, rpc_message: message },
         };
 
@@ -187,12 +203,14 @@ export class SorobanErrorMapper {
           return {
             statusCode: 500,
             message: 'Blockchain RPC server error',
+            errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
             details: { error_code: code as number, rpc_message: message },
           };
         }
         return {
           statusCode: 500,
           message: 'Blockchain RPC error',
+          errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_RPC_ERROR,
           details: { error_code: code as number, rpc_message: message },
         };
     }
@@ -204,33 +222,28 @@ export class SorobanErrorMapper {
   private mapContractErrorMessage(message: string): {
     statusCode: number;
     message: string;
+    errorCode: string;
     details?: Record<string, unknown>;
   } {
-    const errorMap: Record<string, { code: number; message: string }> = {
-      NotInitialized: { code: 400, message: 'Escrow not initialized' },
-      AlreadyInitialized: { code: 409, message: 'Escrow already initialized' },
-      NotAuthorized: {
-        code: 403,
-        message: 'Not authorized to perform this action',
-      },
-      InvalidAmount: { code: 400, message: 'Invalid amount' },
-      PackageNotFound: { code: 404, message: 'Package not found' },
-      PackageNotActive: { code: 400, message: 'Package is not active' },
-      PackageExpired: { code: 410, message: 'Package has expired' },
-      PackageNotExpired: { code: 400, message: 'Package has not expired' },
-      InsufficientFunds: { code: 400, message: 'Insufficient funds in escrow' },
-      PackageIdExists: { code: 409, message: 'Package ID already exists' },
-      InvalidState: { code: 400, message: 'Invalid state transition' },
-      MismatchedArrays: {
-        code: 400,
-        message: 'Recipients and amounts arrays have different lengths',
-      },
-      InsufficientSurplus: { code: 400, message: 'Insufficient surplus funds' },
-      ContractPaused: { code: 503, message: 'Contract is paused' },
-      ClaimTooEarly: { code: 400, message: 'Claim window has not started' },
-      InvalidProof: { code: 400, message: 'Invalid claim proof' },
-      InvalidToken: { code: 400, message: 'Invalid token contract address' },
-      TokenTransferFailed: { code: 502, message: 'Token transfer failed' },
+    const errorMap: Record<string, { code: number; message: string; errorCode: string }> = {
+      NotInitialized: { code: 400, message: 'Escrow not initialized', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      AlreadyInitialized: { code: 409, message: 'Escrow already initialized', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      NotAuthorized: { code: 403, message: 'Not authorized to perform this action', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED },
+      InvalidAmount: { code: 400, message: 'Invalid amount', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      PackageNotFound: { code: 404, message: 'Package not found', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND },
+      PackageNotActive: { code: 400, message: 'Package is not active', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+      PackageExpired: { code: 410, message: 'Package has expired', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED },
+      PackageNotExpired: { code: 400, message: 'Package has not expired', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+      InsufficientFunds: { code: 400, message: 'Insufficient funds in escrow', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS },
+      PackageIdExists: { code: 409, message: 'Package ID already exists', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      InvalidState: { code: 400, message: 'Invalid state transition', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+      MismatchedArrays: { code: 400, message: 'Recipients and amounts arrays have different lengths', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      InsufficientSurplus: { code: 400, message: 'Insufficient surplus funds', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS },
+      ContractPaused: { code: 503, message: 'Contract is paused', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_PAUSED },
+      ClaimTooEarly: { code: 400, message: 'Claim window has not started', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE },
+      InvalidProof: { code: 400, message: 'Invalid claim proof', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      InvalidToken: { code: 400, message: 'Invalid token contract address', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR },
+      TokenTransferFailed: { code: 502, message: 'Token transfer failed', errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED },
     };
 
     for (const [errorKey, errorInfo] of Object.entries(errorMap)) {
@@ -238,6 +251,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: errorInfo.code,
           message: errorInfo.message,
+          errorCode: errorInfo.errorCode,
           details: {
             error_type: 'contract_error',
             error_name: errorKey,
@@ -251,6 +265,7 @@ export class SorobanErrorMapper {
         return {
           statusCode: errorInfo.code,
           message: errorInfo.message,
+          errorCode: errorInfo.errorCode,
           details: {
             error_type: 'contract_error',
             error_code: Number(errorCode),
@@ -263,6 +278,7 @@ export class SorobanErrorMapper {
     return {
       statusCode: 500,
       message: 'Contract error occurred',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
       details: {
         error_type: 'contract_error',
         original_message: message,
@@ -271,71 +287,16 @@ export class SorobanErrorMapper {
   }
 
   /**
-   * Throws an appropriate NestJS exception based on the mapped error
+   * Throws an AppException based on the mapped error so AllExceptionsFilter
+   * emits the stable onchain errorCode verbatim.
    */
   throwMappedError(error: unknown): never {
     const mapped = this.mapError(error);
-
-    if (mapped.statusCode === 400) {
-      throw new BadRequestException({
-        code: mapped.statusCode,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 403) {
-      throw new BadRequestException({
-        code: 403,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 404) {
-      throw new BadRequestException({
-        code: 404,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 409) {
-      throw new BadRequestException({
-        code: 409,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 410) {
-      throw new BadRequestException({
-        code: 410,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 503) {
-      throw new InternalServerErrorException({
-        code: 503,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    if (mapped.statusCode === 502) {
-      throw new InternalServerErrorException({
-        code: 502,
-        message: mapped.message,
-        details: mapped.details,
-      });
-    }
-
-    throw new InternalServerErrorException({
-      code: mapped.statusCode,
-      message: mapped.message,
-      details: mapped.details,
-    });
+    throw new AppException(
+      mapped.errorCode,
+      mapped.statusCode,
+      mapped.message,
+      mapped.details,
+    );
   }
 }

--- a/app/backend/src/verification/verification.service.spec.ts
+++ b/app/backend/src/verification/verification.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getQueueToken } from '@nestjs/bullmq';
 import { HttpService } from '@nestjs/axios';
@@ -248,12 +247,15 @@ describe('VerificationService', () => {
       );
     });
 
-    it('should throw NotFoundException for non-existent claim', async () => {
+    it('should throw AppException(AI_VERIFICATION_FAILED) for non-existent claim', async () => {
       jest.spyOn(prismaService.claim, 'findUnique').mockResolvedValue(null);
 
       await expect(
         service.enqueueVerification('non-existent-id'),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toMatchObject({
+        errorCode: 'AI_VERIFICATION_FAILED',
+        statusCode: 404,
+      });
     });
 
     it('should skip enqueuing for already verified claims', async () => {
@@ -298,7 +300,7 @@ describe('VerificationService', () => {
       expect(updateSpy).toHaveBeenCalled();
     });
 
-    it('should throw NotFoundException for non-existent claim during processing', async () => {
+    it('should throw AppException(AI_VERIFICATION_FAILED) for non-existent claim during processing', async () => {
       jest.spyOn(prismaService.claim, 'findUnique').mockResolvedValue(null);
 
       await expect(
@@ -307,7 +309,10 @@ describe('VerificationService', () => {
           timestamp: Date.now(),
           priority: VerificationPriority.NORMAL,
         }),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toMatchObject({
+        errorCode: 'AI_VERIFICATION_FAILED',
+        statusCode: 404,
+      });
     });
 
     it('should update claim status to verified when score meets threshold', async () => {
@@ -573,12 +578,13 @@ describe('VerificationService', () => {
       expect(result).toEqual(mockClaim);
     });
 
-    it('should throw NotFoundException for non-existent claim', async () => {
+    it('should throw AppException(AI_VERIFICATION_FAILED) for non-existent claim', async () => {
       jest.spyOn(prismaService.claim, 'findUnique').mockResolvedValue(null);
 
-      await expect(service.findOne('non-existent-id')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(service.findOne('non-existent-id')).rejects.toMatchObject({
+        errorCode: 'AI_VERIFICATION_FAILED',
+        statusCode: 404,
+      });
     });
   });
 

--- a/app/backend/src/verification/verification.service.ts
+++ b/app/backend/src/verification/verification.service.ts
@@ -1,8 +1,6 @@
 import {
-  BadRequestException,
   Injectable,
   Logger,
-  NotFoundException,
 } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
@@ -28,6 +26,10 @@ import {
 import { AuditService } from '../audit/audit.service';
 import { firstValueFrom } from 'rxjs';
 import OpenAI from 'openai';
+import {
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from '../common/constants/integration-error-codes';
 import * as crypto from 'crypto';
 import { CircuitBreaker } from '../common/utils/circuit-breaker.util';
 import { VerificationMetadataService } from './metadata.service';
@@ -218,7 +220,12 @@ export class VerificationService {
     });
 
     if (!claim) {
-      throw new NotFoundException(`Claim with ID ${claimId} not found`);
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+        404,
+        `Claim with ID ${claimId} not found`,
+        { claimId },
+      );
     }
 
     if (claim.status === 'verified') {
@@ -298,7 +305,12 @@ export class VerificationService {
     });
 
     if (!claim) {
-      throw new NotFoundException(`Claim with ID ${claimId} not found`);
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+        404,
+        `Claim with ID ${claimId} not found`,
+        { claimId },
+      );
     }
 
     let result: VerificationResult;
@@ -664,17 +676,34 @@ the JSON verdict.
         message: string;
       };
       if (err.response) {
-        throw new Error(
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_INVALID_RESPONSE,
+          502,
           `OCR service returned ${err.response.status}: ` +
             `${JSON.stringify(err.response.data)}`,
+          { httpStatus: err.response.status, body: err.response.data },
         );
-      } else if (err.code === 'ECONNREFUSED') {
-        throw new Error(
+      } else if (err.code === 'ECONNREFUSED' || err.code === 'ENOTFOUND') {
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+          503,
           `OCR service unavailable at ${this.aiServiceUrl}. ` +
             `Is the Python ai-service running?`,
+          { serviceUrl: this.aiServiceUrl },
+        );
+      } else if (err.message?.includes('timeout') || err.code === 'ETIMEDOUT') {
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_SERVICE_TIMEOUT,
+          504,
+          `OCR service call timed out: ${err.message}`,
+          { serviceUrl: this.aiServiceUrl },
         );
       } else {
-        throw new Error(`OCR service call failed: ${err.message}`);
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+          503,
+          `OCR service call failed: ${err.message}`,
+        );
       }
     }
   }
@@ -928,7 +957,12 @@ the JSON verdict.
   async findOne(id: string) {
     const claim = await this.prisma.claim.findUnique({ where: { id } });
     if (!claim) {
-      throw new NotFoundException(`Claim with ID ${id} not found`);
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+        404,
+        `Claim with ID ${id} not found`,
+        { claimId: id },
+      );
     }
     return claim;
   }
@@ -1166,12 +1200,20 @@ the JSON verdict.
         typeof parsed.createdAt !== 'string' ||
         typeof parsed.id !== 'string'
       ) {
-        throw new BadRequestException('Invalid review queue cursor');
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+          400,
+          'Invalid review queue cursor',
+        );
       }
 
       const createdAt = new Date(parsed.createdAt);
       if (Number.isNaN(createdAt.getTime())) {
-        throw new BadRequestException('Invalid review queue cursor');
+        throw new AppException(
+          INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+          400,
+          'Invalid review queue cursor',
+        );
       }
 
       return {
@@ -1179,11 +1221,15 @@ the JSON verdict.
         id: parsed.id,
       };
     } catch (error) {
-      if (error instanceof BadRequestException) {
+      if (error instanceof AppException) {
         throw error;
       }
 
-      throw new BadRequestException('Invalid review queue cursor');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.AI_VERIFICATION_FAILED,
+        400,
+        'Invalid review queue cursor',
+      );
     }
   }
 }

--- a/app/backend/src/webhooks.service.spec.ts
+++ b/app/backend/src/webhooks.service.spec.ts
@@ -6,7 +6,10 @@ import {
   AiVerificationPayloadDto,
   VerificationStatus,
 } from './ai-verification.dto';
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from './common/constants/integration-error-codes';
 
 jest.mock('@prisma/client', () => {
   return {
@@ -25,7 +28,6 @@ jest.mock('@prisma/client', () => {
   };
 });
 
-// Define the mock Prisma type for better type safety
 type MockPrismaService = {
   webhookEvent: {
     findUnique: jest.Mock;
@@ -36,11 +38,8 @@ type MockPrismaService = {
 
 describe('WebhooksService', () => {
   let service: WebhooksService;
-  // _prisma is intentionally unused - kept for potential future use
-  let _prisma: PrismaService;
   let sessionService: SessionService;
 
-  // Use type assertion for the mock
   const mockPrisma = {
     webhookEvent: {
       findUnique: jest.fn(),
@@ -76,7 +75,6 @@ describe('WebhooksService', () => {
     }).compile();
 
     service = module.get<WebhooksService>(WebhooksService);
-    _prisma = module.get<PrismaService>(PrismaService);
     sessionService = module.get<SessionService>(SessionService);
 
     jest.clearAllMocks();
@@ -87,27 +85,57 @@ describe('WebhooksService', () => {
   });
 
   describe('processAiVerification', () => {
-    it('should throw ConflictException if event is already processed', async () => {
-      // Use type assertion to access the mocked property
-      mockPrisma.webhookEvent.findUnique.mockResolvedValue({
-        id: '1',
-      });
+    it('should throw AppException(WEBHOOK_DUPLICATE_EVENT) if event is already processed', async () => {
+      mockPrisma.webhookEvent.findUnique.mockResolvedValue({ id: '1' });
 
-      await expect(service.processAiVerification(payload)).rejects.toThrow(
-        ConflictException,
-      );
+      await expect(service.processAiVerification(payload)).rejects.toMatchObject({
+        errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT,
+        statusCode: 409,
+      });
     });
 
-    it('should throw NotFoundException if session is not found or not active', async () => {
+    it('should be an AppException instance for duplicate event', async () => {
+      mockPrisma.webhookEvent.findUnique.mockResolvedValue({ id: '1' });
+
+      let caught: unknown;
+      try {
+        await service.processAiVerification(payload);
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeInstanceOf(AppException);
+      const ex = caught as AppException;
+      expect(ex.errorCode).toBe(INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT);
+      expect(ex.statusCode).toBe(409);
+      expect(ex.details).toMatchObject({ eventId: payload.eventId });
+    });
+
+    it('should throw AppException(WEBHOOK_SESSION_NOT_FOUND) if session is missing', async () => {
       mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
       mockSessionServiceObj.getSession.mockResolvedValue(null);
 
-      await expect(service.processAiVerification(payload)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(service.processAiVerification(payload)).rejects.toMatchObject({
+        errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+        statusCode: 404,
+      });
     });
 
-    it('should throw NotFoundException if a suitable step is not found', async () => {
+    it('should throw AppException(WEBHOOK_SESSION_NOT_FOUND) if session is not pending', async () => {
+      mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
+      mockSessionServiceObj.getSession.mockResolvedValue({
+        id: 'sess_456',
+        status: 'approved',
+        steps: [],
+      });
+
+      await expect(service.processAiVerification(payload)).rejects.toMatchObject({
+        errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+        statusCode: 404,
+      });
+    });
+
+    it('should throw AppException(WEBHOOK_STEP_NOT_FOUND) if no matching step exists', async () => {
       mockPrisma.webhookEvent.findUnique.mockResolvedValue(null);
       mockSessionServiceObj.getSession.mockResolvedValue({
         id: 'sess_456',
@@ -115,9 +143,10 @@ describe('WebhooksService', () => {
         steps: [{ stepName: 'other_step', status: 'pending' }],
       });
 
-      await expect(service.processAiVerification(payload)).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(service.processAiVerification(payload)).rejects.toMatchObject({
+        errorCode: INTEGRATION_ERROR_CODES.WEBHOOK_STEP_NOT_FOUND,
+        statusCode: 404,
+      });
     });
 
     it('should process the webhook successfully', async () => {
@@ -137,7 +166,6 @@ describe('WebhooksService', () => {
 
       const result = await service.processAiVerification(payload);
 
-      // Use type assertion for the expectation
       expect(mockPrisma.webhookEvent.create).toHaveBeenCalled();
       expect(sessionService.submitToStep).toHaveBeenCalledWith(
         payload.sessionId,

--- a/app/backend/src/webhooks.service.ts
+++ b/app/backend/src/webhooks.service.ts
@@ -1,13 +1,12 @@
-import {
-  Injectable,
-  Logger,
-  ConflictException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { SessionService } from 'src/session/session.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AiVerificationPayloadDto } from 'src/ai-verification.dto';
 import { Prisma } from '@prisma/client';
+import {
+  AppException,
+  INTEGRATION_ERROR_CODES,
+} from './common/constants/integration-error-codes';
 
 @Injectable()
 export class WebhooksService {
@@ -28,13 +27,23 @@ export class WebhooksService {
 
     if (existingEvent) {
       this.logger.log(`Webhook event ${eventId} already processed. Skipping.`);
-      throw new ConflictException('Event already processed');
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_DUPLICATE_EVENT,
+        409,
+        'Event already processed',
+        { eventId },
+      );
     }
 
     // 2. Find the relevant session and step
     const session = await this.sessionService.getSession(sessionId);
     if (!session || session.status !== 'pending') {
-      throw new NotFoundException(`Active session ${sessionId} not found.`);
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+        404,
+        `Active session ${sessionId} not found.`,
+        { sessionId },
+      );
     }
 
     // Optional chaining prevents compilation failures if session.steps is missing
@@ -45,8 +54,11 @@ export class WebhooksService {
     );
 
     if (!verificationStep) {
-      throw new NotFoundException(
+      throw new AppException(
+        INTEGRATION_ERROR_CODES.WEBHOOK_STEP_NOT_FOUND,
+        404,
         `Pending identity_verification step not found for session ${sessionId}.`,
+        { sessionId },
       );
     }
 


### PR DESCRIPTION
 Summary
  
  Introduces a stable, machine-readable error code system for all four backend integration domains so
  frontend and mobile clients can reliably branch on failure type rather than HTTP status alone.
  
  What was changed
  
  - integration-error-codes.ts (new) — single source of truth for all integration error codes across AI
  (AI_SERVICE_UNAVAILABLE, AI_SERVICE_TIMEOUT, AI_INVALID_RESPONSE, AI_QUOTA_EXCEEDED,
  AI_VERIFICATION_FAILED), onchain (ONCHAIN_NETWORK_UNREACHABLE, ONCHAIN_TRANSACTION_TIMEOUT,
  ONCHAIN_TRANSACTION_FAILED, ONCHAIN_CONTRACT_ERROR, ONCHAIN_PACKAGE_NOT_FOUND, ONCHAIN_PACKAGE_EXPIRED,
  ONCHAIN_INVALID_STATE, ONCHAIN_NOT_AUTHORIZED, ONCHAIN_CONTRACT_PAUSED, ONCHAIN_TOKEN_TRANSFER_FAILED,
  ONCHAIN_RPC_ERROR), evidence (EVIDENCE_UPLOAD_FAILED, EVIDENCE_INVALID_FILE_TYPE, EVIDENCE_FILE_TOO_LARGE,
  EVIDENCE_MISSING_FILE, EVIDENCE_NOT_FOUND, EVIDENCE_ACCESS_DENIED, EVIDENCE_CORRUPT_FILE), and webhook
  (WEBHOOK_DUPLICATE_EVENT, WEBHOOK_SESSION_NOT_FOUND, WEBHOOK_STEP_NOT_FOUND, WEBHOOK_INVALID_SIGNATURE,
  WEBHOOK_DELIVERY_FAILED, WEBHOOK_INVALID_PAYLOAD). Also exports AppException — a typed NestJS-compatible
  exception that carries errorCode, statusCode, message, and optional details.
  - error-response.dto.ts — merges INTEGRATION_ERROR_CODES into the central ERROR_CODES map so all codes are
  accessible from one import.
  - http-exception.filter.ts — AllExceptionsFilter now detects AppException and emits its errorCode verbatim
  instead of inferring one from the HTTP status.
  - webhooks.service.ts / audit/webhooks.service.ts — replaced raw ConflictException/NotFoundException with
  AppException(WEBHOOK_DUPLICATE_EVENT), AppException(WEBHOOK_SESSION_NOT_FOUND), and
  AppException(WEBHOOK_STEP_NOT_FOUND).
  - verification.service.ts — replaced NotFoundException/BadRequestException with
  AppException(AI_VERIFICATION_FAILED) on claim lookups; OCR service error paths now emit
  AI_SERVICE_UNAVAILABLE, AI_SERVICE_TIMEOUT, and AI_INVALID_RESPONSE.
  - soroban-error.mapper.ts — expanded the contract-error gate to include ContractPaused, InsufficientFunds,
  InvalidState, MismatchedArrays, and other previously missing contract error names so all string-message
  paths route correctly.
  
  Tests
  
  - integration-error-codes.spec.ts (new) — 40+ unit tests: catalogue completeness for all 4 domains,
  AppException shape and property contract, SorobanErrorMapper covering
  network/numeric-code/string-message/JSON-RPC/throwMappedError paths, AuditWebhooksService all 4 failure
  paths, evidence and AI AppException shapes.
  - webhooks.service.spec.ts — updated to assert AppException instances with stable errorCode and
  statusCode.
  - verification.service.spec.ts — 3 stale NotFoundException assertions replaced with toMatchObject({
  errorCode: 'AI_VERIFICATION_FAILED' }).
  - soroban-error.mapper.spec.ts — updated 2 toEqual to toMatchObject to accommodate the errorCode field now
  present in all mapper results.
  
  Result: 649 tests pass, 0 failures.
  
  Testing done
  
  ./node_modules/.bin/jest --no-coverage
  Test Suites: 1 skipped, 61 passed, 61 of 62 total
  Tests:       10 skipped, 649 passed, 659 total

closes #711