### PR TITLE
feat(aid-escrow): add batch claim for multiple packages (#961)

### DIFF
--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -45,6 +45,10 @@ const KEY_TOTAL_CLAIMED: Symbol = symbol_short!("claimed"); // Map<Address, i128
 const KEY_PENDING_ADMIN: Symbol = symbol_short!("pend_adm");
 const META_MERKLE_ROOT_KEY: &str = "merkle_root";
 
+/// Upper bound on the number of package ids accepted by `batch_claim` in a
+/// single invocation, keeping the call within Soroban resource limits.
+pub const MAX_BATCH_CLAIM_SIZE: u32 = 25;
+
 // --- Data Types ---
 
 #[contracttype]
@@ -88,6 +92,43 @@ pub struct Aggregates {
     pub total_expired_cancelled: i128,
 }
 
+/// Outcome of a single package claim attempt made as part of a `batch_claim`
+/// call. `batch_claim` never fails a whole batch because one package could
+/// not be claimed; instead each id resolves to one of these statuses.
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum ClaimStatus {
+    /// Package was claimed and the payout was transferred.
+    Success = 0,
+    /// No package exists with the given id.
+    NotFound = 1,
+    /// Package status is not `Created` (already claimed, cancelled, or refunded).
+    NotActive = 2,
+    /// Current ledger time is before the package's `claim_starts_at`.
+    ClaimTooEarly = 3,
+    /// Package has passed its `expires_at` timestamp.
+    Expired = 4,
+    /// Package is guarded by a Merkle allowlist; use `claim_with_proof` instead.
+    RequiresProof = 5,
+    /// Caller is neither the package's recipient nor an authorised delegate.
+    Unauthorized = 6,
+    /// The package's campaign is paused.
+    CampaignPaused = 7,
+    /// Eligibility checks passed but the token transfer failed.
+    TransferFailed = 8,
+}
+
+/// Per-package result returned by `batch_claim`.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchClaimResult {
+    pub package_id: u64,
+    pub status: ClaimStatus,
+    /// Amount transferred to the claimant; zero unless `status` is `Success`.
+    pub amount: i128,
+}
+
 #[contracterror]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Error {
@@ -112,6 +153,7 @@ pub enum Error {
     TokenTransferFailed = 18,
     NoPendingTransfer = 19,
     InvalidPendingAdmin = 20,
+    BatchTooLarge = 21,
 }
 
 // --- Contract Events (indexer-friendly; stable topics & payloads) ---
@@ -1208,6 +1250,91 @@ impl AidEscrow {
         .publish(&env);
 
         Ok(())
+    }
+
+    /// Claims multiple packages in a single invocation.
+    ///
+    /// `claimant` must authorize the call once; eligibility (ownership or
+    /// active delegation, timing, campaign pause, Merkle-gating) is then
+    /// checked independently for each package id. A package failing its
+    /// checks does not abort the batch or affect any other package - its
+    /// outcome is simply recorded as a non-`Success` `ClaimStatus` in the
+    /// returned results. Fund transfers and accounting updates only happen
+    /// for packages that resolve to `ClaimStatus::Success`.
+    ///
+    /// Returns `Err(Error::BatchTooLarge)` if more than
+    /// `MAX_BATCH_CLAIM_SIZE` ids are supplied, without touching any package.
+    pub fn batch_claim(
+        env: Env,
+        claimant: Address,
+        ids: Vec<u64>,
+    ) -> Result<Vec<BatchClaimResult>, Error> {
+        Self::check_action_paused(&env, symbol_short!("claim"))?;
+
+        if ids.len() > MAX_BATCH_CLAIM_SIZE {
+            return Err(Error::BatchTooLarge);
+        }
+
+        claimant.require_auth();
+
+        let now = env.ledger().timestamp();
+        let mut results = Vec::new(&env);
+        for id in ids.iter() {
+            results.push_back(Self::claim_one_for_batch(&env, &claimant, id, now));
+        }
+
+        Ok(results)
+    }
+
+    /// Evaluates and, if eligible, finalizes a single package claim as part
+    /// of `batch_claim`. Never panics on an ineligible package; the reason
+    /// is reported back via `ClaimStatus` instead.
+    fn claim_one_for_batch(env: &Env, claimant: &Address, id: u64, now: u64) -> BatchClaimResult {
+        let not_claimable = |status: ClaimStatus| BatchClaimResult {
+            package_id: id,
+            status,
+            amount: 0,
+        };
+
+        let key = (symbol_short!("pkg"), id);
+        let mut package: Package = match env.storage().persistent().get(&key) {
+            Some(p) => p,
+            None => return not_claimable(ClaimStatus::NotFound),
+        };
+
+        if Self::check_campaign_paused(env, &package.metadata).is_err() {
+            return not_claimable(ClaimStatus::CampaignPaused);
+        }
+
+        if package.status != PackageStatus::Created {
+            return not_claimable(ClaimStatus::NotActive);
+        }
+
+        if now < package.claim_starts_at {
+            return not_claimable(ClaimStatus::ClaimTooEarly);
+        }
+
+        if package.expires_at > 0 && now > package.expires_at {
+            return not_claimable(ClaimStatus::Expired);
+        }
+
+        if Self::merkle_root_from_metadata(env, &package.metadata).is_some() {
+            return not_claimable(ClaimStatus::RequiresProof);
+        }
+
+        if !delegate::is_authorised_claimer(env, id, &package.recipient, claimant) {
+            return not_claimable(ClaimStatus::Unauthorized);
+        }
+
+        let amount = package.amount;
+        match Self::finalize_claim(env, &key, &mut package, id, claimant, claimant, now) {
+            Ok(()) => BatchClaimResult {
+                package_id: id,
+                status: ClaimStatus::Success,
+                amount,
+            },
+            Err(_) => not_claimable(ClaimStatus::TransferFailed),
+        }
     }
 
     // --- Admin Actions ---

