### PR TITLE
fix(ai-service): structured provider output validation and refusal de…

### DIFF
--- a/app/ai-service/exceptions.py
+++ b/app/ai-service/exceptions.py
@@ -32,3 +32,67 @@ class LoadShedError(Exception):
         self.message = message
         self.details = details or {}
         super().__init__(message)
+
+
+class ProviderOutputError(AIServiceError):
+    """Raised when a provider returns output that cannot be parsed or does not
+    match the expected schema, even after bounded repair attempts.
+
+    Distinct from transport-level failures (timeouts, HTTP errors) so callers
+    can decide whether to retry with a different provider or surface a
+    structured degraded-output result.
+
+    Attributes:
+        raw_content: The raw string returned by the provider.
+        attempts: Number of parse/repair attempts made before giving up.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        raw_content: str = "",
+        attempts: int = 1,
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            message=message,
+            code="PROVIDER_OUTPUT_ERROR",
+            details=details,
+        )
+        self.raw_content = raw_content
+        self.attempts = attempts
+
+    def __str__(self) -> str:
+        return f"[{self.code}] {self.message} (attempts={self.attempts})"
+
+
+class ProviderRefusalError(AIServiceError):
+    """Raised when a provider explicitly refuses to fulfil the request.
+
+    Content-policy refusals, safety filter trips, and "I cannot help with
+    that" prose responses are all surfaced through this class rather than
+    appearing as opaque parse failures.
+
+    Attributes:
+        raw_content: The raw refusal text returned by the provider.
+        refusal_reason: Short machine-readable reason extracted from the
+            response, e.g. ``"content_policy"`` or ``"safety_filter"``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        raw_content: str = "",
+        refusal_reason: str = "unknown",
+        details: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            message=message,
+            code="PROVIDER_REFUSAL",
+            details=details,
+        )
+        self.raw_content = raw_content
+        self.refusal_reason = refusal_reason
+
+    def __str__(self) -> str:
+        return f"[{self.code}] {self.message} (reason={self.refusal_reason})"

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -7,11 +7,22 @@ import time
 import metrics
 
 from config import settings
+from exceptions import ProviderOutputError, ProviderRefusalError
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
+from services.provider_output_validator import (
+    ProviderOutputValidator,
+    HUMANITARIAN_PRIMARY_KEYS,
+)
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
 
 logger = logging.getLogger(__name__)
+
+# Keys expected at minimum in a well-formed verification response.
+_VERIFICATION_REQUIRED_KEYS = HUMANITARIAN_PRIMARY_KEYS
+
+# How many parse/repair cycles to attempt before surfacing a typed error.
+_MAX_REPAIR_ATTEMPTS = 2
 
 
 class HumanitarianVerificationService:
@@ -21,6 +32,10 @@ class HumanitarianVerificationService:
         self.prompt_engine = HumanitarianPromptEngine()
         self.registry = registry or ProviderRegistry()
         self.breakers: Dict[str, CircuitBreaker] = {}
+        self._validator = ProviderOutputValidator(
+            required_keys=_VERIFICATION_REQUIRED_KEYS,
+            max_repair_attempts=_MAX_REPAIR_ATTEMPTS,
+        )
 
     def _get_breaker(self, provider_name: str) -> CircuitBreaker:
         if provider_name not in self.breakers:
@@ -93,7 +108,13 @@ class HumanitarianVerificationService:
                             model=model,
                             timeout=timeout,
                         )
+
+                        # Validate + repair the raw provider output before use.
+                        # ProviderRefusalError and ProviderOutputError are
+                        # propagated as structured failures; they do NOT trip
+                        # the circuit breaker because the transport succeeded.
                         parsed = self._parse_json_response(response.content)
+
                         breaker.record_success()
                         return {
                             "provider": provider_name,
@@ -102,7 +123,42 @@ class HumanitarianVerificationService:
                             "verification": parsed,
                             "raw_response": response.content,
                         }
+
+                    except ProviderRefusalError as exc:
+                        # Refusal is a definitive answer from the provider —
+                        # no point retrying the same prompt variant.  Record
+                        # a soft failure (not a circuit-breaker trip) and
+                        # surface a structured message.
+                        err = (
+                            f"provider={provider_name}, model={model}, "
+                            f"prompt={prompt_variant}, refusal_reason={exc.refusal_reason}"
+                        )
+                        errors.append(err)
+                        logger.warning(
+                            "Provider refused request: %s", err
+                        )
+                        # Skip remaining prompt variants for this provider —
+                        # a refusal on primary almost always repeats on fallback.
+                        break
+
+                    except ProviderOutputError as exc:
+                        # Malformed output after all repair attempts.  The
+                        # transport worked but the content was unusable.
+                        # Do NOT trip the circuit breaker; try the next
+                        # prompt variant / provider instead.
+                        err = (
+                            f"provider={provider_name}, model={model}, "
+                            f"prompt={prompt_variant}, output_error={exc}, "
+                            f"attempts={exc.attempts}"
+                        )
+                        errors.append(err)
+                        logger.warning(
+                            "Provider output validation failed: %s", err
+                        )
+
                     except Exception as exc:
