### PR TITLE
feat(ai-service): validate configuration at startup

### DIFF
--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -306,7 +306,9 @@ class Settings(BaseSettings):
             )
             raise ConfigurationError(f"Invalid configuration:\n  - {summary}")
 
-    def report_boot_configuration(self, logger_: Optional[logging.Logger] = None) -> None:
+    def report_boot_configuration(
+        self, logger_: Optional[logging.Logger] = None
+    ) -> None:
         """Log the effective configuration at DEBUG level on boot.
 
         Optional values that are still at their declared defaults are

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -3,14 +3,47 @@ Configuration module for Soter AI Service
 Handles environment variables and API key management
 """
 
-from typing import Literal, Optional
-from pydantic import model_validator, HttpUrl
-from pydantic_settings import BaseSettings, SettingsConfigDict
 import logging
 import os
+import re
 import secrets
+from typing import Literal, Optional
+
+from pydantic import model_validator, HttpUrl
+from pydantic_core import PydanticUndefined
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
+
+
+class ConfigurationError(ValueError):
+    """Raised when startup configuration is invalid or incomplete.
+
+    The message names *every* offending configuration key at once so
+    operators can fix all problems in a single deployment cycle. Secret
+    values are never included in the message.
+    """
+
+
+#: Settings fields whose values must never appear in logs or error messages.
+_SECRET_FIELDS = frozenset(
+    {
+        "openai_api_key",
+        "groq_api_key",
+        "ai_webhook_secret",
+        "artifact_signing_secret",
+    }
+)
+
+_WEBHOOK_SECRET_PLACEHOLDER = "change-me-to-a-strong-random-secret"
+_MIN_WEBHOOK_SECRET_LENGTH = 16
+
+# slowapi rate limit strings, e.g. "10/minute".
+_RATE_LIMIT_PATTERN: re.Pattern[str] = re.compile(
+    r"^\s*\d+\s*/\s*(second|minute|hour)\s*$"
+)
+
+_REDIS_SCHEMES = ("redis://", "rediss://", "unix://")
 
 
 class Settings(BaseSettings):
@@ -151,6 +184,152 @@ class Settings(BaseSettings):
         if not has_key:
             logger.warning("No API keys configured. AI features will be unavailable.")
         return has_key
