### PR TITLE
feat: implement mobile startup performance tracking and reporting

### DIFF
--- a/.github/workflows/mobile-startup.yml
+++ b/.github/workflows/mobile-startup.yml
@@ -1,0 +1,49 @@
+name: Mobile startup performance
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "app/mobile/**"
+      - ".github/workflows/mobile-startup.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "app/mobile/**"
+      - ".github/workflows/mobile-startup.yml"
+  workflow_dispatch:
+
+jobs:
+  startup-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_2
+          cores: 2
+          ram-size: 1536M
+          force-avd-creation: true
+          disable-animations: true
+          emulator-options: -no-snapshot -no-window -noaudio -no-boot-anim
+          script: |
+            pnpm install --frozen-lockfile
+            cd app/mobile
+            npx expo prebuild --non-interactive
+            npx expo run:android --variant release
+            node scripts/startup-performance.mjs
+      - name: Upload startup report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-startup-report
+          path: app/mobile/performance/startup-report.json

--- a/app/mobile/App.tsx
+++ b/app/mobile/App.tsx
@@ -23,6 +23,7 @@ import { SaverModeProvider } from './src/contexts/SaverModeContext';
 import { UpdateProvider, useUpdate } from './src/contexts/UpdateContext';
 import { ReleaseNotesModal } from './src/components/ReleaseNotesModal';
 import { ForceUpgradeScreen } from './src/screens/ForceUpgradeScreen';
+import { markStartupPhase } from './src/performance/startup';
 
 // ---------------------------------------------------------------------------
 // Deep-link configuration for React Navigation
@@ -93,7 +94,10 @@ const AppInner = () => {
             linking={linking}
             theme={navTheme}
             ref={navigationRef}
-            onReady={() => setIsNavReady(true)}
+            onReady={() => {
+              markStartupPhase('navigation_ready');
+              setIsNavReady(true);
+            }}
           >
             <AppNavigator />
             <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
@@ -110,6 +114,8 @@ const AppInner = () => {
 // ---------------------------------------------------------------------------
 
 export default function App() {
+  markStartupPhase('app_render');
+
   return (
     <SafeAreaProvider>
       <ThemeProvider>

--- a/app/mobile/index.ts
+++ b/app/mobile/index.ts
@@ -4,6 +4,9 @@ import 'fast-text-encoding';
 import { registerRootComponent } from 'expo';
 
 import App from './App';
+import { markStartupPhase } from './src/performance/startup';
+
+markStartupPhase('js_entry');
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/app/mobile/performance/README.md
+++ b/app/mobile/performance/README.md
@@ -1,0 +1,18 @@
+# Mobile startup performance
+
+The benchmark targets a low-end Android emulator: API 35, 2 CPU cores, 1536 MB RAM, cold boots, and snapshots disabled. React Navigation's `navigation_ready` marker defines time to interactive. The report also records `js_entry`, `app_render`, and update-check start/end markers.
+
+From `app/mobile`, install Android SDK and `adb`, create the configured emulator, then run:
+
+```bash
+pnpm install
+npx expo prebuild --non-interactive
+npx expo run:android --variant release
+node scripts/startup-performance.mjs
+```
+
+The runner writes `performance/startup-report.json` and exits non-zero when the worst of five runs exceeds the 3000 ms budget plus 20% tolerance in `startup-budget.json`. Parser-only validation is available without an emulator:
+
+```bash
+STARTUP_LOG='SOTER_STARTUP {"phase":"navigation_ready","elapsedMs":100}' node scripts/startup-performance.mjs --dry-run
+```

--- a/app/mobile/performance/startup-budget.json
+++ b/app/mobile/performance/startup-budget.json
@@ -1,0 +1,14 @@
+{
+  "profile": "android-low-end-emulator",
+  "device": {
+    "apiLevel": 35,
+    "cores": 2,
+    "ramMb": 1536,
+    "coldBoot": true,
+    "snapshots": false
+  },
+  "metric": "cold_start_to_interactive",
+  "budgetMs": 3000,
+  "tolerancePct": 20,
+  "iterations": 5
+}

--- a/app/mobile/scripts/startup-performance.mjs
+++ b/app/mobile/scripts/startup-performance.mjs
@@ -1,0 +1,55 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const budget = JSON.parse(readFileSync(resolve(root, 'performance/startup-budget.json'), 'utf8'));
+const outputPath = resolve(process.env.STARTUP_REPORT ?? 'performance/startup-report.json');
+const packageName = process.env.STARTUP_PACKAGE ?? 'org.pulsefy.soter.mobile';
+const adb = process.env.ADB ?? 'adb';
+
+function adbCommand(args) {
+  return execFileSync(adb, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function parseMarkers(logcat) {
+  return [...logcat.matchAll(/SOTER_STARTUP (\{"phase":"([^"]+)","elapsedMs":(\d+)\})/g)]
+    .map((match) => ({ phase: match[2], elapsedMs: Number(match[3]) }));
+}
+
+function checkReport(report) {
+  const allowedMs = Math.round(budget.budgetMs * (1 + budget.tolerancePct / 100));
+  const measurements = report.runs
+    .map((run) => run.phases.find((phase) => phase.phase === 'navigation_ready')?.elapsedMs)
+    .filter((value) => Number.isFinite(value));
+  if (measurements.length !== report.runs.length) {
+    throw new Error(`Missing navigation_ready marker in ${report.runs.length - measurements.length} run(s)`);
+  }
+  const worstMs = Math.max(...measurements);
+  report.summary = { worstMs, allowedMs, budgetMs: budget.budgetMs, tolerancePct: budget.tolerancePct };
+  return worstMs <= allowedMs;
+}
+
+if (process.argv.includes('--dry-run')) {
+  const report = { runs: [{ phases: parseMarkers(process.env.STARTUP_LOG ?? '') }] };
+  const withinBudget = checkReport(report);
+  console.log(JSON.stringify(report.summary));
+  process.exit(withinBudget ? 0 : 1);
+}
+
+const runs = [];
+for (let iteration = 1; iteration <= budget.iterations; iteration += 1) {
+  adbCommand(['shell', 'am', 'force-stop', packageName]);
+  adbCommand(['logcat', '-c']);
+  adbCommand(['shell', 'monkey', '-p', packageName, '1']);
+  const phases = parseMarkers(adbCommand(['logcat', '-d', '-s', 'ReactNativeJS:V']));
+  runs.push({ iteration, phases });
+  adbCommand(['shell', 'am', 'force-stop', packageName]);
+}
+
+const report = { profile: budget.profile, device: budget.device, metric: budget.metric, runs };
+const withinBudget = checkReport(report);
+writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(`Startup report written to ${outputPath}`);
+console.log(JSON.stringify(report.summary));
+if (!withinBudget) process.exit(1);

--- a/app/mobile/src/contexts/UpdateContext.tsx
+++ b/app/mobile/src/contexts/UpdateContext.tsx
@@ -3,6 +3,7 @@ import Constants from 'expo-constants';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { VersionInfo, UpdateState } from '../types/update';
 import { fetchVersionInfo, compareVersions } from '../services/updateService';
+import { markStartupPhase } from '../performance/startup';
 
 interface UpdateContextType extends UpdateState {
   markReleaseNotesSeen: () => Promise<void>;
@@ -28,6 +29,7 @@ export const UpdateProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const checkUpdates = async () => {
     try {
       setIsLoading(true);
+      markStartupPhase('update_check_start');
       const versionInfo = await fetchVersionInfo();
       
       const updateAvailable = compareVersions(versionInfo.latestVersion, currentVersion) > 0;
@@ -48,6 +50,7 @@ export const UpdateProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     } catch (error) {
       console.error('UpdateProvider: Failed to check for updates', error);
     } finally {
+      markStartupPhase('update_check_end');
       setIsLoading(false);
     }
   };

--- a/app/mobile/src/performance/startup.ts
+++ b/app/mobile/src/performance/startup.ts
@@ -1,0 +1,14 @@
+export type StartupPhase =
+  | 'js_entry'
+  | 'app_render'
+  | 'update_check_start'
+  | 'update_check_end'
+  | 'navigation_ready';
+
+const startedAt = Date.now();
+
+export function markStartupPhase(phase: StartupPhase): number {
+  const elapsedMs = Date.now() - startedAt;
+  console.log(`SOTER_STARTUP ${JSON.stringify({ phase, elapsedMs })}`);
+  return elapsedMs;
+}


### PR DESCRIPTION
closes #931 

# Measure and budget mobile cold-start performance

## Summary

Adds cold-start-to-interactive measurement for the Expo mobile app and enforces a committed startup budget on Android CI.

## Problem

The mobile app had no measurement for the time between JavaScript startup and a usable navigation surface. Regressions that affect low-end Android devices could therefore pass development testing unnoticed.

## What changed

- Added structured startup markers for:
  - `js_entry`
  - `app_render`
  - `update_check_start`
  - `update_check_end`
  - `navigation_ready`
- Defined `navigation_ready` as the cold-start-to-interactive boundary.
- Added an ADB-based runner that:
  - Force-stops the app before each iteration.
  - Clears logcat and launches the app.
  - Collects startup phase markers.
  - Runs five measurements.
  - Reports the worst `navigation_ready` result.
- Added a committed budget for a representative low-end emulator:
  - API 35
  - 2 CPU cores
  - 1536 MB RAM
  - Cold boot with snapshots disabled
  - Budget: 3000 ms
  - Tolerance: 20%
- Added a GitHub Actions workflow that runs the release APK measurement and uploads the JSON report.
- Documented local setup and parser-only validation.

## Acceptance criteria

| Criterion | Implementation |
| --- | --- |
| Cold start time to interactive is measured and reported | `navigation_ready` marker and `performance/startup-report.json` |
| A committed budget fails CI when exceeded beyond tolerance | `performance/startup-budget.json` and runner exit status |
| Measurement targets a representative low-end device profile | Fixed 2-core, 1536 MB Android emulator profile in budget and CI |
| Report attributes time to identifiable startup phases | Structured markers for JavaScript, render, update, and navigation phases |
| Running measurement locally is documented | `app/mobile/performance/README.md` |

## Validation

Static validation completed successfully for the changed TypeScript, JavaScript, JSON, and workflow files.

With an Android emulator and release APK available:

```bash
cd app/mobile
npx expo prebuild --non-interactive
npx expo run:android --variant release
node scripts/startup-performance.mjs
```

Parser-only validation, without an emulator:

```bash
cd app/mobile
STARTUP_LOG='SOTER_STARTUP {"phase":"navigation_ready","elapsedMs":100}' node scripts/startup-performance.mjs --dry-run
```

## Review notes

- The benchmark uses the worst result across five runs to keep regressions from being hidden by averaging.
- The update check is measured separately because it currently gates rendering through `UpdateProvider`.
- A real emulator run is required to produce a meaningful startup report; static validation does not replace that measurement.
