### PR TITLE
feat(ai-service): account for token usage and cost per request #981

### DIFF
--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import secrets
-from typing import Literal, Optional
+from typing import Dict, Literal, Optional
 
 from pydantic import model_validator, HttpUrl
 from pydantic_core import PydanticUndefined
@@ -126,6 +126,18 @@ class Settings(BaseSettings):
     # Proof-of-life settings
     proof_of_life_confidence_threshold: float = 0.65
     proof_of_life_min_face_size: int = 80
+
+    # Token usage & cost accounting (Issue #981)
+    # Estimated USD cost per 1,000 tokens, keyed by model name. Models without
+    # an entry fall back to the default rates below (0 = cost not tracked).
+    # Overridable via env as JSON, e.g.
+    # TOKEN_COST_RATES='{"gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006}}'
+    token_cost_rates: Dict[str, Dict[str, float]] = {
+        "gpt-4o-mini": {"prompt": 0.00015, "completion": 0.0006},
+        "llama-3.3-70b-versatile": {"prompt": 0.00059, "completion": 0.00079},
+    }
+    token_cost_default_prompt_rate: float = 0.0
+    token_cost_default_completion_rate: float = 0.0
 
     # Verification artifact access settings
     verification_artifacts_dir: str = "./artifacts/verification"
@@ -272,6 +284,34 @@ class Settings(BaseSettings):
             )
         if not 1 <= int(self.port) <= 65535:
             _add("PORT", f"must be between 1 and 65535 (got {self.port})")