+
+    def validate_configuration(self) -> None:
+        """Validate the full configuration, raising on the first pass.
+
+        Every missing or malformed key is collected and reported together so
+        a single boot attempt surfaces all problems. Error messages name
+        configuration keys only - secret values are never included.
+
+        Raises:
+            ConfigurationError: if any required or optional-but-set value is
+                invalid. The service must not start serving in that case.
+        """
+        errors: list[str] = []
+
+        def _add(key: str, problem: str) -> None:
+            errors.append(f"{key}: {problem}")
+
+        # --- Provider keys: set-but-blank is malformed -------------------
+        if self.openai_api_key is not None and not self.openai_api_key.strip():
+            _add("OPENAI_API_KEY", "is set but blank")
+        if self.groq_api_key is not None and not self.groq_api_key.strip():
+            _add("GROQ_API_KEY", "is set but blank")
+
+        # --- Callback/webhook signing secret -----------------------------
+        if self.ai_webhook_secret is not None:
+            webhook_secret = self.ai_webhook_secret.strip()
+            if not webhook_secret:
+                _add("AI_WEBHOOK_SECRET", "is set but blank")
+            elif webhook_secret == _WEBHOOK_SECRET_PLACEHOLDER:
+                _add(
+                    "AI_WEBHOOK_SECRET",
+                    "is still set to the example placeholder value; generate a "
+                    "strong random secret instead",
+                )
+            elif len(webhook_secret) < _MIN_WEBHOOK_SECRET_LENGTH:
+                _add(
+                    "AI_WEBHOOK_SECRET",
+                    f"must be at least {_MIN_WEBHOOK_SECRET_LENGTH} characters",
+                )
+
+        # --- Redis URL scheme --------------------------------------------
+        # Never echo the URL itself - it may embed credentials.
+        redis_url = str(self.redis_url)
+        if not redis_url.startswith(_REDIS_SCHEMES):
+            scheme = redis_url.split("://", 1)[0] if "://" in redis_url else "<none>"
+            _add(
+                "REDIS_URL",
+                f"must use one of {', '.join(_REDIS_SCHEMES)} schemes "
+                f"(got '{scheme}://')",
+            )
+
+        # --- Rate limit strings consumed by slowapi ----------------------
+        for key, rate_limit in (
+            ("REQUEST_RATE_LIMIT", self.request_rate_limit),
+            ("DEAD_LETTER_REPLAY_RATE_LIMIT", self.dead_letter_replay_rate_limit),
+        ):
+            if not _RATE_LIMIT_PATTERN.match(str(rate_limit)):
+                _add(
+                    key,
+                    f"must match '<count>/(second|minute|hour)' (got {rate_limit!r})",
+                )
+
+        # --- Numeric settings must be positive ---------------------------
+        positive_numeric_settings = (
+            ("LLM_TIMEOUT_SECONDS", self.llm_timeout_seconds),
+            ("CACHE_TTL_TASK_STATUS", self.cache_ttl_task_status),
+            ("CACHE_TTL_ARTIFACT_ACCESS", self.cache_ttl_artifact_access),
+            ("CACHE_TTL_VERIFICATION", self.cache_ttl_verification),
+            ("TASK_RETRY_DELAY_SECONDS", self.task_retry_delay_seconds),
+            (
+                "VERIFICATION_ARTIFACT_URL_TTL_SECONDS",
+                self.verification_artifact_url_ttl_seconds,
+            ),
+            ("PROOF_OF_LIFE_MIN_FACE_SIZE", self.proof_of_life_min_face_size),
+        )
+        for key, value in positive_numeric_settings:
+            if value <= 0:
+                _add(key, f"must be a positive number (got {value})")
+
+        # --- Bounded numeric settings ------------------------------------
+        if not 0.0 <= self.proof_of_life_confidence_threshold <= 1.0:
+            _add(
+                "PROOF_OF_LIFE_CONFIDENCE_THRESHOLD",
+                f"must be between 0.0 and 1.0 (got {self.proof_of_life_confidence_threshold})",
+            )
+        if not 1 <= int(self.port) <= 65535:
+            _add("PORT", f"must be between 1 and 65535 (got {self.port})")
+
+        # --- CORS origins: entries must be absolute origins --------------
+        for key, raw in (
+            ("CORS_ALLOWED_ORIGINS", self.cors_allowed_origins),
+            ("CORS_CUSTOM_ORIGINS", self.cors_custom_origins),
+        ):
+            for entry in raw.split(","):
+                entry = entry.strip()
+                if not entry:
+                    continue
+                if not entry.startswith(("http://", "https://")):
+                    _add(key, "origin entries must start with http:// or https://")
+                    break
+
+        # --- Production requirements (defense in depth) ------------------
+        # apply_environment_defaults already rejects this at construction
+        # time; re-checking here keeps validate_configuration() authoritative.
+        if self.app_env == "production" and not (
+            self.openai_api_key or self.groq_api_key or self.test_provider_mode
+        ):
+            _add(
+                "OPENAI_API_KEY / GROQ_API_KEY / TEST_PROVIDER_MODE",
+                "production requires at least one provider API key or "
+                "TEST_PROVIDER_MODE=true",
+            )
+
+        if errors:
+            summary = "\n  - ".join(errors)
+            logger.error(
+                "configuration_validation_failed error_count=%d invalid_keys=%s",
+                len(errors),
+                ", ".join(error.split(":", 1)[0] for error in errors),
+            )
+            raise ConfigurationError(f"Invalid configuration:\n  - {summary}")
+
+    def report_boot_configuration(self, logger_: Optional[logging.Logger] = None) -> None:
+        """Log the effective configuration at DEBUG level on boot.
+
+        Optional values that are still at their declared defaults are
+        reported explicitly so operators can see which knobs were left
+        untouched. Secret-valued fields are never logged - only whether they
+        are set - consistent with ``logging_redaction.py``.
+        """
+        log = logger_ or logger
+
+        for name, field in type(self).model_fields.items():
+            display_name = name.upper()
+            if name in _SECRET_FIELDS:
+                state = "<set>" if getattr(self, name) else "<unset>"
+                log.debug("config %s=%s", display_name, state)
+                continue
+            value = getattr(self, name)
+            default = field.default
+            if default is PydanticUndefined:
+                continue
+            # str() on both sides keeps the comparison stable when pydantic
+            # coerced the raw default into a richer type (e.g. HttpUrl).
+            if value == default or str(value) == str(default):
+                log.debug("config default %s=%r", display_name, value)
 
     def get_active_provider(self) -> Optional[str]:
         if self.test_provider_mode:

