### PR TITLE
feat(ai-service): handle malformed provider responses

### DIFF
--- a/app/ai-service/exceptions.py
+++ b/app/ai-service/exceptions.py
@@ -19,6 +19,22 @@ class AIServiceError(Exception):
         return f"[{self.code}] {self.message}"
 
 
+class AIProviderMalformedResponseError(AIServiceError):
+    """Raised when a provider response cannot be validated against its schema."""
+
+    def __init__(self, message: str, details: Optional[Any] = None):
+        super().__init__(
+            message, code="AI_PROVIDER_MALFORMED_RESPONSE", details=details
+        )
+
+
+class AIProviderRefusalError(AIServiceError):
+    """Raised when a provider declines to perform the requested task."""
+
+    def __init__(self, message: str, details: Optional[Any] = None):
+        super().__init__(message, code="AI_PROVIDER_REFUSAL", details=details)
+
+
 class LoadShedError(Exception):
     """Raised when the service must reject work due to overload."""
 

--- a/app/ai-service/services/fraud_detection.py
+++ b/app/ai-service/services/fraud_detection.py
@@ -95,6 +95,11 @@ def detect_fraud(claims: List[ClaimMetadata]) -> List[ClaimFraudResult]:
             )
         )
 
+    # Re-validate the complete result contract before returning it.
+    results = [
+        ClaimFraudResult.model_validate(result.model_dump()) for result in results
+    ]
+
     logger.info(
         "Fraud detection complete: %d claims, %d flagged",
         len(claims),

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -2,16 +2,38 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 import time
 import metrics
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from config import settings
+from exceptions import AIProviderMalformedResponseError, AIProviderRefusalError
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
 
 logger = logging.getLogger(__name__)
+
+
+class CriterionAssessment(BaseModel):
+    criterion: str
+    status: Literal["met", "partially_met", "not_met", "unknown"]
+    reason: str
+
+
+class HumanitarianVerificationResult(BaseModel):
+    """Schema returned by humanitarian verification providers."""
+
+    model_config = ConfigDict(extra="allow")
+
+    verdict: Literal["credible", "partially_credible", "inconclusive", "not_credible"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    summary: str
+    criteria_assessment: Optional[List[CriterionAssessment]] = None
+    risk_flags: Optional[List[str]] = None
+    missing_information: Optional[List[str]] = None
+    recommended_next_steps: Optional[List[str]] = None
 
 
 class HumanitarianVerificationService:
@@ -62,6 +84,7 @@ class HumanitarianVerificationService:
                 )
 
             errors: List[str] = []
+            typed_error = None
 
             for provider_name, provider in providers:
                 breaker = self._get_breaker(provider_name)
@@ -93,7 +116,13 @@ class HumanitarianVerificationService:
                             model=model,
                             timeout=timeout,
                         )
-                        parsed = self._parse_json_response(response.content)
+                        parsed = self._parse_provider_response(
+                            provider=provider,
+                            response=response,
+                            prompt=prompt,
+                            model=model,
+                            timeout=timeout,
+                        )
                         breaker.record_success()
                         return {
                             "provider": provider_name,
@@ -104,12 +133,19 @@ class HumanitarianVerificationService:
                         }
                     except Exception as exc:
                         breaker.record_failure()
+                        if isinstance(
+                            exc,
+                            (AIProviderMalformedResponseError, AIProviderRefusalError),
+                        ):
+                            typed_error = exc
                         err = f"provider={provider_name}, model={model}, prompt={prompt_variant}, error={exc}"
                         errors.append(err)
                         logger.warning(
                             "Humanitarian verification attempt failed: %s", err
                         )
 
+            if typed_error is not None:
+                raise typed_error
             raise RuntimeError(
                 "All humanitarian verification attempts failed: " + " | ".join(errors)
             )
@@ -148,10 +184,90 @@ class HumanitarianVerificationService:
     def _parse_json_response(self, content: str) -> Dict[str, Any]:
         normalized = content.strip()
         if normalized.startswith("```"):
-            normalized = normalized.strip("`")
-            if normalized.startswith("json"):
-                normalized = normalized[4:].strip()
-        parsed = json.loads(normalized)
+            lines = normalized.splitlines()
+            if lines and lines[0].strip().lower() in ("```", "```json"):
+                normalized = "\n".join(
+                    lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
+                )
+        try:
+            parsed = json.loads(normalized)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AIProviderMalformedResponseError(
+                "Provider returned malformed JSON",
+                details={"reason": str(exc)},
+            ) from exc
         if not isinstance(parsed, dict):
-            raise RuntimeError("LLM response must be a JSON object")
+            raise AIProviderMalformedResponseError(
+                "Provider response must be a JSON object"
+            )
         return parsed
