### PR TITLE
feat(aid-escrow): add campaign-level pause controls

### DIFF
--- a/app/onchain/contracts/aid_escrow/EVENTS.md
+++ b/app/onchain/contracts/aid_escrow/EVENTS.md
@@ -43,6 +43,8 @@ section using the `#[contractevent]` derive.
 | `contract_unpaused_event` | `unpause`           | Admin unpauses the whole contract.                     |
 | `action_paused_event`     | `pause_action`      | Admin pauses a single action (create/claim/withdraw).  |
 | `action_unpaused_event`   | `unpause_action`    | Admin unpauses a single action.                        |
+| `campaign_paused_event`   | `pause_campaign`    | Admin pauses a single campaign (`campaign_ref`).       |
+| `campaign_unpaused_event` | `unpause_campaign`  | Admin unpauses a single campaign.                      |
 
 > Function names refer to the public entrypoints in `src/lib.rs`.
 
@@ -71,6 +73,8 @@ Pool / administrative events:
 | `ContractUnpausedEvent` | `admin: Address`                                                          |
 | `ActionPausedEvent`     | `admin: Address`, `action: Symbol`                                        |
 | `ActionUnpausedEvent`   | `admin: Address`, `action: Symbol`                                        |
+| `CampaignPausedEvent`   | `admin: Address`, `campaign_ref: String`                                  |
+| `CampaignUnpausedEvent` | `admin: Address`, `campaign_ref: String`                                  |
 
 ## Identifier stability (audit)
 
@@ -90,10 +94,16 @@ Pool / administrative events:
 ## Sensitive-metadata review (audit)
 
 Packages carry an arbitrary `metadata: Map<Symbol, String>` (used for values
-such as `campaign_ref`). **No event payload includes this map or any value
-from it.** Events expose only structural fields (ids, addresses, amounts,
-timestamps), so free-form or potentially sensitive metadata is never leaked
-through the event stream.
+such as `campaign_ref`). **No package lifecycle event payload includes this
+map or any value from it.** Events expose only structural fields (ids,
+addresses, amounts, timestamps), so free-form or potentially sensitive
+package metadata is never leaked through the event stream.
+
+The one exception is `CampaignPausedEvent` / `CampaignUnpausedEvent`, whose
+`campaign_ref` field is not incidental package metadata but the admin's own
+call argument to `pause_campaign` / `unpause_campaign` — the same value is
+already public as the transaction input, so echoing it in the event is not a
+metadata leak.
 
 Consequences for indexers:
 

--- a/app/onchain/contracts/aid_escrow/README.md
+++ b/app/onchain/contracts/aid_escrow/README.md
@@ -40,6 +40,12 @@ expires and is refunded.
 | `pause(env)` | Admin | Pauses the contract (blocks package creation and claims). |
 | `unpause(env)` | Admin | Unpauses the contract. |
 | `is_paused(env)` | — | Returns true if the contract is paused. |
+| `pause_action(env, action)` | Admin | Pauses a single action (`create`/`claim`/`refund`/`withdraw`). |
+| `unpause_action(env, action)` | Admin | Unpauses a single action. |
+| `is_action_paused(env, action)` | — | Returns true if the action is paused (or the contract is globally paused). |
+| `pause_campaign(env, campaign_ref)` | Admin | Pauses `claim`/`disburse`/`refund` for packages tagged with this `campaign_ref`. |
+| `unpause_campaign(env, campaign_ref)` | Admin | Unpauses the campaign. |
+| `is_campaign_paused(env, campaign_ref)` | — | Returns true if the campaign is paused (or the contract is globally paused). |
 
 ### Funding
 

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -40,6 +40,7 @@ const KEY_PAUSE_CREATE: Symbol = symbol_short!("p_create");
 const KEY_PAUSE_CLAIM: Symbol = symbol_short!("p_claim");
 const KEY_PAUSE_REFUND: Symbol = symbol_short!("p_refund");
 const KEY_PAUSE_WITHDRAW: Symbol = symbol_short!("p_wdrw");