--- a/app/ai-service/main.py
+++ b/app/ai-service/main.py
@@ -111,6 +111,16 @@ _LEGACY_PREFIX_MAP: list = [
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Starting up Soter AI Service...")
+
+    # Fail fast on invalid configuration: raising inside the lifespan
+    # prevents uvicorn from ever serving traffic. All offending keys are
+    # reported together by validate_configuration().
+    settings.validate_configuration()
+
+    # Report optional values still at their defaults (DEBUG only; secrets
+    # are never included, consistent with logging_redaction.py).
+    settings.report_boot_configuration(logger)
+
     if not settings.validate_api_keys():
         logger.warning("No API keys configured. AI features will be unavailable.")
     else:

--- a/app/ai-service/tests/test_config.py
+++ b/app/ai-service/tests/test_config.py
@@ -1,6 +1,34 @@
+import logging
+
 import pytest
 
-from config import Settings
+from config import ConfigurationError, Settings
+
+_ISOLATED_ENV_KEYS = (
+    "OPENAI_API_KEY",
+    "GROQ_API_KEY",
+    "TEST_PROVIDER_MODE",
+    "AI_DETERMINISTIC_MODE",
+    "APP_ENV",
+    "LOG_LEVEL",
+    "AI_WEBHOOK_SECRET",
+    "REDIS_URL",
+    "REQUEST_RATE_LIMIT",
+    "DEAD_LETTER_REPLAY_RATE_LIMIT",
+    "CORS_ALLOWED_ORIGINS",
+    "CORS_CUSTOM_ORIGINS",
+    "PROOF_OF_LIFE_CONFIDENCE_THRESHOLD",
+    "PROOF_OF_LIFE_MIN_FACE_SIZE",
+    "LLM_TIMEOUT_SECONDS",
+    "CACHE_TTL_TASK_STATUS",
+    "PORT",
+)
+
+
+def _isolate_env(monkeypatch):
+    """Clear config env vars so tests are hermetic regardless of host setup."""
+    for key in _ISOLATED_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
 
 
 def test_ai_deterministic_mode_can_be_enabled_from_environment(monkeypatch):
@@ -83,3 +111,150 @@ def test_malformed_webhook_url_fails_validation(monkeypatch):
     monkeypatch.setenv("BACKEND_WEBHOOK_URL", "not-a-url")
     with pytest.raises(ValueError):
         Settings()
+
+
+# ---------------------------------------------------------------------------
+# Startup configuration validation (issue #987)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_configuration_passes_with_valid_settings(monkeypatch):
+    _isolate_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-valid-key-for-unit-tests")
+
+    settings = Settings(_env_file=None)
+
+    settings.validate_configuration()
+
+
+def test_validate_configuration_passes_with_all_defaults():
+    settings = Settings(_env_file=None)
+
+    settings.validate_configuration()
+
+
+def test_missing_and_malformed_keys_reported_together(monkeypatch):
+    _isolate_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "   ")
+    monkeypatch.setenv("AI_WEBHOOK_SECRET", "change-me-to-a-strong-random-secret")
+    monkeypatch.setenv("REDIS_URL", "postgres://db.internal:5432/soter")
+    monkeypatch.setenv("REQUEST_RATE_LIMIT", "ten per minute")
+
+    settings = Settings(_env_file=None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    message = str(excinfo.value)
+    assert "OPENAI_API_KEY" in message
+    assert "AI_WEBHOOK_SECRET" in message
+    assert "REDIS_URL" in message
+    assert "REQUEST_RATE_LIMIT" in message
+
+
+def test_error_message_never_contains_secret_values(monkeypatch):
+    _isolate_env(monkeypatch)
+    weak_secret = "tiny-key"
+    monkeypatch.setenv("GROQ_API_KEY", "")
+    monkeypatch.setenv("AI_WEBHOOK_SECRET", weak_secret)
+
+    settings = Settings(_env_file=None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    message = str(excinfo.value)
+    assert weak_secret not in message
+    assert weak_secret not in repr(excinfo.value)
+
+
+def test_weak_callback_secret_is_rejected(monkeypatch):
+    _isolate_env(monkeypatch)
+    monkeypatch.setenv("TEST_PROVIDER_MODE", "true")
+    monkeypatch.setenv("AI_WEBHOOK_SECRET", "short")
+
+    settings = Settings(_env_file=None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    assert "AI_WEBHOOK_SECRET" in str(excinfo.value)
+
+
+def test_blank_provider_key_is_malformed(monkeypatch):
+    _isolate_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "")
+
+    settings = Settings(_env_file=None)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    assert "OPENAI_API_KEY" in str(excinfo.value)
+
+
+def test_missing_provider_in_production_names_every_option(monkeypatch):
+    _isolate_env(monkeypatch)
+    monkeypatch.setenv("APP_ENV", "development")
+    settings = Settings(_env_file=None)
+
+    # Simulate promoting an already-constructed development config to production.
+    settings.app_env = "production"
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    message = str(excinfo.value)
+    assert "OPENAI_API_KEY" in message
+    assert "GROQ_API_KEY" in message
+    assert "TEST_PROVIDER_MODE" in message
+
+
+def test_boot_report_logs_defaults_at_debug_level(monkeypatch, caplog):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+
+    config_logger = logging.getLogger("config")
+    with caplog.at_level(logging.DEBUG, logger="config"):
+        settings.report_boot_configuration(config_logger)
+
+    text = caplog.text
+    assert "config default PORT=8000" in text
+    assert "config default LOG_LEVEL='INFO'" in text
+    # HOST is reported with its default value; when main.py has installed the
+    # RedactionFilter the IPv4 value itself is masked, which is acceptable.
+    assert (
+        "config default HOST='0.0.0.0'" in text
+        or "config default HOST='[REDACTED]'" in text
+    )
+
+
+def test_boot_report_never_logs_secret_values(monkeypatch, caplog):
+    _isolate_env(monkeypatch)
+    secret = "sk-super-secret-do-not-log-value"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    settings = Settings(_env_file=None)
+
+    config_logger = logging.getLogger("config")
+    with caplog.at_level(logging.DEBUG, logger="config"):
+        settings.report_boot_configuration(config_logger)
+
+    text = caplog.text
+    assert secret not in text
+    # Presence is reported either verbatim or pre-redacted by the
+    # RedactionFilter installed by main.py - never with the real value.
+    assert "OPENAI_API_KEY=<set>" in text or "OPENAI_API_KEY=[REDACTED]" in text
+
+
+def test_boot_report_marks_unset_secrets(monkeypatch, caplog):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+
+    config_logger = logging.getLogger("config")
+    with caplog.at_level(logging.DEBUG, logger="config"):
+        settings.report_boot_configuration(config_logger)
+
+    assert (
+        "AI_WEBHOOK_SECRET=<unset>" in caplog.text
+        or "AI_WEBHOOK_SECRET=[REDACTED]" in caplog.text
+    )

--- a/app/ai-service/tests/test_startup_validation.py
+++ b/app/ai-service/tests/test_startup_validation.py
@@ -1,0 +1,33 @@
+"""
+Startup validation tests (issue #987).
+
+Verifies that an invalid configuration aborts the FastAPI lifespan so the
+service never starts serving traffic, and that a valid configuration boots.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import config
+import main
+from config import ConfigurationError
+
+
+def test_invalid_configuration_prevents_startup(monkeypatch):
+    def _raise(self):
+        raise ConfigurationError(
+            "Invalid configuration:\n  - REDIS_URL: must use redis:// scheme"
+        )
+
+    # Patch on the class: pydantic instances reject non-field attributes.
+    monkeypatch.setattr(config.Settings, "validate_configuration", _raise)
+
+    with pytest.raises(ConfigurationError):
+        with TestClient(main.app):
+            pass  # lifespan raises before the app can serve any request
+
+
+def test_valid_configuration_boots_and_serves():
+    with TestClient(main.app) as client:
+        response = client.get("/health")
+        assert response.status_code == 200


### PR DESCRIPTION
Validate required and optional-but-set configuration when the service boots so invalid values can no longer surface as runtime failures under production traffic (closes #987).

- Add Settings.validate_configuration(): collects every missing or malformed key and raises ConfigurationError naming them all at once (blank provider keys, placeholder/weak AI_WEBHOOK_SECRET, bad Redis scheme, malformed rate limits, non-positive TTLs, out-of-range threshold/port, scheme-less CORS origins, production without provider)
- Raise inside the FastAPI lifespan so startup failure prevents serving
- Add Settings.report_boot_configuration(): DEBUG-level report of optional values still at their defaults; secret fields are reported only as <set>/<unset>, never with values, consistent with logging_redaction.py
- Tests cover valid, missing, malformed, and secret-redaction paths

closes: #987 