### PR TITLE
fix(ci): add APP_ENV and TEST_PROVIDER_MODE env vars to ai-service docker-build step

### DIFF
--- a/.github/workflows/ai-service-ci.yml
+++ b/.github/workflows/ai-service-ci.yml
@@ -152,7 +152,11 @@ jobs:
         
     - name: Test Docker container
       run: |
-        docker run -d --name test-container -p 8000:8000 soter-ai-service:test
+        docker run -d --name test-container \
+          -e APP_ENV=development \
+          -e TEST_PROVIDER_MODE=true \
+          -p 8000:8000 \
+          soter-ai-service:test
         # Wait for container to be ready with retry logic
         for i in $(seq 1 30); do
           if curl -sf http://localhost:8000/health > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Fixes #879 - ai-service Docker build/test may fail if Dockerfile.simple lacks env vars

## Changes
- Added `APP_ENV=development` and `TEST_PROVIDER_MODE=true` environment variables to the `docker run` command in the docker-build job's "Test Docker container" step
- These env vars ensure the container starts properly without requiring API keys in CI

## Verification
- Dockerfile.simple already has correct port 8000 exposure, healthcheck, and gunicorn binding
- All ai-service tests pass (405 passed, 5 skipped)
- Config validation: development mode + test provider mode allows app to start without API keys

Closes #879