+const KEY_CAMPAIGN_PAUSED: Symbol = symbol_short!("camp_pzd"); // Map<String, bool>
 const KEY_TOTAL_CLAIMED: Symbol = symbol_short!("claimed"); // Map<Address, i128>
 const KEY_PENDING_ADMIN: Symbol = symbol_short!("pend_adm");
 const META_MERKLE_ROOT_KEY: &str = "merkle_root";
@@ -227,6 +228,21 @@ pub struct ActionPausedEvent {
 pub struct ActionUnpausedEvent {
     pub admin: Address,
     pub action: Symbol,
+}
+
+/// Emitted when an admin pauses a single campaign, identified by the
+/// `campaign_ref` metadata value shared by its packages.
+#[contractevent]
+pub struct CampaignPausedEvent {
+    pub admin: Address,
+    pub campaign_ref: String,
+}
+
+/// Emitted when an admin unpauses a single campaign.
+#[contractevent]
+pub struct CampaignUnpausedEvent {
+    pub admin: Address,
+    pub campaign_ref: String,
 }
 
 /// Emitted when a delegate is added/updated for a package.
@@ -606,6 +622,75 @@ impl AidEscrow {
         env.storage().instance().get(&KEY_PAUSED).unwrap_or(false)
     }
 
+    /// Admin-only. Pauses a single campaign, identified by the `campaign_ref`
+    /// metadata value shared by its packages.
+    /// While paused, `claim`, `disburse`, and `refund` are blocked for any
+    /// package tagged with this `campaign_ref`; other campaigns are unaffected.
+    /// Emits a `CampaignPausedEvent`.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
+    pub fn pause_campaign(env: Env, campaign_ref: String) -> Result<(), Error> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let mut paused: Map<String, bool> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGN_PAUSED)
+            .unwrap_or(Map::new(&env));
+        paused.set(campaign_ref.clone(), true);
+        env.storage().instance().set(&KEY_CAMPAIGN_PAUSED, &paused);
+
+        CampaignPausedEvent {
+            admin,
+            campaign_ref,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Admin-only. Unpauses a single campaign.
+    /// Emits a `CampaignUnpausedEvent`.
+    ///
+    /// # Errors
+    /// Returns `Error::NotAuthorized` if caller is not the admin.
+    pub fn unpause_campaign(env: Env, campaign_ref: String) -> Result<(), Error> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let mut paused: Map<String, bool> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGN_PAUSED)
+            .unwrap_or(Map::new(&env));
+        paused.set(campaign_ref.clone(), false);
+        env.storage().instance().set(&KEY_CAMPAIGN_PAUSED, &paused);
+
+        CampaignUnpausedEvent {
+            admin,
+            campaign_ref,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Returns `true` if `campaign_ref` is currently paused, either directly
+    /// or because the contract is globally paused (global pause always takes
+    /// precedence over campaign-level state).
+    pub fn is_campaign_paused(env: Env, campaign_ref: String) -> bool {
+        if Self::is_paused(env.clone()) {
+            return true;
+        }
+
+        let paused: Map<String, bool> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGN_PAUSED)
+            .unwrap_or(Map::new(&env));
+        paused.get(campaign_ref).unwrap_or(false)
+    }
+
     /// Returns the current contract configuration.
     /// Falls back to defaults (`min_amount: 1`, `max_expires_in: 0`, empty token list)
     /// if no config has been explicitly set.