+                        # Transport-level or unexpected errors do trip the
+                        # circuit breaker.
                         breaker.record_failure()
                         err = f"provider={provider_name}, model={model}, prompt={prompt_variant}, error={exc}"
                         errors.append(err)
@@ -146,12 +202,17 @@ class HumanitarianVerificationService:
         raise ValueError(f"Unsupported provider: {provider}")
 
     def _parse_json_response(self, content: str) -> Dict[str, Any]:
-        normalized = content.strip()
-        if normalized.startswith("```"):
-            normalized = normalized.strip("`")
-            if normalized.startswith("json"):
-                normalized = normalized[4:].strip()
-        parsed = json.loads(normalized)
-        if not isinstance(parsed, dict):
-            raise RuntimeError("LLM response must be a JSON object")
-        return parsed
+        """Validate *content* against the expected schema.
+
+        Delegates to :class:`~services.provider_output_validator.ProviderOutputValidator`
+        which handles markdown fences, truncated-JSON repair, refusal
+        detection, and required-key validation.
+
+        Raises
+        ------
+        ProviderRefusalError
+            If the provider refused the request (content-policy / safety).
+        ProviderOutputError
+            If the content cannot be parsed or validated after repair attempts.
+        """
+        return self._validator.validate(content)

--- a/app/ai-service/services/provider_output_validator.py
+++ b/app/ai-service/services/provider_output_validator.py
@@ -1,0 +1,291 @@
+"""Provider output validation, refusal detection, and bounded repair logic.
+
+This module is the single authority for turning a raw LLM response string into
+a validated ``dict`` that matches the expected output schema.  It handles the
+four most common real-world failure modes:
+
+1. **Valid JSON** — passes schema validation and is returned immediately.
+2. **Markdown-fenced JSON** — the ```json ... ``` wrapper is stripped, then
+   the content is re-validated.
+3. **Truncated JSON** — a best-effort bracket-balance repair is attempted
+   before validation.
+4. **Provider refusals / prose** — patterns such as "I cannot help" or
+   "I'm sorry" are detected and raised as ``ProviderRefusalError`` instead of
+   an opaque parse error.
+
+Any output that still fails validation after the repair attempt raises
+``ProviderOutputError``, carrying the raw content and the attempt count so
+callers can decide whether to retry with a different provider.
+
+Typical call site usage (see ``HumanitarianVerificationService``)::
+
+    from services.provider_output_validator import ProviderOutputValidator
+
+    validator = ProviderOutputValidator(
+        required_keys={"verdict", "confidence", "summary"},
+        max_repair_attempts=2,
+    )
+    parsed = validator.validate(raw_content)   # raises on persistent failure
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, FrozenSet, Optional, Set
+
+from exceptions import ProviderOutputError, ProviderRefusalError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Refusal detection — ordered from most to least specific
+# ---------------------------------------------------------------------------
+
+# Phrases that indicate the model refused the request rather than producing
+# output.  Patterns use re.IGNORECASE so they work on both original and
+# lower-cased text.
+_F = re.IGNORECASE  # shorthand used below
+
+_REFUSAL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Explicit policy / safety blocks
+    (re.compile(r"\bcannot\s+(?:help|assist|provide|fulfill|complete)\b", _F), "content_policy"),
+    (re.compile(r"\bI(?:'m|\s+am)\s+(?:unable|not\s+able)\s+to\b", _F), "content_policy"),
+    (re.compile(r"\bviolates?\s+(?:my\s+)?(?:content\s+)?(?:policy|guidelines|terms)\b", _F), "content_policy"),
+    (re.compile(r"\bsafety\s+(?:filter|policy|guidelines)\b", _F), "safety_filter"),
+    (re.compile(r"\bnot\s+(?:appropriate|allowed|permitted)\b", _F), "content_policy"),
+    # Apology-then-decline constructions
+    (re.compile(r"\bI(?:'m|\s+am)\s+sorry[,.]?\s+(?:but\s+)?I\s+(?:can(?:'t|not)|won't|will\s+not)\b", _F), "content_policy"),
+    (re.compile(r"\bI\s+(?:can(?:'t|not)|won't|will\s+not)\s+(?:help|assist|do|provide)\b", _F), "content_policy"),
+    # Model expressing inability without JSON
+    (re.compile(r"\bAs\s+an\s+AI\b.*?\bI\s+(?:can(?:'t|not)|cannot)\b", _F), "content_policy"),
+]
+
+# Minimum character length below which a response that contains no JSON
+# structure at all is treated as a refusal placeholder.
+_MIN_CONTENT_LENGTH_FOR_JSON = 2
+
+# ---------------------------------------------------------------------------
+# Required keys for each supported output variant
+# ---------------------------------------------------------------------------
+
+#: Minimum keys required in a primary (full) humanitarian verification response.
+HUMANITARIAN_PRIMARY_KEYS: FrozenSet[str] = frozenset(
+    {"verdict", "confidence", "summary"}
+)
+
+#: Minimum keys required in a fallback humanitarian verification response.
+HUMANITARIAN_FALLBACK_KEYS: FrozenSet[str] = frozenset(
+    {"verdict", "confidence", "summary"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_markdown_fence(text: str) -> str:
+    """Remove leading/trailing markdown code fences from *text*.
+
+    Handles both ````json`` and plain ```` variants.
+    """
+    stripped = text.strip()
+    # Remove opening fence (```json or ```)
+    stripped = re.sub(r"^```(?:json)?\s*\n?", "", stripped, flags=re.IGNORECASE)
+    # Remove closing fence
+    stripped = re.sub(r"\n?```\s*$", "", stripped)
+    return stripped.strip()
+
+
+def _repair_truncated_json(text: str) -> str:
+    """Attempt to close unclosed JSON brackets/braces in *text*.
+
+    This is a heuristic: it counts unmatched ``{`` / ``[`` openers and
+    appends the corresponding closers.  It handles the most common
+    truncation case (response cut off mid-object) but is not a full
+    JSON parser.
+
+    Returns the (possibly repaired) string; does *not* guarantee valid JSON.
+    """
+    open_chars = {"{": "}", "[": "]"}
+    close_chars = set(open_chars.values())
+
+    stack: list[str] = []
+    in_string = False
+    escape_next = False
+
+    for ch in text:
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch in open_chars:
+            stack.append(open_chars[ch])
+        elif ch in close_chars:
+            if stack and stack[-1] == ch:
+                stack.pop()
+
+    if not stack:
+        return text
+
+    # Close any trailing comma before appending closers, which is another
+    # common truncation artefact (last key-value pair ends with ", ...")
+    repaired = text.rstrip()
+    if repaired.endswith(","):
+        repaired = repaired[:-1]
+
+    # Append missing closers in reverse stack order
+    repaired += "".join(reversed(stack))
+    return repaired
+
+
+def _detect_refusal(text: str) -> Optional[str]:
+    """Return a refusal reason string if *text* looks like a refusal, else None."""
+    for pattern, reason in _REFUSAL_PATTERNS:
+        if pattern.search(text):
+            return reason
+    return None
+
+
+def _looks_like_prose(text: str) -> bool:
+    """Return True when *text* contains no JSON structure at all."""
+    stripped = text.strip()
+    return not stripped.startswith(("{", "[", "`"))
+
+
+# ---------------------------------------------------------------------------
+# Public validator
+# ---------------------------------------------------------------------------
+
+
+class ProviderOutputValidator:
+    """Validate and repair a raw LLM response string.
+
+    Parameters
+    ----------
+    required_keys:
+        Set of top-level keys that must be present in the parsed dict.
+        Defaults to ``HUMANITARIAN_PRIMARY_KEYS``.
+    max_repair_attempts:
+        Maximum number of parse-and-repair cycles before giving up.
+        Must be >= 1.  Defaults to 2.
+    """
+
+    def __init__(
+        self,
+        required_keys: Optional[Set[str]] = None,
+        max_repair_attempts: int = 2,
+    ) -> None:
+        if max_repair_attempts < 1:
+            raise ValueError("max_repair_attempts must be >= 1")
+        self.required_keys: FrozenSet[str] = frozenset(
+            required_keys if required_keys is not None else HUMANITARIAN_PRIMARY_KEYS
+        )
+        self.max_repair_attempts = max_repair_attempts
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def validate(self, raw_content: str) -> Dict[str, Any]:
+        """Parse, validate, and optionally repair *raw_content*.
+
+        Returns a ``dict`` that passes schema validation.
+
+        Raises
+        ------
+        ProviderRefusalError
+            If the response matches a known refusal pattern.
+        ProviderOutputError
+            If the response cannot be parsed or validated after all repair
+            attempts are exhausted.
+        """
+        if not raw_content or not raw_content.strip():
+            raise ProviderOutputError(
+                message="Provider returned empty content",
+                raw_content=raw_content,
+                attempts=1,
+            )
+
+        # Refusal check before any JSON work — refusals are prose and the
+        # right action is different from parse errors.
+        refusal_reason = _detect_refusal(raw_content)
+        if refusal_reason:
+            raise ProviderRefusalError(
+                message="Provider refused to fulfil the request",
+                raw_content=raw_content,
+                refusal_reason=refusal_reason,
+            )
+
+        # Also check for pure prose with no JSON structure
+        if _looks_like_prose(raw_content):
+            # One last refusal heuristic: short/generic prose
+            raise ProviderOutputError(
+                message="Provider returned prose instead of JSON",
+                raw_content=raw_content,
+                attempts=1,
+            )
+
+        last_exc: Exception = RuntimeError("unknown error")
+        candidate = raw_content
+
+        for attempt in range(1, self.max_repair_attempts + 1):
+            try:
+                parsed = self._parse_and_validate(candidate, attempt)
+                if attempt > 1:
+                    logger.info(
+                        "Provider output repaired successfully on attempt %d", attempt
+                    )
+                return parsed
+            except (json.JSONDecodeError, ValueError) as exc:
+                last_exc = exc
+                logger.debug(
+                    "Parse/validate failed on attempt %d: %s", attempt, exc
+                )
+                if attempt < self.max_repair_attempts:
+                    candidate = self._repair(candidate, attempt)
+
+        raise ProviderOutputError(
+            message=f"Provider output failed validation after {self.max_repair_attempts} attempt(s): {last_exc}",
+            raw_content=raw_content,
+            attempts=self.max_repair_attempts,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _parse_and_validate(self, text: str, attempt: int) -> Dict[str, Any]:
+        """Strip fences, parse JSON, and check required keys."""
+        # Strip markdown code fences (e.g., ```json ... ```)
+        cleaned = _strip_markdown_fence(text)
+
+        parsed: Any = json.loads(cleaned)
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Provider response must be a JSON object, got {type(parsed).__name__}"
+            )
+
+        missing = self.required_keys - parsed.keys()
+        if missing:
+            raise ValueError(
+                f"Provider response missing required keys: {sorted(missing)}"
+            )
+
+        return parsed
+
+    def _repair(self, text: str, attempt: int) -> str:
+        """Apply repair heuristics to *text* and return the repaired string."""
+        logger.debug("Attempting JSON repair (attempt=%d)", attempt)
+        # Strip fences first so the bracket balancer sees raw JSON
+        defenced = _strip_markdown_fence(text)
+        return _repair_truncated_json(defenced)

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -133,7 +133,7 @@ class TestHumanitarianVerificationService:
         assert self.service.get_model_version("auto") == "none:none"
 
     def test_parse_json_response_supports_markdown_block(self):
-        content = '```json\n{"verdict":"credible","confidence":0.9}\n```'
+        content = '```json\n{"verdict":"credible","confidence":0.9,"summary":"Claim is supported by evidence."}\n```'
         parsed = self.service._parse_json_response(content)
 
         assert parsed["verdict"] == "credible"

--- a/app/ai-service/tests/test_provider_output_validator.py
+++ b/app/ai-service/tests/test_provider_output_validator.py
@@ -1,0 +1,598 @@
+"""Tests for services/provider_output_validator.py.
+
+Coverage:
+- Valid JSON passes straight through
+- Markdown-fenced JSON (```json ... ```) is stripped and parsed
+- Truncated JSON is repaired and validated successfully
+- Prose responses (no JSON structure) raise ProviderOutputError
+- Explicit provider refusals raise ProviderRefusalError with the right reason
+- Schema violations (missing required keys) raise ProviderOutputError
+- Repair succeeds when truncation is mild (one missing brace/bracket)
+- Exhausted retries produce ProviderOutputError with attempts == max_repair_attempts
+- Empty / whitespace-only content raises ProviderOutputError immediately
+- Nested-object truncation is repaired correctly
+- _strip_markdown_fence handles all common fence variants
+- _repair_truncated_json leaves already-valid JSON untouched
+- _detect_refusal identifies all registered refusal patterns
+- _looks_like_prose rejects JSON, accepts prose
+- ProviderOutputValidator constructor validates max_repair_attempts
+"""
+
+import json
+import pytest
+
+from exceptions import ProviderOutputError, ProviderRefusalError
+from services.provider_output_validator import (
+    HUMANITARIAN_PRIMARY_KEYS,
+    ProviderOutputValidator,
+    _detect_refusal,
+    _looks_like_prose,
+    _repair_truncated_json,
+    _strip_markdown_fence,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_RESPONSE = json.dumps(
+    {
+        "verdict": "credible",
+        "confidence": 0.85,
+        "summary": "Claim is consistent with field reports.",
+        "risk_flags": [],
+        "missing_information": [],
+        "recommended_next_steps": ["Follow up with local NGO"],
+    }
+)
+
+REQUIRED_KEYS = {"verdict", "confidence", "summary"}
+
+
+def make_validator(**kwargs) -> ProviderOutputValidator:
+    return ProviderOutputValidator(
+        required_keys=REQUIRED_KEYS,
+        max_repair_attempts=kwargs.get("max_repair_attempts", 2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarkdownFence:
+    def test_strips_json_labeled_fence(self):
+        text = "```json\n{\"a\": 1}\n```"
+        assert _strip_markdown_fence(text) == '{"a": 1}'
+
+    def test_strips_plain_fence(self):
+        text = "```\n{\"a\": 1}\n```"
+        assert _strip_markdown_fence(text) == '{"a": 1}'
+
+    def test_leaves_plain_json_untouched(self):
+        text = '{"a": 1}'
+        assert _strip_markdown_fence(text) == text
+
+    def test_strips_fence_with_trailing_whitespace(self):
+        text = "```json  \n{\"x\": 2}\n```  "
+        result = _strip_markdown_fence(text)
+        assert result == '{"x": 2}'
+
+    def test_strips_fence_with_no_newline_after_opening(self):
+        text = '```json{"a":1}```'
+        result = _strip_markdown_fence(text)
+        assert result == '{"a":1}'
+
+
+class TestRepairTruncatedJson:
+    def test_leaves_valid_json_untouched(self):
+        text = '{"a": 1}'
+        assert _repair_truncated_json(text) == text
+
+    def test_closes_single_missing_brace(self):
+        text = '{"verdict": "credible", "confidence": 0.9'
+        repaired = _repair_truncated_json(text)
+        # Should be parseable after repair
+        parsed = json.loads(repaired)
+        assert parsed["verdict"] == "credible"
+
+    def test_closes_missing_bracket_and_brace(self):
+        text = '{"items": [1, 2, 3'
+        repaired = _repair_truncated_json(text)
+        parsed = json.loads(repaired)
+        assert parsed["items"] == [1, 2, 3]
+
+    def test_removes_trailing_comma_before_closing(self):
+        text = '{"a": 1, "b": 2,'
+        repaired = _repair_truncated_json(text)
+        parsed = json.loads(repaired)
+        assert parsed == {"a": 1, "b": 2}
+
+    def test_nested_truncation(self):
+        text = '{"outer": {"inner": "value"'
+        repaired = _repair_truncated_json(text)
+        parsed = json.loads(repaired)
+        assert parsed["outer"]["inner"] == "value"
+
+    def test_deeply_nested_truncation(self):
+        text = '{"a": {"b": {"c": [1, 2'
+        repaired = _repair_truncated_json(text)
+        parsed = json.loads(repaired)
+        assert parsed["a"]["b"]["c"] == [1, 2]
+
+    def test_already_balanced_array(self):
+        text = '[1, 2, 3]'
+        assert _repair_truncated_json(text) == text
+
+
+class TestDetectRefusal:
+    def test_cannot_help_detected(self):
+        assert _detect_refusal("I cannot help with this request.") == "content_policy"
+
+    def test_cannot_assist_detected(self):
+        assert _detect_refusal("I cannot assist with humanitarian claims.") == "content_policy"
+
+    def test_unable_to_detected(self):
+        assert _detect_refusal("I'm unable to provide a response.") == "content_policy"
+
+    def test_safety_filter_detected(self):
+        assert _detect_refusal("This triggers a safety filter.") == "safety_filter"
+
+    def test_policy_violation_detected(self):
+        assert _detect_refusal("This violates my content policy.") == "content_policy"
+
+    def test_sorry_but_cannot(self):
+        assert _detect_refusal("I'm sorry, but I can't do that.") == "content_policy"
+
+    def test_not_appropriate(self):
+        assert _detect_refusal("That is not appropriate to answer.") == "content_policy"
+
+    def test_valid_json_not_detected(self):
+        assert _detect_refusal('{"verdict": "credible", "confidence": 0.9}') is None
+
+    def test_neutral_prose_not_detected(self):
+        assert _detect_refusal("The claim is credible based on evidence.") is None
+
+    def test_case_insensitive(self):
+        assert _detect_refusal("I CANNOT HELP with this.") == "content_policy"
+
+    def test_i_wont_help(self):
+        assert _detect_refusal("I won't help with that task.") == "content_policy"
+
+    def test_will_not_assist(self):
+        assert _detect_refusal("I will not assist with this.") == "content_policy"
+
+
+class TestLooksLikeProse:
+    def test_json_object_not_prose(self):
+        assert _looks_like_prose('{"a": 1}') is False
+
+    def test_json_array_not_prose(self):
+        assert _looks_like_prose('[1, 2, 3]') is False
+
+    def test_markdown_fence_not_prose(self):
+        assert _looks_like_prose('```json\n{"a":1}\n```') is False
+
+    def test_plain_sentence_is_prose(self):
+        assert _looks_like_prose("The aid was distributed successfully.") is True
+
+    def test_empty_string_is_prose(self):
+        # Empty strings are handled separately, but the helper should be consistent
+        assert _looks_like_prose("") is True
+
+
+# ---------------------------------------------------------------------------
+# ProviderOutputValidator unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderOutputValidatorConstruction:
+    def test_default_required_keys(self):
+        v = ProviderOutputValidator()
+        assert v.required_keys == HUMANITARIAN_PRIMARY_KEYS
+
+    def test_custom_required_keys(self):
+        v = ProviderOutputValidator(required_keys={"a", "b"})
+        assert v.required_keys == frozenset({"a", "b"})
+
+    def test_max_repair_attempts_must_be_positive(self):
+        with pytest.raises(ValueError, match="max_repair_attempts must be >= 1"):
+            ProviderOutputValidator(max_repair_attempts=0)
+
+    def test_max_repair_attempts_of_one_is_valid(self):
+        v = ProviderOutputValidator(max_repair_attempts=1)
+        assert v.max_repair_attempts == 1
+
+
+class TestValidatorHappyPath:
+    def test_valid_json_passes_through(self):
+        v = make_validator()
+        result = v.validate(VALID_RESPONSE)
+        assert result["verdict"] == "credible"
+        assert result["confidence"] == 0.85
+
+    def test_markdown_fenced_json_accepted(self):
+        v = make_validator()
+        fenced = f"```json\n{VALID_RESPONSE}\n```"
+        result = v.validate(fenced)
+        assert result["verdict"] == "credible"
+
+    def test_plain_fence_accepted(self):
+        v = make_validator()
+        fenced = f"```\n{VALID_RESPONSE}\n```"
+        result = v.validate(fenced)
+        assert result["verdict"] == "credible"
+
+    def test_whitespace_around_json_accepted(self):
+        v = make_validator()
+        result = v.validate(f"\n\n  {VALID_RESPONSE}  \n")
+        assert result["verdict"] == "credible"
+
+    def test_extra_keys_are_preserved(self):
+        v = make_validator()
+        payload = {
+            "verdict": "inconclusive",
+            "confidence": 0.5,
+            "summary": "Insufficient evidence",
+            "extra_field": "allowed",
+        }
+        result = v.validate(json.dumps(payload))
+        assert result["extra_field"] == "allowed"
+
+
+class TestValidatorRefusals:
+    def test_cannot_help_raises_refusal_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate("I cannot help with this humanitarian claim.")
+        assert exc_info.value.refusal_reason == "content_policy"
+        assert "humanitarian claim" in exc_info.value.raw_content
+
+    def test_safety_filter_raises_refusal_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate("This request triggered a safety filter and cannot be processed.")
+        assert exc_info.value.refusal_reason == "safety_filter"
+
+    def test_policy_violation_raises_refusal_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate("Your request violates my content policy.")
+        assert exc_info.value.refusal_reason == "content_policy"
+        assert isinstance(exc_info.value, ProviderRefusalError)
+
+    def test_sorry_but_cannot_raises_refusal_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError):
+            v.validate("I'm sorry, but I can't provide a response to this claim.")
+
+    def test_refusal_error_carries_raw_content(self):
+        v = make_validator()
+        raw = "I'm unable to assist with this type of request."
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate(raw)
+        assert exc_info.value.raw_content == raw
+
+    def test_refusal_error_is_subclass_of_ai_service_error(self):
+        from exceptions import AIServiceError
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate("I cannot help with that.")
+        assert isinstance(exc_info.value, AIServiceError)
+
+    def test_refusal_error_str_contains_reason(self):
+        v = make_validator()
+        with pytest.raises(ProviderRefusalError) as exc_info:
+            v.validate("I won't help with this.")
+        assert "content_policy" in str(exc_info.value)
+
+
+class TestValidatorProse:
+    def test_plain_prose_raises_output_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate("The claim appears credible based on the evidence presented.")
+        # Should specifically call out prose vs refusal
+        assert "prose" in exc_info.value.message.lower()
+
+    def test_prose_error_carries_raw_content(self):
+        v = make_validator()
+        raw = "This is just a sentence, not JSON at all."
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(raw)
+        assert exc_info.value.raw_content == raw
+
+    def test_empty_string_raises_output_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate("")
+        assert "empty" in exc_info.value.message.lower()
+
+    def test_whitespace_only_raises_output_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate("   \n\t  ")
+        assert "empty" in exc_info.value.message.lower()
+
+
+class TestValidatorSchemaViolation:
+    def test_missing_single_required_key_raises_output_error(self):
+        v = make_validator()
+        # verdict and confidence present, summary missing
+        payload = json.dumps({"verdict": "credible", "confidence": 0.8})
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(payload)
+        assert "summary" in exc_info.value.message
+
+    def test_missing_all_required_keys_raises_output_error(self):
+        v = make_validator()
+        payload = json.dumps({"completely": "wrong", "schema": True})
+        with pytest.raises(ProviderOutputError):
+            v.validate(payload)
+
+    def test_json_array_instead_of_object_raises_output_error(self):
+        v = make_validator()
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate("[1, 2, 3]")
+        assert "object" in exc_info.value.message.lower()
+
+    def test_schema_error_is_output_error_not_refusal(self):
+        v = make_validator()
+        with pytest.raises(ProviderOutputError):
+            v.validate(json.dumps({"wrong": "keys"}))
+
+    def test_output_error_carries_raw_content(self):
+        v = make_validator()
+        raw = json.dumps({"wrong": "keys"})
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(raw)
+        assert exc_info.value.raw_content == raw
+
+
+class TestValidatorTruncatedJson:
+    def test_truncated_object_is_repaired(self):
+        v = make_validator()
+        truncated = '{"verdict": "credible", "confidence": 0.9, "summary": "ok"'
+        result = v.validate(truncated)
+        assert result["verdict"] == "credible"
+
+    def test_truncated_with_nested_array_is_repaired(self):
+        v = make_validator()
+        truncated = (
+            '{"verdict": "inconclusive", "confidence": 0.5, "summary": "unclear", '
+            '"risk_flags": ["missing documents", "unverified location"'
+        )
+        result = v.validate(truncated)
+        assert result["verdict"] == "inconclusive"
+        assert "missing documents" in result["risk_flags"]
+
+    def test_truncated_object_mid_value_raises_after_exhausted_retries(self):
+        """A response cut off inside a string value cannot be repaired."""
+        v = make_validator(max_repair_attempts=2)
+        # Truncated mid-string — the value is unclosed and the bracket balancer
+        # cannot fix it because the string's double-quote is still "open"
+        truncated = '{"verdict": "credible", "confidence": 0.9, "summary": "truncated mid-str'
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(truncated)
+        assert exc_info.value.attempts == 2
+
+    def test_valid_json_without_required_keys_not_repaired(self):
+        """Repair heuristic only applies to parse errors, not schema errors."""
+        v = make_validator(max_repair_attempts=2)
+        # Valid JSON but wrong schema — repair won't help
+        payload = json.dumps({"wrong": "schema"})
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(payload)
+        assert exc_info.value.attempts == 2
+
+
+class TestValidatorRepairBound:
+    def test_attempts_equals_max_on_exhaustion(self):
+        v = make_validator(max_repair_attempts=3)
+        garbage = '{"verdict": "x", "confidence": invalid'
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(garbage)
+        assert exc_info.value.attempts == 3
+
+    def test_single_attempt_max_raises_immediately(self):
+        v = make_validator(max_repair_attempts=1)
+        truncated = '{"verdict": "credible"'
+        # With only 1 attempt, there is no repair cycle and it must raise
+        # ProviderOutputError (attempts=1)
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate(truncated)
+        assert exc_info.value.attempts == 1
+
+    def test_repair_succeeds_on_second_attempt(self):
+        """Verify the repair cycle actually runs and succeeds."""
+        v = make_validator(max_repair_attempts=2)
+        # Missing closing brace — repairable
+        truncated = '{"verdict": "credible", "confidence": 0.9, "summary": "ok"'
+        result = v.validate(truncated)
+        assert result["verdict"] == "credible"
+
+    def test_output_error_is_subclass_of_ai_service_error(self):
+        from exceptions import AIServiceError
+        v = make_validator()
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate('{"no": "required keys"}')
+        assert isinstance(exc_info.value, AIServiceError)
+
+    def test_output_error_str_includes_attempts(self):
+        v = make_validator(max_repair_attempts=2)
+        with pytest.raises(ProviderOutputError) as exc_info:
+            v.validate('{"no": "required keys"}')
+        assert "attempts=2" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: HumanitarianVerificationService + validator
+# ---------------------------------------------------------------------------
+
+
+class TestHumanitarianVerificationServiceOutputHandling:
+    """End-to-end tests that exercise the wiring between verify_claim and the
+    validator without making any real network calls."""
+
+    def _make_service_with_stub(self, responses):
+        """Return a service configured with a stub provider that yields *responses*."""
+        from services.humanitarian_verification import HumanitarianVerificationService
+        from services.providers import ProviderRegistry, ModelProvider, LLMResponse
+        from unittest.mock import MagicMock
+
+        class StubProvider(ModelProvider):
+            def __init__(self, resps):
+                self._resps = list(resps)
+                self._idx = 0
+
+            @property
+            def name(self):
+                return "stub"
+
+            def llm_chat(self, system_prompt, user_prompt, *, model=None, timeout=None):
+                if self._idx >= len(self._resps):
+                    raise RuntimeError("No more stub responses")
+                r = self._resps[self._idx]
+                self._idx += 1
+                if isinstance(r, Exception):
+                    raise r
+                return LLMResponse(content=r, provider="stub", model=model or "stub-model")
+
+        stub = StubProvider(responses)
+        registry = MagicMock(spec=ProviderRegistry)
+        registry.resolve_llm.return_value = [("stub", stub)]
+
+        svc = HumanitarianVerificationService(registry=registry)
+        svc._get_model_for_provider = lambda p: "stub-model"
+        return svc
+
+    # --- Refusal handling ---
+
+    def test_refusal_on_primary_skips_to_next_provider_not_fallback(self):
+        """A refusal should break out of both prompt variants for that provider."""
+        svc = self._make_service_with_stub([
+            # primary: refusal
+            "I cannot help with this humanitarian claim.",
+            # fallback should NOT be reached; if it is, it would succeed
+            VALID_RESPONSE,
+        ])
+        with pytest.raises(RuntimeError, match="All humanitarian verification attempts failed"):
+            svc.verify_claim(
+                aid_claim="Aid delivered to 200 households.",
+                supporting_evidence=["field report"],
+            )
+
+    def test_refusal_does_not_trip_circuit_breaker(self):
+        """A refusal is a structured provider outcome, not a transport failure."""
+        from services.circuit_breaker import CircuitBreaker
+        from unittest.mock import patch
+
+        svc = self._make_service_with_stub([
+            "I cannot help with that.",
+        ])
+        # Override _get_breaker to track if record_failure is called
+        breaker = CircuitBreaker(name="stub", failure_threshold=3, recovery_timeout=60)
+        svc.breakers["stub"] = breaker
+
+        with pytest.raises(RuntimeError):
+            svc.verify_claim(
+                aid_claim="Aid claim text here.",
+                supporting_evidence=[],
+            )
+
+        # record_failure should NOT have been called for a refusal
+        assert breaker.failure_count == 0
+
+    # --- Malformed output handling ---
+
+    def test_malformed_primary_falls_through_to_fallback(self):
+        """Persistent malformed primary output allows the fallback prompt to be tried."""
+        svc = self._make_service_with_stub([
+            # primary: bad schema
+            json.dumps({"wrong": "schema"}),
+            # fallback: good response
+            VALID_RESPONSE,
+        ])
+        result = svc.verify_claim(
+            aid_claim="Aid distributed successfully.",
+            supporting_evidence=["distribution log"],
+        )
+        assert result["prompt_variant"] == "fallback"
+        assert result["verification"]["verdict"] == "credible"
+
+    def test_malformed_output_does_not_trip_circuit_breaker(self):
+        """Parse failures should not increment the circuit breaker failure count."""
+        from services.circuit_breaker import CircuitBreaker
+
+        svc = self._make_service_with_stub([
+            # Both variants: bad schema — triggers ProviderOutputError
+            json.dumps({"wrong": "schema"}),
+            json.dumps({"wrong": "schema"}),
+        ])
+        breaker = CircuitBreaker(name="stub", failure_threshold=3, recovery_timeout=60)
+        svc.breakers["stub"] = breaker
+
+        with pytest.raises(RuntimeError):
+            svc.verify_claim(
+                aid_claim="Test claim.",
+                supporting_evidence=[],
+            )
+
+        assert breaker.failure_count == 0
+
+    def test_truncated_json_is_repaired_and_returned(self):
+        """A truncated but repairable response should succeed without error."""
+        truncated = '{"verdict": "credible", "confidence": 0.9, "summary": "ok"'
+        svc = self._make_service_with_stub([truncated])
+        result = svc.verify_claim(
+            aid_claim="Aid delivered.",
+            supporting_evidence=[],
+        )
+        assert result["verification"]["verdict"] == "credible"
+
+    def test_prose_response_falls_through_to_fallback(self):
+        """Pure prose on primary → ProviderOutputError → try fallback."""
+        svc = self._make_service_with_stub([
+            # primary: prose
+            "The aid claim appears to be valid based on the evidence.",
+            # fallback: valid JSON
+            VALID_RESPONSE,
+        ])
+        result = svc.verify_claim(
+            aid_claim="Claim about food distribution.",
+            supporting_evidence=[],
+        )
+        assert result["prompt_variant"] == "fallback"
+        assert result["verification"]["verdict"] == "credible"
+
+    def test_all_variants_malformed_raises_runtime_error(self):
+        """When every prompt variant fails with ProviderOutputError, RuntimeError is raised."""
+        svc = self._make_service_with_stub([
+            json.dumps({"wrong": "schema"}),
+            json.dumps({"wrong": "schema"}),
+        ])
+        with pytest.raises(RuntimeError, match="All humanitarian verification attempts failed"):
+            svc.verify_claim(
+                aid_claim="A claim.",
+                supporting_evidence=[],
+            )
+
+    def test_transport_error_trips_circuit_breaker(self):
+        """A network/transport error (not ProviderOutputError) DOES trip the breaker."""
+        from services.circuit_breaker import CircuitBreaker
+
+        svc = self._make_service_with_stub([
+            RuntimeError("Connection refused"),
+            RuntimeError("Connection refused"),
+        ])
+        breaker = CircuitBreaker(name="stub", failure_threshold=10, recovery_timeout=60)
+        svc.breakers["stub"] = breaker
+
+        with pytest.raises(RuntimeError):
+            svc.verify_claim(
+                aid_claim="Test.",
+                supporting_evidence=[],
+            )
+
+        assert breaker.failure_count == 2  # both prompt variants failed


### PR DESCRIPTION
…tection

- Add ProviderOutputError and ProviderRefusalError typed exceptions to exceptions.py, both subclassing AIServiceError so existing handlers catch them without changes

- Add services/provider_output_validator.py with:
  - ProviderOutputValidator: validates parsed dict against required keys, bounded repair cycle (max_repair_attempts=2)
  - _repair_truncated_json: bracket-balance heuristic to close truncated JSON objects/arrays and strip trailing commas
  - _strip_markdown_fence: removes ```json ... ``` wrappers
  - _detect_refusal: 8 IGNORECASE patterns covering content-policy and safety-filter refusal phrases
  - _looks_like_prose: fast structural check for non-JSON responses

- Wire validator into HumanitarianVerificationService:
  - _parse_json_response delegates to ProviderOutputValidator.validate()
  - verify_claim distinguishes ProviderRefusalError (skip variant, no circuit-breaker trip), ProviderOutputError (try next variant, no circuit-breaker trip), and transport Exception (circuit-breaker trip)

- Add tests/test_provider_output_validator.py: 71 tests covering truncated JSON repair, prose detection, all refusal patterns, schema violations, bounded retry exhaustion, and end-to-end service wiring including circuit-breaker isolation

- Update test_parse_json_response_supports_markdown_block to include the now-required 'summary' key (schema enforcement was previously too permissive)


closes #980 