--- a/app/onchain/contracts/aid_escrow/tests/batch_claim.rs
+++ b/app/onchain/contracts/aid_escrow/tests/batch_claim.rs
@@ -1,0 +1,218 @@
+#![cfg(test)]
+
+//! Tests for `batch_claim` (issue #961): claiming multiple packages in one
+//! invocation, with per-package eligibility and explicit partial-success
+//! semantics.
+
+use aid_escrow::{
+    AidEscrow, AidEscrowClient, ClaimStatus, Error, PackageStatus, MAX_BATCH_CLAIM_SIZE,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env, Map, Vec,
+};
+
+const UNIT: i128 = 10_000_000; // 1.0 token for a 7-decimal Stellar asset
+
+struct Fixture {
+    env: Env,
+    client: AidEscrowClient<'static>,
+    admin: Address,
+    token: TokenClient<'static>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+        let token = TokenClient::new(&env, &token_contract.address());
+        let token_sac = StellarAssetClient::new(&env, &token_contract.address());
+
+        let contract_id = env.register(AidEscrow, ());
+        let client = AidEscrowClient::new(&env, &contract_id);
+        client.init(&admin);
+
+        token_sac.mint(&admin, &(1_000 * UNIT));
+        client.fund(&token.address, &admin, &(1_000 * UNIT));
+
+        Fixture {
+            env,
+            client,
+            admin,
+            token,
+        }
+    }
+
+    fn create_package(&self, id: u64, recipient: &Address, amount: i128, expires_in: u64) {
+        let expires_at = self.env.ledger().timestamp() + expires_in;
+        self.client.create_package(
+            &self.admin,
+            &id,
+            recipient,
+            &amount,
+            &self.token.address,
+            &expires_at,
+            &Map::new(&self.env),
+        );
+    }
+
+    fn advance_time(&self, seconds: u64) {
+        let mut info = self.env.ledger().get();
+        info.timestamp += seconds;
+        self.env.ledger().set(info);
+    }
+
+    fn ids(&self, values: &[u64]) -> Vec<u64> {
+        let mut v = Vec::new(&self.env);
+        for id in values {
+            v.push_back(*id);
+        }
+        v
+    }
+}
+
+#[test]
+fn batch_claim_success_pays_out_every_package() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+    f.create_package(1, &recipient, UNIT, 3_600);
+    f.create_package(2, &recipient, 2 * UNIT, 3_600);
+    f.create_package(3, &recipient, 3 * UNIT, 3_600);
+
+    let results = f.client.batch_claim(&recipient, &f.ids(&[1, 2, 3]));
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results.get(0).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(0).unwrap().amount, UNIT);
+    assert_eq!(results.get(1).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(1).unwrap().amount, 2 * UNIT);
+    assert_eq!(results.get(2).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(2).unwrap().amount, 3 * UNIT);
+
+    assert_eq!(f.token.balance(&recipient), 6 * UNIT);
+    assert_eq!(f.client.get_package(&1).status, PackageStatus::Claimed);
+    assert_eq!(f.client.get_package(&2).status, PackageStatus::Claimed);
+    assert_eq!(f.client.get_package(&3).status, PackageStatus::Claimed);
+}
+
+#[test]
+fn batch_claim_partial_failure_does_not_abort_the_batch() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+    let stranger = Address::generate(&f.env);
+
+    f.create_package(10, &recipient, UNIT, 3_600); // claimable
+    f.create_package(11, &recipient, UNIT, 3_600); // will be claimed ahead of the batch
+    f.create_package(12, &stranger, UNIT, 3_600); // not the caller's package
+    f.create_package(13, &recipient, UNIT, 1); // will expire before the batch runs
+
+    f.client.claim(&11);
+    f.advance_time(10); // pushes package 13 past its expiry
+
+    let results = f
+        .client
+        .batch_claim(&recipient, &f.ids(&[10, 11, 12, 13, 999]));
+
+    assert_eq!(results.len(), 5);
+    assert_eq!(results.get(0).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(0).unwrap().amount, UNIT);
+    assert_eq!(results.get(1).unwrap().status, ClaimStatus::NotActive);
+    assert_eq!(results.get(2).unwrap().status, ClaimStatus::Unauthorized);
+    assert_eq!(results.get(3).unwrap().status, ClaimStatus::Expired);
+    assert_eq!(results.get(4).unwrap().status, ClaimStatus::NotFound);
+
+    // Only package 10 was paid out by this batch (package 11 was already paid
+    // by the earlier individual claim); accounting reflects exactly that.
+    assert_eq!(f.token.balance(&recipient), 2 * UNIT);
+    assert_eq!(f.client.get_package(&10).status, PackageStatus::Claimed);
+    assert_eq!(f.client.get_package(&12).status, PackageStatus::Created);
+    assert_eq!(f.client.get_package(&13).status, PackageStatus::Created);
+}
+
+#[test]
+fn batch_claim_rejects_batches_above_the_max_size() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+
+    let mut ids = Vec::new(&f.env);
+    for i in 0..(MAX_BATCH_CLAIM_SIZE + 1) {
+        ids.push_back(i as u64);
+    }
+
+    let result = f.client.try_batch_claim(&recipient, &ids);
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn batch_claim_allows_exactly_the_max_size() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+
+    let mut ids = Vec::new(&f.env);
+    for i in 0..MAX_BATCH_CLAIM_SIZE as u64 {
+        f.create_package(i, &recipient, UNIT, 3_600);
+        ids.push_back(i);
+    }
+
+    let results = f.client.batch_claim(&recipient, &ids);
+    assert_eq!(results.len(), MAX_BATCH_CLAIM_SIZE);
+    for r in results.iter() {
+        assert_eq!(r.status, ClaimStatus::Success);
+    }
+}
+
+#[test]
+fn batch_claim_respects_the_claim_pause_switch() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+    f.create_package(20, &recipient, UNIT, 3_600);
+
+    f.client.pause_action(&symbol_short!("claim"));
+
+    let result = f.client.try_batch_claim(&recipient, &f.ids(&[20]));
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+    assert_eq!(f.client.get_package(&20).status, PackageStatus::Created);
+}
+
+#[test]
+fn batch_claim_with_empty_ids_returns_empty_results() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+
+    let results = f.client.batch_claim(&recipient, &Vec::new(&f.env));
+    assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn batch_claim_duplicate_id_only_pays_out_once() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+    f.create_package(30, &recipient, UNIT, 3_600);
+
+    let results = f.client.batch_claim(&recipient, &f.ids(&[30, 30]));
+
+    assert_eq!(results.get(0).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(1).unwrap().status, ClaimStatus::NotActive);
+    assert_eq!(f.token.balance(&recipient), UNIT);
+}
+
+#[test]
+fn batch_claim_pays_an_authorised_delegate() {
+    let f = Fixture::new();
+    let recipient = Address::generate(&f.env);
+    let delegate = Address::generate(&f.env);
+    f.create_package(40, &recipient, UNIT, 3_600);
+    f.client.set_delegate(&f.admin, &40, &delegate);
+
+    let results = f.client.batch_claim(&delegate, &f.ids(&[40]));
+
+    assert_eq!(results.get(0).unwrap().status, ClaimStatus::Success);
+    assert_eq!(f.token.balance(&delegate), UNIT);
+    assert_eq!(f.client.get_package(&40).status, PackageStatus::Claimed);
+}


### PR DESCRIPTION
This PR introduces Batch Claiming for the AidEscrow contract, enabling recipients and authorized delegates to claim up to 25 packages in a single transaction.

Key Enhancements:
Batch Entrypoint (batch_claim): Accepts a vector of package IDs up to a strict limit of MAX_BATCH_CLAIM_SIZE (25) and enforces recipient authorization.

Partial Success & Robust Reporting (BatchClaimResult / ClaimStatus): Instead of reverting the entire transaction upon encountering an ineligible package, each ID is evaluated independently. Status outcomes (such as Success, AlreadyClaimed, Expired, Unauthorized, NotFound, or InvalidProof) are returned cleanly in a result vector.

Invariant & Security Preservation: Fund accounting invariants, event emissions, and state updates execute strictly for successfully validated packages. All existing eligibility rules (ownership, timing, campaign pauses, and Merkle gating) remain fully enforced per package.

Benefits:
Significantly reduces transaction overhead and gas costs for users claiming multiple distributions at once.

Streamlines multi-package operations with a clear, predictable developer response payload. closes #961 