+
+    @staticmethod
+    def _is_refusal(content: str) -> bool:
+        text = content.strip().lower()
+        refusal_markers = (
+            "i can't",
+            "i cannot",
+            "i’m unable",
+            "i am unable",
+            "i won't",
+            "i will not",
+            "i refuse",
+            "cannot comply",
+            "not able to",
+        )
+        return any(marker in text for marker in refusal_markers)
+
+    def _parse_provider_response(
+        self,
+        provider: ModelProvider,
+        response: LLMResponse,
+        prompt: Dict[str, str],
+        model: str,
+        timeout: Optional[float],
+    ) -> Dict[str, Any]:
+        if self._is_refusal(response.content):
+            raise AIProviderRefusalError(
+                "Provider refused the humanitarian verification request",
+                details={"provider": response.provider, "model": model},
+            )
+        try:
+            parsed = self._parse_json_response(response.content)
+            return HumanitarianVerificationResult.model_validate(parsed).model_dump(
+                exclude_none=True
+            )
+        except (ValidationError, AIProviderMalformedResponseError):
+            pass
+
+        # A single repair request is enough to handle truncated/prose output
+        # without allowing malformed providers to consume unbounded capacity.
+        repair = provider.llm_chat(
+            system_prompt=prompt["system"],
+            user_prompt=(
+                "Reformat your previous answer. Return only one complete JSON object "
+                "matching the requested schema; do not add prose or markdown.\n\n"
+                f"Previous answer:\n{response.content}"
+            ),
+            model=model,
+            timeout=timeout,
+        )
+        if self._is_refusal(repair.content):
+            raise AIProviderRefusalError(
+                "Provider refused the humanitarian verification repair request",
+                details={"provider": repair.provider, "model": model},
+            )
+        try:
+            repaired = self._parse_json_response(repair.content)
+            return HumanitarianVerificationResult.model_validate(repaired).model_dump(
+                exclude_none=True
+            )
+        except ValidationError as exc:
+            raise AIProviderMalformedResponseError(
+                "Provider response remained invalid after repair attempt",
+                details={"provider": repair.provider, "errors": exc.errors()},
+            ) from exc
+        except AIProviderMalformedResponseError as exc:
+            raise AIProviderMalformedResponseError(
+                "Provider response remained malformed after repair attempt",
+                details={"provider": repair.provider, "reason": str(exc)},
+            ) from exc

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -8,6 +8,7 @@ from services.providers import (
     LLMResponse,
     ModelProvider,
 )
+from exceptions import AIProviderMalformedResponseError, AIProviderRefusalError
 import metrics
 from unittest.mock import patch, MagicMock
 
@@ -138,6 +139,65 @@ class TestHumanitarianVerificationService:
 
         assert parsed["verdict"] == "credible"
         assert parsed["confidence"] == 0.9
+
+    def test_malformed_response_is_repaired_once(self, monkeypatch):
+        mock_provider = MagicMock(spec=ModelProvider)
+        mock_provider.llm_chat.side_effect = [
+            LLMResponse(content='{"verdict":"credible"', provider="openai", model="m"),
+            LLMResponse(
+                content='{"verdict":"credible","confidence":0.8,"summary":"repaired"}',
+                provider="openai",
+                model="m",
+            ),
+        ]
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda _: "m")
+
+        result = self.service.verify_claim(
+            "A sufficiently long aid claim.", provider_preference="openai"
+        )
+
+        assert result["verification"]["summary"] == "repaired"
+        assert mock_provider.llm_chat.call_count == 2
+        assert (
+            "Reformat" in mock_provider.llm_chat.call_args_list[1].kwargs["user_prompt"]
+        )
+
+    def test_persistent_malformed_response_is_typed(self, monkeypatch):
+        mock_provider = MagicMock(spec=ModelProvider)
+        mock_provider.llm_chat.return_value = LLMResponse(
+            content="This is prose, not JSON.", provider="openai", model="m"
+        )
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda _: "m")
+
+        with pytest.raises(AIProviderMalformedResponseError):
+            self.service.verify_claim(
+                "A sufficiently long aid claim.", provider_preference="openai"
+            )
+
+        assert mock_provider.llm_chat.call_count == 4  # repair for primary and fallback
+
+    def test_provider_refusal_is_typed_and_not_repaired(self, monkeypatch):
+        mock_provider = MagicMock(spec=ModelProvider)
+        mock_provider.llm_chat.return_value = LLMResponse(
+            content="I cannot comply with this request.", provider="openai", model="m"
+        )
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(self.service, "_get_model_for_provider", lambda _: "m")
+
+        with pytest.raises(AIProviderRefusalError):
+            self.service.verify_claim(
+                "A sufficiently long aid claim.", provider_preference="openai"
+            )
+
+        assert mock_provider.llm_chat.call_count == 2
 
     def test_verify_claim_returns_deterministic_response_when_enabled(
         self, monkeypatch


### PR DESCRIPTION
Add schema validation, bounded repair retries, and typed refusal and malformed-response errors for provider output handling.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

#980