### PR TITLE
Harden scanner against duplicate and bounce scans 

### DIFF
--- a/app/mobile/src/__tests__/ScannerScreen.test.tsx
+++ b/app/mobile/src/__tests__/ScannerScreen.test.tsx
@@ -1,4 +1,5 @@
 import { parseAidIdFromQRCode } from '../screens/ScannerScreen';
+import { createScanDeduper } from '../screens/scanDeduper';
 
 describe('ScannerScreen QR parsing', () => {
   it('extracts aidId from app deep link', () => {
@@ -11,5 +12,25 @@ describe('ScannerScreen QR parsing', () => {
 
   it('returns null for invalid QR content', () => {
     expect(parseAidIdFromQRCode('https://example.com')).toBeNull();
+  });
+});
+
+describe('scan deduplication', () => {
+  it('suppresses the same scan during the debounce window', () => {
+    let now = 1000;
+    const isDuplicate = createScanDeduper(1500, () => now);
+
+    expect(isDuplicate('aid-123')).toBe(false);
+    now += 500;
+    expect(isDuplicate('aid-123')).toBe(true);
+    now += 1500;
+    expect(isDuplicate('aid-123')).toBe(false);
+  });
+
+  it('allows different packages without waiting', () => {
+    const isDuplicate = createScanDeduper(1500, () => 1000);
+
+    expect(isDuplicate('aid-123')).toBe(false);
+    expect(isDuplicate('aid-456')).toBe(false);
   });
 });

--- a/app/mobile/src/screens/BulkScannerScreen.tsx
+++ b/app/mobile/src/screens/BulkScannerScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Text,
   View,
@@ -13,6 +13,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeContext';
 import { useSync } from '../contexts/SyncContext';
+import { createScanDeduper } from './scanDeduper';
 
 type BulkScannerScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'BulkScanner'>;
 
@@ -27,10 +28,12 @@ interface SessionStats {
   skipped: number;
 }
 
+type ScanResult = { status: 'success' | 'error' | 'skipped'; message: string };
+
 export const BulkScannerScreen: React.FC<Props> = ({ navigation }) => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [lastScanResult, setLastScanResult] = useState<{ status: 'success' | 'error'; message: string } | null>(null);
+  const [lastScanResult, setLastScanResult] = useState<ScanResult | null>(null);
   const [stats, setStats] = useState<SessionStats>({
     scanned: 0,
     verified: 0,
@@ -40,6 +43,7 @@ export const BulkScannerScreen: React.FC<Props> = ({ navigation }) => {
 
   const { colors } = useTheme();
   const { queueClaimConfirmation, isConnected } = useSync();
+  const [isDuplicateScan] = useState(() => createScanDeduper());
 
   useEffect(() => {
     const getBarCodeScannerPermissions = async () => {
@@ -52,11 +56,19 @@ export const BulkScannerScreen: React.FC<Props> = ({ navigation }) => {
 
   const handleBarCodeScanned = async ({ type, data }: { type: string; data: string }) => {
     if (isProcessing) return;
+
+    const normalizedData = data.trim();
+    if (isDuplicateScan(normalizedData)) {
+      setStats(prev => ({ ...prev, skipped: prev.skipped + 1 }));
+      setLastScanResult({ status: 'skipped', message: 'Duplicate scan skipped. Ready for the next package.' });
+      return;
+    }
+
     setIsProcessing(true);
 
     // Check if it's the correct format: soter://package/{id}
     const regex = /^soter:\/\/package\/(.+)$/;
-    const match = data.match(regex);
+    const match = normalizedData.match(regex);
 
     setStats(prev => ({ ...prev, scanned: prev.scanned + 1 }));
 
@@ -134,6 +146,10 @@ export const BulkScannerScreen: React.FC<Props> = ({ navigation }) => {
             <Text style={[styles.statValue, { color: colors.error }]}>{stats.failed}</Text>
             <Text style={styles.statLabel}>Failed</Text>
           </View>
+          <View style={styles.statItem}>
+            <Text style={[styles.statValue, { color: colors.warning }]}>{stats.skipped}</Text>
+            <Text style={styles.statLabel}>Skipped</Text>
+          </View>
         </View>
 
         <View style={styles.viewfinderContainer}>
@@ -152,7 +168,7 @@ export const BulkScannerScreen: React.FC<Props> = ({ navigation }) => {
           {lastScanResult && (
             <View style={[
               styles.resultBadge, 
-              { backgroundColor: lastScanResult.status === 'success' ? colors.success : colors.error }
+              { backgroundColor: lastScanResult.status === 'success' ? colors.success : lastScanResult.status === 'skipped' ? colors.warning : colors.error }
             ]}>
               <Text style={styles.resultText}>{lastScanResult.message}</Text>
             </View>

--- a/app/mobile/src/screens/ScannerScreen.tsx
+++ b/app/mobile/src/screens/ScannerScreen.tsx
@@ -11,6 +11,7 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeContext';
+import { createScanDeduper } from './scanDeduper';
 
 type ScannerScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Scanner'>;
 
@@ -46,6 +47,7 @@ export const parseAidIdFromQRCode = (data: string): string | null => {
 export const ScannerScreen: React.FC<Props> = ({ navigation }) => {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [scanned, setScanned] = useState(false);
+  const [isDuplicateScan] = useState(() => createScanDeduper());
   const { colors } = useTheme();
 
   useEffect(() => {
@@ -58,6 +60,8 @@ export const ScannerScreen: React.FC<Props> = ({ navigation }) => {
   }, []);
 
   const handleBarCodeScanned = ({ type, data }: { type: string; data: string }) => {
+    if (isDuplicateScan(data.trim())) return;
+
     setScanned(true);
 
     const aidId = parseAidIdFromQRCode(data);

--- a/app/mobile/src/screens/scanDeduper.ts
+++ b/app/mobile/src/screens/scanDeduper.ts
@@ -1,0 +1,25 @@
+export const SCAN_DEDUPE_WINDOW_MS = 1500;
+
+type Clock = () => number;
+
+export const createScanDeduper = (
+  windowMs: number = SCAN_DEDUPE_WINDOW_MS,
+  clock: Clock = Date.now,
+) => {
+  const recentScans = new Map<string, number>();
+
+  return (scanKey: string): boolean => {
+    const now = clock();
+
+    for (const [key, timestamp] of recentScans) {
+      if (now - timestamp >= windowMs) {
+        recentScans.delete(key);
+      }
+    }
+
+    const previousScan = recentScans.get(scanKey);
+    recentScans.set(scanKey, now);
+
+    return previousScan !== undefined && now - previousScan < windowMs;
+  };
+};


### PR DESCRIPTION
closes #752 


## Problem
Rapid successive reads of the same code (from camera jitter, slow trigger release, or fast re-scanning in bulk mode) were being registered as multiple separate scans, leading to duplicate entries and inconsistent bulk scan counts.

## Changes
- Introduces a short suppression window after a successful read, during which an identical code is ignored rather than re-processed.
- Bulk scan mode now surfaces clear, non-blocking feedback when a scan is skipped as a duplicate (e.g. a toast/inline indicator distinct from a successful scan confirmation), so users understand why the count didn't increment.
- Suppression logic is scoped per-code (not a blanket scanner lockout), so scanning a *different* code immediately after is not delayed.
- Performance-conscious implementation to avoid added latency or dropped frames on lower-end devices.

## Implementation Notes
- Debounce window duration is configurable/tunable rather than hardcoded, to allow adjustment based on field testing.
- Duplicate detection compares against the most recent scan(s) within the suppression window, not the full session history, to keep the check cheap.
- Feedback for skipped duplicates is visually distinct from both "success" and "error" scan states.

## How to Test
1. **Single scan mode:** Scan the same code twice in quick succession — verify only one scan registers.
2. **Bulk scan mode:**
   - Rapidly re-scan the same code multiple times — verify duplicates are skipped and clearly flagged, and only one entry is added.
   - Scan a sequence of different codes quickly — verify all are captured without unintended suppression.
3. **Bounce behavior:** Simulate a jittery/slow scan release — verify it doesn't register as multiple reads.
4. **Performance:** Test on a low-end/older device to confirm no added lag or dropped scans during normal use.

## Checklist
- [ ] No false suppression of legitimately distinct rapid scans
- [ ] Bulk scan duplicate feedback is clear and non-intrusive
- [ ] Verified on at least one low-end/low-power test device
- [ ] No regression to existing single-scan and bulk-scan flows