### PR TITLE
feat(ai-service): add batch OCR endpoint for grouped evidence documents

### DIFF
--- a/app/ai-service/api/v1/ocr.py
+++ b/app/ai-service/api/v1/ocr.py
@@ -16,7 +16,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 import tasks
-from schemas.ocr import OCRData, LanguageHint
+from schemas.ocr import BatchOCRDocumentStatus, BatchOCRResponse, OCRData, LanguageHint
 from schemas.common import ResultEnvelope
 from services.ocr_job import run_ocr_from_bytes
 from config import settings
@@ -112,6 +112,93 @@ async def process_ocr(
                 "message": str(e),
             },
         )
+
+
+@router.post(
+    "/ai/ocr/batch",
+    response_model=BatchOCRResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+@limiter.limit(settings.request_rate_limit)
+async def queue_batch_ocr_jobs(
+    request: Request,
+    files: Annotated[list[UploadFile], File(description="One or more image files to process")],
+    anchor_metadata: Annotated[Optional[str], Form(description="JSON encoded AnchorMetadata")] = None,
+    language_hint: Annotated[Optional[LanguageHint], Form(description="Language hint for OCR")] = None,
+) -> BatchOCRResponse:
+    """Queue OCR processing for a batch of uploaded document images."""
+    if not files:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "empty_batch",
+                "message": "At least one image file is required for batch OCR",
+            },
+        )
+
+    document_statuses: list[BatchOCRDocumentStatus] = []
+    for image in files:
+        try:
+            if image.content_type not in ALLOWED_CONTENT_TYPES:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "code": "invalid_content_type",
+                        "message": (
+                            f"Invalid content type: {image.content_type}. "
+                            f"Allowed: {', '.join(ALLOWED_CONTENT_TYPES)}"
+                        ),
+                    },
+                )
+
+            contents = await image.read()
+            if len(contents) == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "code": "empty_image",
+                        "message": "Uploaded image is empty",
+                    },
+                )
+
+            _validate_image_bytes(contents)
+            task_id = tasks.create_task(
+                task_type="ocr",
+                payload={
+                    "image_base64": base64.b64encode(contents).decode("ascii"),
+                    "content_type": image.content_type,
+                    "filename": image.filename,
+                    "anchor_metadata": anchor_metadata,
+                    "language_hint": language_hint.value if language_hint else None,
+                },
+            )
+
+            document_statuses.append(
+                BatchOCRDocumentStatus(
+                    filename=image.filename,
+                    status="pending",
+                    task_id=task_id,
+                    status_url=f"/v1/ai/jobs/{task_id}",
+                )
+            )
+        except HTTPException as exc:
+            document_statuses.append(
+                BatchOCRDocumentStatus(
+                    filename=image.filename,
+                    status="failed",
+                    error=exc.detail if isinstance(exc.detail, dict) else {"code": "processing_error", "message": str(exc.detail)},
+                )
+            )
+        except Exception as exc:
+            document_statuses.append(
+                BatchOCRDocumentStatus(
+                    filename=image.filename,
+                    status="failed",
+                    error={"code": "processing_error", "message": str(exc)},
+                )
+            )
+
+    return BatchOCRResponse(success=True, documents=document_statuses)
 
 
 @router.post(

--- a/app/ai-service/schemas/ocr.py
+++ b/app/ai-service/schemas/ocr.py
@@ -4,6 +4,19 @@ from pydantic import BaseModel, Field
 from schemas.common import AnchorMetadata
 
 
+class BatchOCRDocumentStatus(BaseModel):
+    filename: str | None = None
+    status: str
+    task_id: str | None = None
+    status_url: str | None = None
+    error: dict[str, str] | None = None
+
+
+class BatchOCRResponse(BaseModel):
+    success: bool = Field(examples=[True])
+    documents: list[BatchOCRDocumentStatus]
+
+
 class LanguageHint(str, Enum):
     eng = "eng"
     spa = "spa"

--- a/app/ai-service/tests/test_async_ocr_jobs.py
+++ b/app/ai-service/tests/test_async_ocr_jobs.py
@@ -85,6 +85,37 @@ def test_task_status_endpoint_returns_local_job_status(client):
     assert data["result"]["type"] == "ocr"
 
 
+def test_batch_ocr_returns_document_statuses_for_mixed_inputs(client, monkeypatch):
+    created_tasks = []
+
+    def fake_create_task(task_type, payload):
+        created_tasks.append((task_type, payload))
+        return f"ocr-task-{len(created_tasks)}"
+
+    monkeypatch.setattr(tasks, "create_task", fake_create_task)
+
+    response = client.post(
+        "/v1/ai/ocr/batch",
+        files=[
+            ("files", ("doc-a.png", _png_bytes(), "image/png")),
+            ("files", ("doc-b.png", b"not-a-real-image", "image/png")),
+            ("files", ("doc-c.png", _png_bytes(), "image/png")),
+        ],
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["success"] is True
+    assert len(data["documents"]) == 3
+    assert data["documents"][0]["status"] == "pending"
+    assert data["documents"][0]["task_id"] == "ocr-task-1"
+    assert data["documents"][1]["status"] == "failed"
+    assert data["documents"][1]["error"]["code"] == "invalid_image"
+    assert data["documents"][2]["status"] == "pending"
+    assert data["documents"][2]["task_id"] == "ocr-task-2"
+    assert len(created_tasks) == 2
+
+
 def test_retry_policy_is_defined_on_heavy_task():
     task = tasks.get_process_heavy_inference_task()
 


### PR DESCRIPTION

Summary
add a new batch OCR endpoint for submitting multiple evidence documents in one request
return per-document job IDs and status so clients can track grouped OCR work
ensure validation failures on one document do not prevent the rest of the batch from being processed
Changes
implemented a batch OCR route in the AI service
added per-document status reporting for queued and failed submissions
covered mixed success and validation-error scenarios with regression tests
Closes
Closes #765