+
+        # --- Token cost rates must be non-negative ------------------------
+        for rate_key, rate_value in (
+            ("TOKEN_COST_DEFAULT_PROMPT_RATE", self.token_cost_default_prompt_rate),
+            (
+                "TOKEN_COST_DEFAULT_COMPLETION_RATE",
+                self.token_cost_default_completion_rate,
+            ),
+        ):
+            if rate_value < 0:
+                _add(rate_key, f"must be non-negative (got {rate_value})")
+        if isinstance(self.token_cost_rates, dict):
+            for model_name, model_rates in self.token_cost_rates.items():
+                if not isinstance(model_rates, dict):
+                    _add(
+                        "TOKEN_COST_RATES",
+                        f"entry for '{model_name}' must be an object with "
+                        "'prompt'/'completion' keys",
+                    )
+                    continue
+                for direction in ("prompt", "completion"):
+                    value = model_rates.get(direction)
+                    if value is None or not isinstance(value, (int, float)) or value < 0:
+                        _add(
+                            "TOKEN_COST_RATES",
+                            f"'{model_name}.{direction}' must be a "
+                            f"non-negative number (got {value})",
+                        )
 
         # --- CORS origins: entries must be absolute origins --------------
         for key, raw in (

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -56,6 +56,27 @@ JOB_CANCELLED_TOTAL = Counter(
 )
 JOB_EXPIRED_TOTAL = Counter("job_expired_total", "Total jobs expired", ["task_type"])
 
+# Token usage & estimated cost metrics (Issue #981)
+# Labels are kept bounded: provider/model/endpoint values are normalized to
+# fixed allowlists (see services/providers.py) so cardinality cannot grow
+# with traffic. Requests where the provider does not report usage are counted
+# separately instead of being folded into zero-token counts.
+TOKEN_USAGE_TOTAL = Counter(
+    "ai_token_usage",
+    "LLM tokens consumed, labelled by provider, model, endpoint and token type",
+    ["provider", "model", "endpoint", "token_type"],
+)
+TOKEN_COST_ESTIMATED_USD_TOTAL = Counter(
+    "ai_token_cost_estimated_usd",
+    "Estimated USD cost of LLM tokens consumed",
+    ["provider", "model", "endpoint"],
+)
+TOKEN_USAGE_UNAVAILABLE_TOTAL = Counter(
+    "ai_token_usage_unavailable",
+    "LLM requests where the provider did not report token usage",
+    ["provider", "model", "endpoint"],
+)
+
 # Cache invalidation metrics
 CACHE_INVALIDATION_TOTAL = Counter(
     "cache_invalidation_total",

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -9,7 +9,12 @@ import metrics
 from config import settings
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
-from services.providers import ProviderRegistry, ModelProvider, LLMResponse
+from services.providers import (
+    ProviderRegistry,
+    ModelProvider,
+    LLMResponse,
+    usage_endpoint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +92,14 @@ class HumanitarianVerificationService:
                             model,
                             prompt_variant,
                         )
-                        response = provider.llm_chat(
-                            system_prompt=prompt["system"],
-                            user_prompt=prompt["user"],
-                            model=model,
-                            timeout=timeout,
-                        )
+                        response: LLMResponse
+                        with usage_endpoint("humanitarian_verification"):
+                            response = provider.llm_chat(
+                                system_prompt=prompt["system"],
+                                user_prompt=prompt["user"],
+                                model=model,
+                                timeout=timeout,
+                            )
                         parsed = self._parse_json_response(response.content)
                         breaker.record_success()
                         return {

--- a/app/ai-service/services/providers.py
+++ b/app/ai-service/services/providers.py
@@ -1,6 +1,7 @@
 """Abstract provider interface and concrete implementations for LLM and OCR.
 
 Issue #615 — Provider Interface for LLM + OCR
+Issue #981 — Token usage & cost accounting per request
 
 Defines a uniform ``ModelProvider`` abstraction with two capability methods:
 
@@ -10,19 +11,27 @@ Defines a uniform ``ModelProvider`` abstraction with two capability methods:
 Concrete providers implement only the capabilities they support; unsupported
 operations raise ``NotImplementedError``.  A thin ``ProviderRegistry`` resolves
 the right provider for a given capability and provider name.
+
+LLM providers additionally capture the token usage reported by the upstream
+API (when available) and export it as Prometheus metrics labelled by provider,
+model and calling endpoint, alongside an estimated USD cost derived from the
+configurable per-model rates in ``config.settings.token_cost_rates``.
 """
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import time
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import httpx
 
+import metrics
 from config import settings
 from exceptions import AIServiceError
 
@@ -36,12 +45,172 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class LLMResponse:
-    """Structured return value from an LLM provider."""
+    """Structured return value from an LLM provider.
+
+    Token fields are ``None`` when the provider did not report usage for the
+    request; missing usage is accounted separately rather than as zero.
+    """
 
     content: str
     provider: str
     model: str
     latency_ms: int = 0
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Token usage & cost accounting (Issue #981)
+# ---------------------------------------------------------------------------
+
+#: Endpoint attribution for metrics. Callers wrap provider dispatch in
+#: ``usage_endpoint(...)`` so spend can be attributed per API capability.
+_usage_endpoint: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "usage_endpoint", default=None
+)
+
+_BUILTIN_ENDPOINT_LABELS = frozenset({"humanitarian_verification"})
+_BUILTIN_PROVIDER_LABELS = frozenset({"openai", "groq", "test", "tesseract"})
+_UNKNOWN_MODEL_LABEL = "other"
+_UNATTRIBUTED_ENDPOINT_LABEL = "unattributed"
+_TEST_MODEL_LABEL = "test-provider/fixture"
+
+
+@contextmanager
+def usage_endpoint(endpoint: str):
+    """Attribute token usage recorded inside the block to ``endpoint``."""
+    token = _usage_endpoint.set(endpoint)
+    try:
+        yield
+    finally:
+        _usage_endpoint.reset(token)
+
+
+def _normalize_provider_label(provider: Optional[str]) -> str:
+    name = (provider or "").strip()
+    if not name:
+        return "unknown"
+    return name if name in _BUILTIN_PROVIDER_LABELS else _UNKNOWN_MODEL_LABEL
+
+
+def _normalize_model_label(model: Optional[str]) -> str:
+    name = (model or "").strip()
+    if not name:
+        return _UNKNOWN_MODEL_LABEL
+    if name == _TEST_MODEL_LABEL:
+        return name
+    allowlist: Set[str] = set()
+    rates = getattr(settings, "token_cost_rates", None)
+    if isinstance(rates, dict):
+        allowlist.update(str(key) for key in rates)
+    for attr in ("openai_model", "groq_model"):
+        value = getattr(settings, attr, None)
+        if isinstance(value, str):
+            allowlist.add(value)
+    return name if name in allowlist else _UNKNOWN_MODEL_LABEL
+
+
+def _normalize_endpoint_label(endpoint: Optional[str]) -> str:
+    name = (endpoint or "").strip()
+    if not name:
+        return _UNATTRIBUTED_ENDPOINT_LABEL
+    return name if name in _BUILTIN_ENDPOINT_LABELS else _UNKNOWN_MODEL_LABEL
+
+
+def current_usage_endpoint() -> str:
+    """Return the normalized endpoint label for the current context."""
+    return _normalize_endpoint_label(_usage_endpoint.get())
+
+
+def get_model_cost_rates(model: str) -> Tuple[float, float]:
+    """Return ``(prompt_rate, completion_rate)`` USD per 1k tokens for ``model``."""
+    rates = getattr(settings, "token_cost_rates", None)
+    if isinstance(rates, dict):
+        entry = rates.get(model)
+        if isinstance(entry, dict):
+            prompt_rate = entry.get("prompt")
+            completion_rate = entry.get("completion")
+            if (
+                isinstance(prompt_rate, (int, float))
+                and prompt_rate >= 0
+                and isinstance(completion_rate, (int, float))
+                and completion_rate >= 0
+            ):
+                return float(prompt_rate), float(completion_rate)
+
+    default_prompt = getattr(settings, "token_cost_default_prompt_rate", 0.0)
+    default_completion = getattr(settings, "token_cost_default_completion_rate", 0.0)
+    prompt_rate = default_prompt if isinstance(default_prompt, (int, float)) else 0.0
+    completion_rate = (
+        default_completion if isinstance(default_completion, (int, float)) else 0.0
+    )
+    return max(0.0, float(prompt_rate)), max(0.0, float(completion_rate))
+
+
+def estimate_token_cost_usd(
+    model: str, prompt_tokens: int, completion_tokens: int
+) -> float:
+    """Estimate USD cost for the given token counts using configured rates."""
+    prompt_rate, completion_rate = get_model_cost_rates(model)
+    cost = (prompt_tokens / 1000.0) * prompt_rate
+    cost += (completion_tokens / 1000.0) * completion_rate
+    return max(0.0, cost)
+
+
+def _usage_int_or_none(value: Any) -> Optional[int]:
+    """Coerce a provider-reported usage value to a non-negative int or None."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return max(0, int(value))
+
+
+def record_llm_token_usage(response: LLMResponse) -> None:
+    """Export token usage/cost metrics for a completed LLM request.
+
+    Requests where the provider did not report usage are counted separately
+    via ``ai_token_usage_unavailable_total`` instead of being recorded as
+    zero tokens.
+    """
+    try:
+        provider_label = _normalize_provider_label(response.provider)
+        # Cost is estimated from the raw model name so unconfigured models can
+        # still fall back to the default rates before label normalization.
+        cost_model = (response.model or "").strip() or _UNKNOWN_MODEL_LABEL
+        model_label = _normalize_model_label(response.model)
+        endpoint_label = current_usage_endpoint()
+        labels = {
+            "provider": provider_label,
+            "model": model_label,
+            "endpoint": endpoint_label,
+        }
+
+        prompt_tokens = response.prompt_tokens
+        completion_tokens = response.completion_tokens
+        if prompt_tokens is None and completion_tokens is None:
+            metrics.TOKEN_USAGE_UNAVAILABLE_TOTAL.labels(**labels).inc()
+            return
+
+        prompt_count = int(prompt_tokens or 0)
+        completion_count = int(completion_tokens or 0)
+        if prompt_count > 0:
+            metrics.TOKEN_USAGE_TOTAL.labels(**labels, token_type="prompt").inc(
+                prompt_count
+            )
+        if completion_count > 0:
+            metrics.TOKEN_USAGE_TOTAL.labels(
+                **labels, token_type="completion"
+            ).inc(completion_count)
+        if prompt_count > 0 or completion_count > 0:
+            cost = estimate_token_cost_usd(cost_model, prompt_count, completion_count)
+            if cost > 0:
+                metrics.TOKEN_COST_ESTIMATED_USD_TOTAL.labels(**labels).inc(cost)
+        else:
+            # Provider reported a usage object but no positive token counts;
+            # treat as unavailable rather than silently recording zeros.
+            metrics.TOKEN_USAGE_UNAVAILABLE_TOTAL.labels(**labels).inc()
+    except Exception:  # pragma: no cover - accounting must never break requests
+        logger.exception("Failed to record LLM token usage")
 
 
 @dataclass
@@ -159,7 +328,9 @@ class OpenAIProvider(ModelProvider):
                 separators=(",", ":"),
                 sort_keys=True,
             )
-            return LLMResponse(content=stable, provider=provider_name, model=model)
+            response = LLMResponse(content=stable, provider=provider_name, model=model)
+            record_llm_token_usage(response)
+            return response
 
         payload = {
             "model": model,
@@ -212,12 +383,19 @@ class OpenAIProvider(ModelProvider):
         if not content:
             raise RuntimeError("LLM returned empty content")
 
-        return LLMResponse(
+        usage = data.get("usage") if isinstance(data, dict) else None
+        usage = usage if isinstance(usage, dict) else {}
+        llm_response = LLMResponse(
             content=str(content),
             provider=provider_name,
             model=model,
             latency_ms=int((time.time() - start) * 1000),
+            prompt_tokens=_usage_int_or_none(usage.get("prompt_tokens")),
+            completion_tokens=_usage_int_or_none(usage.get("completion_tokens")),
+            total_tokens=_usage_int_or_none(usage.get("total_tokens")),
         )
+        record_llm_token_usage(llm_response)
+        return llm_response
 
 
 # ---------------------------------------------------------------------------
@@ -286,9 +464,11 @@ class FixtureProvider(ModelProvider):
             request_data={"system_prompt": system_prompt, "user_prompt": user_prompt},
         )
         content = json.dumps(response, separators=(",", ":"), sort_keys=True)
-        return LLMResponse(
+        llm_response = LLMResponse(
             content=content, provider="test", model="test-provider/fixture"
         )
+        record_llm_token_usage(llm_response)
+        return llm_response
 
     def ocr_extract(
         self,

--- a/app/ai-service/tests/test_token_usage.py
+++ b/app/ai-service/tests/test_token_usage.py
@@ -1,0 +1,293 @@
+"""Tests for LLM token usage & cost accounting (Issue #981)."""
+
+import pytest
+from prometheus_client import REGISTRY
+from unittest.mock import MagicMock, patch
+
+from services import providers
+from services.providers import (
+    LLMResponse,
+    OpenAIProvider,
+    estimate_token_cost_usd,
+    record_llm_token_usage,
+    usage_endpoint,
+)
+
+
+def _sample(name: str, labels: dict) -> float:
+    value = REGISTRY.get_sample_value(name, labels)
+    return 0.0 if value is None else float(value)
+
+
+def _assert_delta(
+    sample_name: str, labels: dict, expected: float, fn, msg: str = ""
+):
+    before = _sample(sample_name, labels)
+    fn()
+    after = _sample(sample_name, labels)
+    assert pytest.approx(after - before) == expected, msg
+
+
+def _make_llm_success(usage=None, model: str = "gpt-4o-mini"):
+    body = {"choices": [{"message": {"content": "test content"}}]}
+    if usage is not None:
+        body["usage"] = usage
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = body
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.post.return_value = mock_response
+
+    def _invoke():
+        with patch.object(providers.settings, "openai_api_key", "test-key"), \
+                patch.object(providers.settings, "ai_deterministic_mode", False), \
+                patch.object(providers.settings, "llm_timeout_seconds", 30), \
+                patch("httpx.Client") as MockClient:
+            MockClient.return_value.__enter__ = MagicMock(
+                return_value=mock_client_instance
+            )
+            MockClient.return_value.__exit__ = MagicMock(return_value=False)
+            return OpenAIProvider().llm_chat("sys", "usr", model=model)
+
+    return _invoke
+
+
+class TestTokenCapture:
+    def test_llm_response_captures_reported_usage(self):
+        call = _make_llm_success(
+            usage={"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+        )
+        resp = call()
+        assert resp.prompt_tokens == 11
+        assert resp.completion_tokens == 7
+        assert resp.total_tokens == 18
+
+    def test_missing_usage_leaves_token_fields_none(self):
+        call = _make_llm_success(usage=None)
+        resp = call()
+        assert resp.prompt_tokens is None
+        assert resp.completion_tokens is None
+        assert resp.total_tokens is None
+
+    def test_non_numeric_usage_is_ignored(self):
+        call = _make_llm_success(usage={"prompt_tokens": "many"})
+        resp = call()
+        assert resp.prompt_tokens is None
+
+
+class TestUsageMetrics:
+    def test_tokens_and_cost_recorded_with_labels(self):
+        labels = {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "endpoint": "humanitarian_verification",
+        }
+
+        def counters():
+            return (
+                _sample("ai_token_usage_total", {**labels, "token_type": "prompt"}),
+                _sample(
+                    "ai_token_usage_total", {**labels, "token_type": "completion"}
+                ),
+                _sample("ai_token_cost_estimated_usd_total", labels),
+            )
+
+        def request():
+            with usage_endpoint("humanitarian_verification"):
+                with patch.object(
+                    providers.settings,
+                    "token_cost_rates",
+                    {"gpt-4o-mini": {"prompt": 1.0, "completion": 2.0}},
+                ):
+                    _make_llm_success(
+                        usage={
+                            "prompt_tokens": 1000,
+                            "completion_tokens": 500,
+                            "total_tokens": 1500,
+                        }
+                    )()
+
+        before = counters()
+        request()
+        after = counters()
+
+        assert after[0] - before[0] == 1000, "prompt tokens should be recorded"
+        assert after[1] - before[1] == 500, "completion tokens should be recorded"
+        assert pytest.approx(after[2] - before[2]) == (
+            1.0 * 1.0 + 0.5 * 2.0
+        ), "cost should use the configured per-model rates"
+
+    def test_missing_usage_counted_separately_not_zero(self):
+        labels = {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "endpoint": "unattributed",
+        }
+        token_labels = {**labels, "token_type": "prompt"}
+
+        call = _make_llm_success(usage=None)
+
+        _assert_delta(
+            "ai_token_usage_unavailable_total",
+            labels,
+            1,
+            call,
+            "requests without reported usage must be counted separately",
+        )
+        _assert_delta(
+            "ai_token_usage_total",
+            token_labels,
+            0,
+            lambda: None,
+            "missing usage must never be folded into zero-token counts",
+        )
+
+    def test_deterministic_mode_counts_unavailable(self):
+        labels = {
+            "provider": "openai",
+            "model": "other",
+            "endpoint": "unattributed",
+        }
+
+        def request():
+            with patch.object(providers.settings, "openai_api_key", "test-key"), \
+                    patch.object(
+                        providers.settings, "ai_deterministic_mode", True
+                    ):
+                OpenAIProvider().llm_chat("sys", "usr", model="some-custom-model")
+
+        _assert_delta(
+            "ai_token_usage_unavailable_total",
+            labels,
+            1,
+            request,
+            "deterministic mode reports no usage",
+        )
+
+
+class TestCostRates:
+    def test_estimate_uses_configured_model_rates(self):
+        rates = {"model-a": {"prompt": 3.0, "completion": 5.0}}
+        with patch.object(providers.settings, "token_cost_rates", rates):
+            cost = estimate_token_cost_usd("model-a", 2000, 1000)
+        assert pytest.approx(cost) == 2 * 3.0 + 1 * 5.0
+
+    def test_unknown_model_falls_back_to_defaults(self):
+        rates = {}
+        defaults = (
+            providers.settings.token_cost_default_prompt_rate,
+            providers.settings.token_cost_default_completion_rate,
+        )
+        with patch.object(providers.settings, "token_cost_rates", rates), \
+                patch.object(
+                    providers.settings, "token_cost_default_prompt_rate", 2.0
+                ), \
+                patch.object(
+                    providers.settings,
+                    "token_cost_default_completion_rate",
+                    4.0,
+                ):
+            cost = estimate_token_cost_usd("never-seen-model", 1000, 1000)
+        assert pytest.approx(cost) == 1 * 2.0 + 1 * 4.0
+
+    def test_negative_rates_are_clamped(self):
+        rates = {"bad-model": {"prompt": -1.0, "completion": -2.0}}
+        with patch.object(providers.settings, "token_cost_rates", rates):
+            assert estimate_token_cost_usd("bad-model", 1000, 1000) == 0.0
+
+
+class TestLabelCardinality:
+    def test_unknown_model_buckets_into_other(self):
+        labels = {
+            "provider": "openai",
+            "model": "other",
+            "endpoint": "unattributed",
+        }
+        call = _make_llm_success(
+            usage={"prompt_tokens": 5, "completion_tokens": 5},
+            model="totally-custom-model",
+        )
+
+        def request():
+            with patch.object(providers.settings, "token_cost_rates", {}):
+                call()
+
+        _assert_delta(
+            "ai_token_usage_total",
+            {**labels, "token_type": "prompt"},
+            5,
+            request,
+            "unlisted models must normalize to the bounded 'other' label",
+        )
+
+    def test_unknown_endpoint_buckets_into_other(self):
+        labels = {
+            "provider": "groq",
+            "model": "llama-3.3-70b-versatile",
+            "endpoint": "other",
+        }
+        response = LLMResponse(
+            content="ok",
+            provider="groq",
+            model="llama-3.3-70b-versatile",
+            prompt_tokens=3,
+            completion_tokens=3,
+        )
+
+        def request():
+            with usage_endpoint("rogue-endpoint-name"):
+                record_llm_token_usage(response)
+
+        _assert_delta(
+            "ai_token_usage_total",
+            {**labels, "token_type": "prompt"},
+            3,
+            request,
+            "endpoints outside the allowlist must normalize to 'other'",
+        )
+
+    def test_builtin_models_keep_their_label(self):
+        assert (
+            providers._normalize_model_label("llama-3.3-70b-versatile")
+            == "llama-3.3-70b-versatile"
+        )
+
+
+class TestEndpointAttribution:
+    def test_context_manager_scopes_endpoint(self):
+        with usage_endpoint("humanitarian_verification"):
+            assert providers.current_usage_endpoint() == "humanitarian_verification"
+        assert providers.current_usage_endpoint() == "unattributed"
+
+    def test_exception_resets_endpoint(self):
+        with pytest.raises(RuntimeError):
+            with usage_endpoint("humanitarian_verification"):
+                raise RuntimeError("boom")
+        assert providers.current_usage_endpoint() == "unattributed"
+
+    def test_humanitarian_service_attributes_usage_to_endpoint(self):
+        from PIL import Image  # noqa: F401  (ensures stub consistent with conftest)
+
+        from services.humanitarian_verification import HumanitarianVerificationService
+
+        labels = {
+            "provider": "test",
+            "model": "test-provider/fixture",
+            "endpoint": "humanitarian_verification",
+        }
+
+        def request():
+            with patch.object(providers.settings, "test_provider_mode", True):
+                service = HumanitarianVerificationService()
+                result = service.verify_claim("claim text")
+                assert result["provider"] == "test"
+
+        _assert_delta(
+            "ai_token_usage_unavailable_total",
+            labels,
+            1,
+            request,
+            "service dispatch should be attributed to the humanitarian endpoint",
+        )


### PR DESCRIPTION
## Overview

This PR adds per-request **token usage and cost accounting** for every LLM call dispatched through `app/ai-service/services/providers.py`. Token consumption is captured where providers report it, exported as Prometheus metrics labelled by provider/model/endpoint, and priced against configurable per-model USD rates — so spend can finally be attributed and capacity/cost planning stops being guesswork.

## Related Issue

Closes [#981](https://github.com/Pulsefy/Soter/issues/981)

## Changes

### 📊 Token Usage Capture & Metrics

-   **[MODIFY]** `app/ai-service/services/providers.py`
    -   Parses the OpenAI-compatible `usage` object (`prompt_tokens`, `completion_tokens`, `total_tokens`) from every chat completion response and attaches it to `LLMResponse`.
    -   New `record_llm_token_usage()` exports usage on every LLM dispatch path (real API calls, deterministic mode, fixture provider).
    -   Label normalization keeps cardinality bounded: unknown models/endpoints collapse into fixed `"other"` / `"unattributed"` buckets instead of unbounded label values.
    -   Requests where the provider does not report usage increment `ai_token_usage_unavailable_total` rather than being recorded as zero tokens.
    -   `usage_endpoint()` context manager attributes each request to a calling endpoint.
-   **[MODIFY]** `app/ai-service/metrics.py`
    -   **[ADD]** `ai_token_usage_total{provider, model, endpoint, token_type}` — prompt/completion token counters.
    -   **[ADD]** `ai_token_cost_estimated_usd_total{provider, model, endpoint}` — estimated USD spend.
    -   **[ADD]** `ai_token_usage_unavailable_total{provider, model, endpoint}` — requests without reported usage.

### ⚙️ Configurable Cost Rates

-   **[MODIFY]** `app/ai-service/config.py`
    -   **[ADD]** `token_cost_rates` — per-model USD rates per 1K tokens (defaults for `gpt-4o-mini` and `llama-3.3-70b-versatile`; overridable via `TOKEN_COST_RATES` env JSON).
    -   **[ADD]** `token_cost_default_prompt_rate` / `token_cost_default_completion_rate` fallbacks for unlisted models.
    -   Startup validation rejects negative rates and malformed entries.
-   **[MODIFY]** `app/ai-service/services/humanitarian_verification.py`
    -   Wraps provider dispatch in `usage_endpoint("humanitarian_verification")` so spend is attributed per endpoint.

### ✅ Tests

-   **[ADD]** `app/ai-service/tests/test_token_usage.py` — 15 tests covering capture, metric deltas with exact labels, cost-rate math (configured, default-fallback, negative clamping), unavailable-vs-zero accounting, cardinality bucketing, endpoint context scoping, and end-to-end attribution through `HumanitarianVerificationService`.

## Verification Results

```
python -m pytest tests/test_token_usage.py -v
✅ 15/15 passed in 0.43s

Full suite (app/ai-service):
✅ 417 passed (402 on clean main + 15 new), 0 new failures
(26 pre-existing environment failures identical on clean upstream/main)

Live metrics smoke test:
ai_token_usage_total{endpoint="humanitarian_verification",model="gpt-4o-mini",provider="openai",token_type="prompt"} 240.0
ai_token_usage_total{endpoint="humanitarian_verification",model="gpt-4o-mini",provider="openai",token_type="completion"} 120.0
ai_token_cost_estimated_usd_total{endpoint="humanitarian_verification",model="gpt-4o-mini",provider="openai"} 0.000108
```

| Acceptance Criteria | Status |
| --- | --- |
| Prompt and completion token counts are captured per request where the provider reports them | ✅ Parsed from the provider `usage` object into `LLMResponse` and exported as counters |
| Usage is exposed as metrics labelled by provider, model, and endpoint | ✅ `ai_token_usage_total{provider, model, endpoint, token_type}` |
| Estimated cost is derivable from configurable per-model rates | ✅ `TOKEN_COST_RATES` config → `ai_token_cost_estimated_usd_total`, verified rate math |
| Requests where usage is unavailable are counted separately rather than as zero | ✅ Dedicated `ai_token_usage_unavailable_total` counter; zero-token counts never inflated |
| Metric label cardinality stays bounded | ✅ Allowlist normalization buckets unknown models/endpoints into fixed labels |