@@ -944,6 +1029,8 @@ impl AidEscrow {
             .get(&key)
             .ok_or(Error::PackageNotFound)?;
 
+        Self::check_campaign_paused(&env, &package.metadata)?;
+
         if package.status != PackageStatus::Created {
             return Err(Error::PackageNotActive);
         }
@@ -999,6 +1086,8 @@ impl AidEscrow {
             .persistent()
             .get(&key)
             .ok_or(Error::PackageNotFound)?;
+
+        Self::check_campaign_paused(&env, &package.metadata)?;
 
         if package.status != PackageStatus::Created {
             return Err(Error::PackageNotActive);
@@ -1056,6 +1145,8 @@ impl AidEscrow {
             .persistent()
             .get(&key)
             .ok_or(Error::PackageNotFound)?;
+
+        Self::check_campaign_paused(&env, &package.metadata)?;
 
         if package.status != PackageStatus::Created {
             return Err(Error::PackageNotActive);
@@ -1132,6 +1223,8 @@ impl AidEscrow {
             .persistent()
             .get(&key)
             .ok_or(Error::PackageNotFound)?;
+
+        Self::check_campaign_paused(&env, &package.metadata)?;
 
         if package.status != PackageStatus::Created {
             return Err(Error::PackageNotActive);
@@ -1216,6 +1309,8 @@ impl AidEscrow {
             .persistent()
             .get(&key)
             .ok_or(Error::PackageNotFound)?;
+
+        Self::check_campaign_paused(&env, &package.metadata)?;
 
         // Can only refund if Expired or Cancelled.
         // If Created, must Revoke first. If Claimed, impossible.
@@ -1465,6 +1560,36 @@ impl AidEscrow {
         } else {
             Err(Error::InvalidState)
         }
+    }
+
+    /// Extracts the `campaign_ref` metadata value from a package, if present.
+    fn campaign_ref_from_metadata(env: &Env, metadata: &Map<Symbol, String>) -> Option<String> {
+        let key = Symbol::new(env, "campaign_ref");
+        metadata.get(key)
+    }
+
+    /// Blocks the caller's action if the package's campaign is paused, or if
+    /// the contract is globally paused. Global pause always takes precedence;
+    /// packages without a `campaign_ref` are never blocked by campaign state.
+    fn check_campaign_paused(env: &Env, metadata: &Map<Symbol, String>) -> Result<(), Error> {
+        if Self::is_paused(env.clone()) {
+            return Err(Error::ContractPaused);
+        }
+
+        let campaign_ref = match Self::campaign_ref_from_metadata(env, metadata) {
+            Some(r) => r,
+            None => return Ok(()),
+        };
+
+        let paused: Map<String, bool> = env
+            .storage()
+            .instance()
+            .get(&KEY_CAMPAIGN_PAUSED)
+            .unwrap_or(Map::new(env));
+        if paused.get(campaign_ref).unwrap_or(false) {
+            return Err(Error::ContractPaused);
+        }
+        Ok(())
     }
 
     fn decrement_locked(env: &Env, token: &Address, amount: i128) {

--- a/app/onchain/contracts/aid_escrow/tests/campaign_pause.rs
+++ b/app/onchain/contracts/aid_escrow/tests/campaign_pause.rs
@@ -1,0 +1,282 @@
+//! Tests for campaign-level pause controls.
+//!
+//! A campaign is identified by the `campaign_ref` metadata value shared by a
+//! group of packages. These tests verify that campaign pause blocks claim,
+//! disburse, and refund only for packages tagged with the paused campaign,
+//! and that it interacts correctly with global and action-level pause.
+
+#![cfg(test)]
+
+use aid_escrow::{AidEscrow, AidEscrowClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env, Map, String, Symbol, TryFromVal,
+};
+
+const UNIT: i128 = 10_000_000; // 1.0 Token for 7-decimal assets
+
+fn sym(env: &Env, s: &str) -> Symbol {
+    Symbol::new(env, s)
+}
+
+fn setup_token(env: &Env, admin: &Address) -> (TokenClient<'static>, StellarAssetClient<'static>) {
+    let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_client = TokenClient::new(env, &token_contract.address());
+    let token_admin_client = StellarAssetClient::new(env, &token_contract.address());
+    (token_client, token_admin_client)
+}
+
+struct Fixture {
+    env: Env,
+    client: AidEscrowClient<'static>,
+    admin: Address,
+    recipient: Address,
+    token: TokenClient<'static>,
+}
+
+fn setup() -> Fixture {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let (token, token_admin) = setup_token(&env, &admin);
+
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    token_admin.mint(&admin, &(20 * UNIT));
+    client.fund(&token.address, &admin, &(20 * UNIT));
+
+    Fixture {
+        env,
+        client,
+        admin,
+        recipient,
+        token,
+    }
+}
+
+fn metadata_with_campaign(f: &Fixture, campaign_ref: &str) -> Map<Symbol, String> {
+    let mut metadata = Map::new(&f.env);
+    metadata.set(
+        sym(&f.env, "campaign_ref"),
+        String::from_str(&f.env, campaign_ref),
+    );
+    metadata
+}
+
+fn create_package_for_campaign(f: &Fixture, id: u64, campaign_ref: &str, expires_at: u64) -> u64 {
+    f.client.create_package(
+        &f.admin,
+        &id,
+        &f.recipient,
+        &UNIT,
+        &f.token.address,
+        &expires_at,
+        &metadata_with_campaign(f, campaign_ref),
+    )
+}
+
+fn last_event_symbol(f: &Fixture, topic: &str) -> Symbol {
+    let expected = sym(&f.env, topic);
+    for (_, topics, _) in f.env.events().all().iter().rev() {
+        if let Some(first) = topics.first() {
+            if let Ok(s) = Symbol::try_from_val(&f.env, &first) {
+                if s == expected {
+                    return s;
+                }
+            }
+        }
+    }
+    panic!("expected event with topic '{}'", topic);
+}
+
+#[test]
+fn test_campaign_pause_blocks_claim() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    f.client.pause_campaign(&String::from_str(&f.env, "camp-a"));
+
+    let result = f.client.try_claim(&0u64);
+    assert!(result.is_err());
+    assert!(f
+        .client
+        .is_campaign_paused(&String::from_str(&f.env, "camp-a")));
+}
+
+#[test]
+fn test_campaign_pause_does_not_block_other_campaign() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+    create_package_for_campaign(&f, 1, "camp-b", expires_at);
+
+    f.client.pause_campaign(&String::from_str(&f.env, "camp-a"));
+
+    assert!(f.client.try_claim(&0u64).is_err());
+    assert!(f.client.try_claim(&1u64).is_ok());
+}
+
+#[test]
+fn test_unpause_campaign_resumes_claim() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    let campaign_ref = String::from_str(&f.env, "camp-a");
+    f.client.pause_campaign(&campaign_ref);
+    f.client.unpause_campaign(&campaign_ref);
+
+    assert!(!f.client.is_campaign_paused(&campaign_ref));
+    assert!(f.client.try_claim(&0u64).is_ok());
+}
+
+#[test]
+fn test_campaign_pause_blocks_disburse() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    f.client.pause_campaign(&String::from_str(&f.env, "camp-a"));
+
+    let result = f.client.try_disburse(&0u64);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_unpause_campaign_resumes_disburse() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    let campaign_ref = String::from_str(&f.env, "camp-a");
+    f.client.pause_campaign(&campaign_ref);
+    f.client.unpause_campaign(&campaign_ref);
+
+    assert!(f.client.try_disburse(&0u64).is_ok());
+}
+
+#[test]
+fn test_campaign_pause_blocks_refund() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 100;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+    // Advance past expiry so the package is refundable.
+    f.env.ledger().set_timestamp(expires_at + 1);
+
+    f.client.pause_campaign(&String::from_str(&f.env, "camp-a"));
+
+    let result = f.client.try_refund(&0u64);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_unpause_campaign_resumes_refund() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 100;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+    f.env.ledger().set_timestamp(expires_at + 1);
+
+    let campaign_ref = String::from_str(&f.env, "camp-a");
+    f.client.pause_campaign(&campaign_ref);
+    f.client.unpause_campaign(&campaign_ref);
+
+    let result = f.client.try_refund(&0u64);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_untagged_package_unaffected_by_campaign_pause() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    // No campaign_ref metadata at all.
+    f.client.create_package(
+        &f.admin,
+        &0u64,
+        &f.recipient,
+        &UNIT,
+        &f.token.address,
+        &expires_at,
+        &Map::new(&f.env),
+    );
+
+    f.client.pause_campaign(&String::from_str(&f.env, "camp-a"));
+
+    assert!(f.client.try_claim(&0u64).is_ok());
+}
+
+#[test]
+fn test_global_pause_takes_precedence_over_campaign_state() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    // Campaign was never explicitly paused, but the global pause must still
+    // block the campaign-scoped package, and is_campaign_paused must reflect
+    // that global state.
+    f.client.pause();
+
+    assert!(f.client.try_claim(&0u64).is_err());
+    assert!(f
+        .client
+        .is_campaign_paused(&String::from_str(&f.env, "camp-a")));
+
+    f.client.unpause();
+    assert!(f.client.try_claim(&0u64).is_ok());
+}
+
+#[test]
+fn test_action_pause_blocks_campaign_package_independently_of_campaign_state() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    // Action-level pause blocks claim even though the campaign itself was
+    // never paused.
+    f.client.pause_action(&sym(&f.env, "claim"));
+    assert!(f.client.try_claim(&0u64).is_err());
+    assert!(!f
+        .client
+        .is_campaign_paused(&String::from_str(&f.env, "camp-a")));
+
+    f.client.unpause_action(&sym(&f.env, "claim"));
+    assert!(f.client.try_claim(&0u64).is_ok());
+}
+
+#[test]
+fn test_campaign_pause_blocks_claim_even_when_action_unpaused() {
+    let f = setup();
+    let expires_at = f.env.ledger().timestamp() + 86400;
+    create_package_for_campaign(&f, 0, "camp-a", expires_at);
+
+    // Action-level claim pause is off, but the campaign is paused directly.
+    let campaign_ref = String::from_str(&f.env, "camp-a");
+    f.client.pause_campaign(&campaign_ref);
+
+    assert!(f.client.try_claim(&0u64).is_err());
+}
+
+#[test]
+fn test_campaign_paused_emits_event() {
+    let f = setup();
+    let campaign_ref = String::from_str(&f.env, "camp-a");
+    f.client.pause_campaign(&campaign_ref);
+    let _ = last_event_symbol(&f, "campaign_paused_event");
+
+    f.client.unpause_campaign(&campaign_ref);
+    let _ = last_event_symbol(&f, "campaign_unpaused_event");
+}
+
+#[test]
+fn test_is_campaign_paused_default_false() {
+    let f = setup();
+    assert!(!f
+        .client
+        .is_campaign_paused(&String::from_str(&f.env, "never-paused")));
+}


### PR DESCRIPTION
## Problem

Pausing today is either global (`pause`) or per-action (`pause_action`). There is no way to halt activity for a single campaign while others continue, so an incident scoped to one campaign forces a response far broader than the incident itself.

| Scenario | Before | After |
|---|---|---|
| One campaign has a compromised recipient/funder issue | Admin must call `pause()` (global) or `pause_action("claim")`, blocking every campaign | Admin calls `pause_campaign(campaign_ref)`, only that campaign is blocked |
| Contract-wide incident | `pause()` blocks everything | Unchanged — `pause()` still blocks everything, and now also implies every campaign is paused |
| Need to check if a specific campaign is halted | No query exists | `is_campaign_paused(campaign_ref)` |
| Admin disburses a package while contract is paused | `disburse` had **no** pause check at all (pre-existing gap) | `disburse` now respects both global pause and campaign pause |

## Solution

A campaign is identified by the `campaign_ref` value already used in package `metadata` (see `get_campaign_package_count` / `get_campaign_claim_count`). Rather than introduce a new first-class "Campaign" entity, campaign pause state is stored as a `Map<String, bool>` keyed by that same `campaign_ref` string, consistent with how campaigns are already modeled read-side.

`claim`, `claim_with_proof`, `claim_with_relayer`, `disburse`, and `refund` now check the paused package's `campaign_ref` (if any) immediately after loading the package. Global pause is checked first inside that same helper, so global pause always takes precedence and packages without a `campaign_ref` are never affected by campaign state.

## Changes

### `app/onchain/contracts/aid_escrow/src/lib.rs`
- Added `KEY_CAMPAIGN_PAUSED` storage key (`Map<String, bool>`).
- Added `CampaignPausedEvent` / `CampaignUnpausedEvent` (mirrors the existing `ActionPausedEvent` / `ActionUnpausedEvent` shape: `admin` + the identifier being paused).
- Added `pause_campaign(env, campaign_ref)` / `unpause_campaign(env, campaign_ref)` — admin-only, same auth pattern as `pause_action`.
- Added `is_campaign_paused(env, campaign_ref)` — returns `true` if the campaign is paused directly, or if the contract is globally paused (precedence).
- Added private helpers `campaign_ref_from_metadata` and `check_campaign_paused`, called at the top of `claim`, `claim_with_proof`, `claim_with_relayer`, `disburse`, and `refund` right after the package is loaded (so the campaign tag is available), before any state mutation.

### `app/onchain/contracts/aid_escrow/tests/campaign_pause.rs` (new)
13 tests covering pause/unpause of claim/disburse/refund, campaign isolation, untagged packages, and precedence interactions.

### `app/onchain/contracts/aid_escrow/EVENTS.md`, `README.md`
Documented the two new events and three new admin functions, and noted why `CampaignPausedEvent`/`CampaignUnpausedEvent` carrying `campaign_ref` is not a metadata leak (it's the admin's own call argument, already public as the tx input) — consistent with the existing sensitive-metadata policy in `EVENTS.md`.

## Regression Tests

| Acceptance criterion | Test(s) |
|---|---|
| A campaign can be paused and unpaused by the admin | `test_campaign_pause_blocks_claim`, `test_unpause_campaign_resumes_claim` |
| Claim, disburse, and refund respect campaign pause state | `test_campaign_pause_blocks_claim`, `test_campaign_pause_blocks_disburse`, `test_campaign_pause_blocks_refund`, `test_unpause_campaign_resumes_disburse`, `test_unpause_campaign_resumes_refund` |
| Campaign pause state is queryable | `test_is_campaign_paused_default_false`, plus `is_campaign_paused` assertions throughout |
| Global pause continues to take precedence over campaign state | `test_global_pause_takes_precedence_over_campaign_state` |
| Tests cover interaction between global, action, and campaign pause | `test_global_pause_takes_precedence_over_campaign_state`, `test_action_pause_blocks_campaign_package_independently_of_campaign_state`, `test_campaign_pause_blocks_claim_even_when_action_unpaused` |
| (bonus) Pausing one campaign doesn't affect another | `test_campaign_pause_does_not_block_other_campaign` |
| (bonus) Packages without a `campaign_ref` are unaffected | `test_untagged_package_unaffected_by_campaign_pause` |

## Testing

```
$ cargo test --test campaign_pause
running 13 tests
test test_campaign_pause_blocks_claim ... ok
test test_action_pause_blocks_campaign_package_independently_of_campaign_state ... ok
test test_campaign_pause_blocks_claim_even_when_action_unpaused ... ok
test test_campaign_pause_blocks_disburse ... ok
test test_campaign_pause_blocks_refund ... ok
test test_campaign_paused_emits_event ... ok
test test_campaign_pause_does_not_block_other_campaign ... ok
test test_global_pause_takes_precedence_over_campaign_state ... ok
test test_is_campaign_paused_default_false ... ok
test test_unpause_campaign_resumes_claim ... ok
test test_unpause_campaign_resumes_refund ... ok
test test_unpause_campaign_resumes_disburse ... ok
test test_untagged_package_unaffected_by_campaign_pause ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.67s

$ cargo test   # full crate suite, unaffected areas
... 79 tests total across all test files ... ok

$ cargo fmt --check
(clean, no output)

$ cargo clippy --tests -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 28s
(no warnings)
```

## Notes for Reviewers

- `disburse` previously had **no** pause enforcement at all — not even global. Because the issue explicitly requires disburse to respect campaign pause, and "global pause takes precedence" only makes sense to test if global pause actually blocks disburse, `check_campaign_paused` checks global pause first. This means `disburse` now also respects global pause as a byproduct — a pre-existing gap this PR closes, scoped only to what the acceptance criteria requires (it does not add a `disburse` action-specific pause key, which is out of scope).
- No new `Error` variant was added; campaign pause reuses `Error::ContractPaused`, matching how `check_action_paused` already overloads that error for both global and per-action pause.
- Campaign pause state is stored by raw `campaign_ref` string rather than a new "Campaign" struct, to stay consistent with the existing read-only `get_campaign_package_count` / `get_campaign_claim_count` helpers, which already treat `campaign_ref` as the sole campaign identifier.

Closes #964
