### PR TITLE
feat: Add Wasm checksum verification to testnet deployment flow 

### DIFF
--- a/app/onchain/DEPLOY_TESTNET_RUNBOOK.md
+++ b/app/onchain/DEPLOY_TESTNET_RUNBOOK.md
@@ -18,7 +18,7 @@ From `app/onchain` with a funded `.env`:
 ./scripts/deploy-testnet.sh
 ```
 
-This builds WASM, deploys via `deploy.sh`, writes `deployments/registry.json`, and prints the semver/git tag (`v<crate-version>-testnet`).
+This builds WASM, deploys via `deploy.sh`, writes `deployments/registry.json`, verifies the artifact checksum against that registry entry, and prints the semver/git tag (`v<crate-version>-testnet`).
 
 To create the local git tag automatically:
 
@@ -121,6 +121,8 @@ Example expected output:
 ```
 
 If the script updates `.env`, it will also write `CONTRACT_ID=<id>` there.
+
+After registration, the deployment flow prints a machine-readable verification result. It exits nonzero if the SHA-256 checksum of the uploaded Wasm artifact differs from the checksum recorded next to the contract ID in `deployments/registry.json`.
 
 ### Manual deploy alternative
 

--- a/app/onchain/scripts/deploy-testnet.sh
+++ b/app/onchain/scripts/deploy-testnet.sh
@@ -64,6 +64,13 @@ REGISTER_OUT=$(python3 "$SCRIPT_DIR/register-deployment.py" \
 
 echo "$REGISTER_OUT"
 
+python3 "$SCRIPT_DIR/verify-deployment.py" \
+    --project-dir "$PROJECT_DIR" \
+    --contract-id "$CONTRACT_ID" \
+    --version "$CONTRACT_VERSION" \
+    --network testnet \
+    --wasm "$WASM_FILE"
+
 VERSION_TAG=$(echo "$REGISTER_OUT" | awk -F= '/^VERSION_TAG=/{print $2}')
 echo ""
 echo "✅ Registered deployment in deployments/registry.json"

--- a/app/onchain/scripts/deploy.sh
+++ b/app/onchain/scripts/deploy.sh
@@ -167,6 +167,13 @@ if [ -n "$CONTRACT_ID" ]; then
                 esac
             done
         fi
+
+        python3 "$SCRIPT_DIR/verify-deployment.py" \
+            --project-dir "$PROJECT_DIR" \
+            --contract-id "$CONTRACT_ID" \
+            --version "$CONTRACT_VERSION" \
+            --network "$NETWORK" \
+            --wasm "$WASM_FILE"
     else
         echo "⚠️  python3 not found; skipped registry update (run scripts/register-deployment.py manually)"
     fi

--- a/app/onchain/scripts/generate-registry.py
+++ b/app/onchain/scripts/generate-registry.py
@@ -138,6 +138,7 @@ def build_contract_registry(
 
         contracts_map[contract_name]["networks"][network] = {
             "contract_id": dep["contract_id"],
+            "wasm_hash": dep["wasm_hash"],
             "version": dep["version"],
             "deployed_at": dep["deployed_at"],
         }

--- a/app/onchain/scripts/test_generate_registry.py
+++ b/app/onchain/scripts/test_generate_registry.py
@@ -73,10 +73,12 @@ def test_registry_required_fields():
     testnet = registry["contracts"]["aid_escrow"]["networks"]["testnet"]
 
     # Required fields per the issue
-    required_fields = ["contract_id", "version", "deployed_at"]
+    required_fields = ["contract_id", "wasm_hash", "version", "deployed_at"]
     for field in required_fields:
         assert field in testnet, f"Missing required field: {field}"
         assert testnet[field], f"Required field {field} is empty"
+
+    assert len(testnet["wasm_hash"]) == 64
 
     # network is implicit in the key structure (testnet), but we verify
     # it's present in the networks map

--- a/app/onchain/scripts/test_verify_deployment.py
+++ b/app/onchain/scripts/test_verify_deployment.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for verify-deployment.py."""
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-deployment.py")
+
+
+def _run(project_dir: Path, wasm: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--project-dir",
+            str(project_dir),
+            "--contract-id",
+            "C123",
+            "--version",
+            "1.0.0",
+            "--network",
+            "testnet",
+            "--wasm",
+            str(wasm),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_matching_artifact_is_verified(tmp_path: Path):
+    wasm = tmp_path / "artifact.wasm"
+    wasm.write_bytes(b"artifact")
+    digest = hashlib.sha256(wasm.read_bytes()).hexdigest()
+    registry_dir = tmp_path / "deployments"
+    registry_dir.mkdir()
+    (registry_dir / "registry.json").write_text(
+        json.dumps(
+            {
+                "deployments": [
+                    {
+                        "network": "testnet",
+                        "version": "1.0.0",
+                        "contract_id": "C123",
+                        "wasm_hash": digest,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, wasm)
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["verified"] is True
+
+
+def test_different_artifact_fails_verification(tmp_path: Path):
+    wasm = tmp_path / "artifact.wasm"
+    wasm.write_bytes(b"artifact")
+    registry_dir = tmp_path / "deployments"
+    registry_dir.mkdir()
+    (registry_dir / "registry.json").write_text(
+        json.dumps(
+            {
+                "deployments": [
+                    {
+                        "network": "testnet",
+                        "version": "1.0.0",
+                        "contract_id": "C123",
+                        "wasm_hash": "0" * 64,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, wasm)
+
+    assert result.returncode != 0
+    output = json.loads(result.stdout)
+    assert output["verified"] is False
+    assert "checksum mismatch" in output["error"]

--- a/app/onchain/scripts/verify-deployment.py
+++ b/app/onchain/scripts/verify-deployment.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Verify a deployed artifact matches its machine-readable registry entry."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def wasm_hash_hex(wasm_path: Path) -> str:
+    return hashlib.sha256(wasm_path.read_bytes()).hexdigest()
+
+
+def find_deployment(registry: dict, *, contract_id: str, network: str, version: str) -> dict:
+    for deployment in registry.get("deployments", []):
+        if (
+            deployment.get("contract_id") == contract_id
+            and deployment.get("network") == network
+            and deployment.get("version") == version
+        ):
+            return deployment
+    raise ValueError(
+        f"No registry deployment found for {contract_id} on {network} (version {version})"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a deployed Wasm artifact matches deployments/registry.json"
+    )
+    parser.add_argument("--project-dir", required=True)
+    parser.add_argument("--contract-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--network", default="testnet")
+    parser.add_argument("--wasm", required=True)
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    wasm_path = Path(args.wasm)
+    if not wasm_path.is_absolute():
+        wasm_path = project_dir / wasm_path
+    registry_path = project_dir / "deployments" / "registry.json"
+
+    try:
+        artifact_hash = wasm_hash_hex(wasm_path)
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        deployment = find_deployment(
+            registry,
+            contract_id=args.contract_id,
+            network=args.network,
+            version=args.version,
+        )
+        registry_hash = deployment.get("wasm_hash")
+        if artifact_hash != registry_hash:
+            raise ValueError(
+                f"WASM checksum mismatch: artifact={artifact_hash} registry={registry_hash}"
+            )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"verified": False, "error": str(exc)}))
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "verified": True,
+                "contract_id": args.contract_id,
+                "network": args.network,
+                "version": args.version,
+                "wasm_hash": artifact_hash,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
closes #727 

## Summary
Adds checksum recording and verification for deployed Wasm artifacts in the testnet deployment flow, so the registry can prove exactly which build is live for a given contract ID — and deployment fails fast if the uploaded artifact doesn't match what's recorded.

## Problem
Currently the deployment flow records a contract ID without a verifiable link back to the exact Wasm artifact that was deployed. This makes it possible for the registry to reference a contract without any guarantee that the live bytecode matches what was intended/reviewed, and leaves no way to detect drift between the artifact and what's actually on-chain.

## Changes
- Deployment flow now computes a checksum (hash) of the Wasm artifact at deploy time and records it alongside the contract ID in the registry.
- Adds a verification step that re-checks the uploaded artifact's checksum against the recorded registry value, and fails the deployment if they diverge.
- Registry output format is preserved as machine-readable (existing schema extended with a checksum field, not restructured).

## Implementation Notes
- Checksum algorithm: (fill in — e.g. SHA-256) applied to the raw Wasm binary before upload.
- Verification runs as a distinct step in the deployment pipeline, after upload and before the deployment is marked successful, so a mismatch blocks completion rather than being logged after the fact.
- Checksum field added to registry entries in a way that's additive/backward-compatible for existing consumers parsing registry output.

## How to Test
1. Run a standard testnet deployment — verify the resulting registry entry includes the correct checksum next to the contract ID.
2. Confirm the checksum matches an independently computed hash of the deployed Wasm artifact.
3. Simulate a mismatch (e.g. modify the artifact after checksum computation but before verification, or upload a different artifact than what was hashed) — verify the deployment fails clearly at the verification step rather than completing silently.
4. Parse the registry output with existing tooling/scripts — confirm it remains valid machine-readable format (e.g. valid JSON) with the new field present.
5. Re-run deployment for the same contract with an unchanged artifact — verify checksum stays consistent across runs (determinism check).

## Checklist
- [ ] Checksum recorded correctly for every successful deployment
- [ ] Verification step reliably fails on artifact/registry divergence
- [ ] Registry output remains valid, machine-readable, and backward-compatible
- [ ] Failure mode is clear and actionable (not a silent/ambiguous error)
- [ ] Deterministic checksum across repeated deployments of the same artifact