### PR TITLE
feat(ai-service): Make provider fallback order explicit and configurable

### DIFF
--- a/app/ai-service/.env.example
+++ b/app/ai-service/.env.example
@@ -9,6 +9,16 @@ GROQ_MODEL=llama-3.3-70b-versatile
 AI_DETERMINISTIC_MODE=false
 LLM_TIMEOUT_SECONDS=30
 
+# Provider fallback order (comma-separated, "auto" mode only)
+# Controls which LLM provider is tried first when provider_preference=auto.
+# Useful for cost optimisation (cheapest-first) or latency tuning.
+# Supported values: openai, groq, test  (omit or leave blank for code-default order)
+# Example — prefer Groq for lower cost, fall back to OpenAI:
+#   LLM_PROVIDER_ORDER=groq,openai
+# Example — always prefer OpenAI, use Groq as fallback:
+#   LLM_PROVIDER_ORDER=openai,groq
+LLM_PROVIDER_ORDER=
+
 # Demo / contributor mode
 # Set TEST_PROVIDER_MODE=true to use fixture-driven responses without any API
 # keys.  This enables "demo mode" so contributors can run the service locally

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import secrets
-from typing import Literal, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import model_validator, HttpUrl
 from pydantic_core import PydanticUndefined
@@ -78,6 +78,14 @@ class Settings(BaseSettings):
     test_provider_mode: bool = False
     llm_timeout_seconds: int = 30
 
+    # Explicit LLM provider fallback order.
+    # Comma-separated list of provider names that controls the order in which
+    # providers are tried when provider_preference is "auto".
+    # Supported values: openai, groq, test
+    # Example: LLM_PROVIDER_ORDER=groq,openai   (cheapest-first / lowest-latency-first)
+    # When empty (the default) the implicit code order is used: test > openai > groq.
+    llm_provider_order: List[str] = []
+
     # Request throttling
     request_rate_limit: str = "10/minute"
 
@@ -145,6 +153,18 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_list_fields(cls, values: Any) -> Any:  # type: ignore[override]
+        """Convert comma-separated env strings to lists where needed."""
+        if isinstance(values, dict):
+            raw = values.get("llm_provider_order")
+            if isinstance(raw, str):
+                values["llm_provider_order"] = [
+                    p.strip() for p in raw.split(",") if p.strip()
+                ]
+        return values
 
     @model_validator(mode="after")
     def apply_environment_defaults(self) -> "Settings":
@@ -297,6 +317,20 @@ class Settings(BaseSettings):
                 "production requires at least one provider API key or "
                 "TEST_PROVIDER_MODE=true",
             )
+
+        # --- LLM provider order: entries must be known provider names ----
+        _KNOWN_LLM_PROVIDERS = {"openai", "groq", "test"}
+        for entry in self.llm_provider_order:
+            entry = entry.strip()
+            if not entry:
+                continue
+            if entry not in _KNOWN_LLM_PROVIDERS:
+                _add(
+                    "LLM_PROVIDER_ORDER",
+                    f"unknown provider {entry!r}; valid values are "
+                    f"{', '.join(sorted(_KNOWN_LLM_PROVIDERS))}",
+                )
+                break
 
         if errors:
             summary = "\n  - ".join(errors)

--- a/app/ai-service/exceptions.py
+++ b/app/ai-service/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 
 class AIServiceError(Exception):
@@ -17,6 +17,40 @@ class AIServiceError(Exception):
 
     def __str__(self) -> str:
         return f"[{self.code}] {self.message}"
+
+
+class AllProvidersExhaustedError(AIServiceError):
+    """Raised when every LLM provider in the fallback chain has been tried
+    and none produced a successful response.
+
+    Attributes:
+        attempted_providers: Names of the providers that were tried (in
+            attempt order).  Providers skipped due to an open circuit breaker
+            are listed as well, prefixed with ``"(skipped) "``.
+        per_provider_errors: Mapping of provider name → error description
+            collected during the attempt loop.
+    """
+
+    def __init__(
+        self,
+        attempted_providers: List[str],
+        per_provider_errors: Optional[List[str]] = None,
+    ):
+        self.attempted_providers = attempted_providers
+        self.per_provider_errors = per_provider_errors or []
+        detail_str = " | ".join(self.per_provider_errors) if self.per_provider_errors else "no providers available"
+        message = (
+            f"All LLM providers exhausted after trying "
+            f"{attempted_providers}: {detail_str}"
+        )
+        super().__init__(
+            message=message,
+            code="ALL_PROVIDERS_EXHAUSTED",
+            details={
+                "attempted_providers": attempted_providers,
+                "errors": self.per_provider_errors,
+            },
+        )
 
 
 class LoadShedError(Exception):

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -7,6 +7,7 @@ import time
 import metrics
 
 from config import settings
+from exceptions import AllProvidersExhaustedError
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
@@ -57,11 +58,13 @@ class HumanitarianVerificationService:
 
             providers = self.registry.resolve_llm(provider_preference)
             if not providers:
-                raise RuntimeError(
-                    "No LLM providers configured for humanitarian verification"
+                raise AllProvidersExhaustedError(
+                    attempted_providers=[],
+                    per_provider_errors=["No LLM providers configured for humanitarian verification"],
                 )
 
             errors: List[str] = []
+            attempted: List[str] = []
 
             for provider_name, provider in providers:
                 breaker = self._get_breaker(provider_name)
@@ -70,11 +73,13 @@ class HumanitarianVerificationService:
                         "Circuit breaker is OPEN for provider=%s. Skipping.",
                         provider_name,
                     )
+                    attempted.append(f"(skipped) {provider_name}")
                     errors.append(
                         f"provider={provider_name}, error=Circuit breaker is OPEN"
                     )
                     continue
 
+                attempted.append(provider_name)
                 model = self._get_model_for_provider(provider_name)
                 for prompt_variant, prompt in (
                     ("primary", primary_prompt),
@@ -97,6 +102,7 @@ class HumanitarianVerificationService:
                         breaker.record_success()
                         return {
                             "provider": provider_name,
+                            "served_by": response.served_by,
                             "model": model,
                             "prompt_variant": prompt_variant,
                             "verification": parsed,
@@ -110,8 +116,9 @@ class HumanitarianVerificationService:
                             "Humanitarian verification attempt failed: %s", err
                         )
 
-            raise RuntimeError(
-                "All humanitarian verification attempts failed: " + " | ".join(errors)
+            raise AllProvidersExhaustedError(
+                attempted_providers=attempted,
+                per_provider_errors=errors,
             )
         finally:
             latency = time.time() - start_time

--- a/app/ai-service/services/providers.py
+++ b/app/ai-service/services/providers.py
@@ -42,6 +42,13 @@ class LLMResponse:
     provider: str
     model: str
     latency_ms: int = 0
+    # Which provider actually served this request.  Always the same as
+    # ``provider``; exposed under a dedicated name so callers can reference
+    # it without knowing the internal field layout.
+    served_by: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.served_by = self.provider
 
 
 @dataclass
@@ -439,15 +446,44 @@ class ProviderRegistry:
         return available
 
     def resolve_llm(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:
-        """Return (name, provider) pairs in attempt order for LLM chat."""
+        """Return (name, provider) pairs in attempt order for LLM chat.
+
+        Resolution rules (applied in order):
+        1. ``preference == "test"`` — test provider only (fast path for fixtures).
+        2. ``preference`` names a specific provider — that provider first, then
+           the rest in their natural order.
+        3. ``preference == "auto"`` — use ``settings.llm_provider_order`` when it
+           is non-empty; otherwise fall back to the implicit code order returned
+           by :meth:`available_llm_providers`.
+
+        Providers that are not in :meth:`available_llm_providers` (because no API
+        key is configured) are silently dropped from the result.
+        """
         available = self.available_llm_providers()
         pref = (preference or "auto").lower()
+
         if pref == "test" and "test" in available:
             return [("test", self.get("test"))]
-        if pref in available:
+
+        if pref not in ("auto",) and pref in available:
+            # Explicit preference: requested provider first, then the rest.
             ordered = [pref] + [p for p in available if p != pref]
+        elif pref == "auto" and settings.llm_provider_order:
+            # Configured order: only include entries that are actually available.
+            seen: set = set()
+            ordered = []
+            for name in settings.llm_provider_order:
+                if name in available and name not in seen:
+                    ordered.append(name)
+                    seen.add(name)
+            # Append any available provider not mentioned in the configured list.
+            for name in available:
+                if name not in seen:
+                    ordered.append(name)
+                    seen.add(name)
         else:
             ordered = available
+
         return [(name, self.get(name)) for name in ordered]
 
     def resolve_ocr(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:

--- a/app/ai-service/tests/test_circuit_breaker.py
+++ b/app/ai-service/tests/test_circuit_breaker.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 from services.circuit_breaker import CircuitBreaker
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.providers import ProviderRegistry, LLMResponse, ModelProvider
-from exceptions import AIServiceError
+from exceptions import AIServiceError, AllProvidersExhaustedError
 from config import settings
 
 
@@ -130,7 +130,7 @@ class TestHumanitarianVerificationServiceCircuitBreaker:
             self.service, "_get_model_for_provider", lambda p: "test-model"
         )
 
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
             self.service.verify_claim(
                 aid_claim="Food aid reached target demographic.",
                 supporting_evidence=[],

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -1,6 +1,7 @@
 import pytest
 
 from config import settings
+from exceptions import AllProvidersExhaustedError
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.providers import (
     ProviderRegistry,
@@ -104,12 +105,15 @@ class TestHumanitarianVerificationService:
         mock_registry.resolve_llm.return_value = []
         monkeypatch.setattr(self.service, "registry", mock_registry)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
             self.service.verify_claim(
                 aid_claim="Food distribution completed.",
                 supporting_evidence=[],
                 context_factors={},
             )
+
+        assert exc_info.value.code == "ALL_PROVIDERS_EXHAUSTED"
+        assert exc_info.value.attempted_providers == []
 
     def test_get_model_version_resolves_provider_and_model(self, monkeypatch):
         mock_registry = MagicMock(spec=ProviderRegistry)

--- a/app/ai-service/tests/test_provider_fallback.py
+++ b/app/ai-service/tests/test_provider_fallback.py
@@ -1,0 +1,411 @@
+"""Tests for explicit, configurable provider fallback order (issue #982).
+
+Acceptance criteria verified here:
+  1. Fallback order is defined in configuration and validated at startup.
+  2. The provider that actually served a request is recorded on the result.
+  3. Providers with an open circuit are skipped rather than retried.
+  4. Exhausting all providers yields AllProvidersExhaustedError.
+  5. Tests cover ordering, circuit-skip, and exhaustion.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from config import Settings, ConfigurationError
+from exceptions import AIServiceError, AllProvidersExhaustedError
+from services.providers import LLMResponse, ModelProvider, ProviderRegistry
+from services.humanitarian_verification import HumanitarianVerificationService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_llm_response(provider: str) -> LLMResponse:
+    return LLMResponse(
+        content='{"verdict":"credible","confidence":0.9,"summary":"ok"}',
+        provider=provider,
+        model="test-model",
+    )
+
+
+def _make_failing_provider(name: str) -> MagicMock:
+    mock = MagicMock(spec=ModelProvider)
+    mock.name = name
+    mock.llm_chat.side_effect = AIServiceError(
+        message=f"{name} unavailable", code="AI_PROVIDER_ERROR"
+    )
+    return mock
+
+
+def _make_successful_provider(name: str) -> MagicMock:
+    mock = MagicMock(spec=ModelProvider)
+    mock.name = name
+    mock.llm_chat.return_value = _make_llm_response(name)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# 1. Configuration validation — LLM_PROVIDER_ORDER field
+# ---------------------------------------------------------------------------
+
+class TestLLMProviderOrderConfig:
+    """Startup validation of LLM_PROVIDER_ORDER."""
+
+    def test_valid_order_passes_validation(self):
+        s = Settings(
+            openai_api_key="key",
+            groq_api_key="key",
+            llm_provider_order=["groq", "openai"],
+            redis_url="redis://localhost:6379/0",
+        )
+        # Should not raise
+        s.validate_configuration()
+
+    def test_empty_order_passes_validation(self):
+        s = Settings(
+            openai_api_key="key",
+            redis_url="redis://localhost:6379/0",
+        )
+        s.validate_configuration()
+
+    def test_unknown_provider_fails_validation(self):
+        s = Settings(
+            openai_api_key="key",
+            llm_provider_order=["openai", "unknown_provider"],
+            redis_url="redis://localhost:6379/0",
+        )
+        with pytest.raises(ConfigurationError, match="LLM_PROVIDER_ORDER"):
+            s.validate_configuration()
+
+    def test_single_entry_valid_order(self):
+        s = Settings(
+            groq_api_key="key",
+            llm_provider_order=["groq"],
+            redis_url="redis://localhost:6379/0",
+        )
+        s.validate_configuration()
+
+    def test_comma_string_parsed_to_list(self):
+        """Env-var style comma-separated string is coerced to a list."""
+        # Simulate what pydantic-settings does when reading from env
+        s = Settings.model_validate(
+            {
+                "llm_provider_order": "groq,openai",
+                "redis_url": "redis://localhost:6379/0",
+            }
+        )
+        assert s.llm_provider_order == ["groq", "openai"]
+
+
+# ---------------------------------------------------------------------------
+# 2. served_by is populated on LLMResponse
+# ---------------------------------------------------------------------------
+
+class TestServedByField:
+    def test_served_by_equals_provider(self):
+        resp = LLMResponse(content="hi", provider="openai", model="gpt-4")
+        assert resp.served_by == "openai"
+
+    def test_served_by_equals_provider_for_groq(self):
+        resp = LLMResponse(content="hi", provider="groq", model="llama")
+        assert resp.served_by == "groq"
+
+    def test_served_by_present_in_verify_claim_result(self, monkeypatch):
+        service = HumanitarianVerificationService()
+
+        mock_provider = _make_successful_provider("groq")
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("groq", mock_provider)]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        result = service.verify_claim(
+            aid_claim="Food aid delivered",
+            supporting_evidence=[],
+            context_factors={},
+            provider_preference="groq",
+        )
+
+        assert "served_by" in result
+        assert result["served_by"] == "groq"
+        assert result["provider"] == "groq"
+
+
+# ---------------------------------------------------------------------------
+# 3. Configured order is respected under "auto"
+# ---------------------------------------------------------------------------
+
+class TestProviderOrderRespected:
+    """resolve_llm() must follow settings.llm_provider_order when pref==auto."""
+
+    def test_groq_first_when_configured(self):
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = ["groq", "openai"]
+
+            result = registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+
+        assert names[0] == "groq"
+        assert names[1] == "openai"
+
+    def test_openai_first_when_configured(self):
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = ["openai", "groq"]
+
+            result = registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+
+        assert names[0] == "openai"
+        assert names[1] == "groq"
+
+    def test_implicit_order_when_no_config(self):
+        """When llm_provider_order is empty, code-default order is used."""
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = []
+
+            result = registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+
+        assert set(names) == {"openai", "groq"}
+
+    def test_unavailable_provider_in_order_is_skipped(self):
+        """A provider listed in llm_provider_order but not configured is silently dropped."""
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = None   # openai has no key
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = ["openai", "groq"]  # openai listed first
+
+            result = registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+
+        # openai is dropped; groq remains
+        assert names == ["groq"]
+
+    def test_extra_available_providers_appended(self):
+        """Providers not in llm_provider_order but available are appended at the end."""
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = ["groq"]   # openai not listed
+
+            result = registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+
+        assert names[0] == "groq"
+        assert "openai" in names  # appended
+
+    def test_explicit_preference_overrides_configured_order(self):
+        """An explicit non-auto preference ignores llm_provider_order."""
+        registry = ProviderRegistry()
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.llm_provider_order = ["groq", "openai"]
+
+            result = registry.resolve_llm("openai")
+            names = [n for n, _ in result]
+
+        assert names[0] == "openai"
+
+    def test_verify_claim_respects_configured_order(self, monkeypatch):
+        """End-to-end: groq is called first when llm_provider_order=groq,openai."""
+        service = HumanitarianVerificationService()
+
+        call_order: list[str] = []
+
+        def groq_chat(*args, **kwargs):
+            call_order.append("groq")
+            return _make_llm_response("groq")
+
+        def openai_chat(*args, **kwargs):
+            call_order.append("openai")
+            return _make_llm_response("openai")
+
+        mock_groq = MagicMock(spec=ModelProvider)
+        mock_groq.llm_chat.side_effect = groq_chat
+        mock_openai = MagicMock(spec=ModelProvider)
+        mock_openai.llm_chat.side_effect = openai_chat
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        # Simulate resolve_llm returning groq first (as configured order)
+        mock_registry.resolve_llm.return_value = [
+            ("groq", mock_groq),
+            ("openai", mock_openai),
+        ]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        result = service.verify_claim(
+            aid_claim="Water aid delivered",
+            provider_preference="auto",
+        )
+
+        assert call_order[0] == "groq"
+        assert result["served_by"] == "groq"
+        mock_openai.llm_chat.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. Open circuit breakers are skipped
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreakerSkip:
+    """Providers with open circuits must be skipped, not retried."""
+
+    def test_open_circuit_provider_is_skipped(self, monkeypatch):
+        service = HumanitarianVerificationService()
+
+        mock_openai = _make_successful_provider("openai")
+        mock_groq = _make_successful_provider("groq")
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", mock_openai),
+            ("groq", mock_groq),
+        ]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        # Trip the openai circuit
+        openai_breaker = service._get_breaker("openai")
+        openai_breaker.failure_threshold = 1
+        openai_breaker.record_failure()
+        assert openai_breaker.state == "OPEN"
+
+        result = service.verify_claim(
+            aid_claim="Shelter kits distributed",
+            provider_preference="auto",
+        )
+
+        mock_openai.llm_chat.assert_not_called()
+        mock_groq.llm_chat.assert_called()
+        assert result["provider"] == "groq"
+        assert result["served_by"] == "groq"
+
+    def test_skipped_provider_in_attempted_list(self, monkeypatch):
+        """AllProvidersExhaustedError.attempted_providers marks skipped entries."""
+        service = HumanitarianVerificationService()
+
+        mock_openai = _make_failing_provider("openai")
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_openai)]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        # Trip the openai circuit by marking failures directly
+        openai_breaker = service._get_breaker("openai")
+        openai_breaker.failure_threshold = 1
+        openai_breaker.record_failure()
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            service.verify_claim(aid_claim="test")
+
+        attempted = exc_info.value.attempted_providers
+        assert any("(skipped)" in a for a in attempted), (
+            f"Expected a skipped entry in attempted_providers, got: {attempted}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. AllProvidersExhaustedError on total exhaustion
+# ---------------------------------------------------------------------------
+
+class TestAllProvidersExhausted:
+    """Exhausting all providers must raise AllProvidersExhaustedError."""
+
+    def test_all_providers_fail_raises_exhausted(self, monkeypatch):
+        service = HumanitarianVerificationService()
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", _make_failing_provider("openai")),
+            ("groq", _make_failing_provider("groq")),
+        ]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            service.verify_claim(
+                aid_claim="No providers work",
+                provider_preference="auto",
+            )
+
+        err = exc_info.value
+        assert err.code == "ALL_PROVIDERS_EXHAUSTED"
+        assert "openai" in err.attempted_providers
+        assert "groq" in err.attempted_providers
+        assert len(err.per_provider_errors) > 0
+
+    def test_no_providers_configured_raises_exhausted(self, monkeypatch):
+        service = HumanitarianVerificationService()
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = []  # nothing configured
+        monkeypatch.setattr(service, "registry", mock_registry)
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            service.verify_claim(aid_claim="test")
+
+        assert exc_info.value.code == "ALL_PROVIDERS_EXHAUSTED"
+        assert exc_info.value.attempted_providers == []
+
+    def test_exhausted_error_is_subclass_of_ai_service_error(self):
+        err = AllProvidersExhaustedError(
+            attempted_providers=["openai", "groq"],
+            per_provider_errors=["openai: timeout", "groq: 500"],
+        )
+        assert isinstance(err, AIServiceError)
+
+    def test_exhausted_error_message_contains_providers(self):
+        err = AllProvidersExhaustedError(
+            attempted_providers=["openai", "groq"],
+            per_provider_errors=["openai: timeout", "groq: 500"],
+        )
+        msg = str(err)
+        assert "openai" in msg
+        assert "groq" in msg
+
+    def test_all_open_circuits_raises_exhausted(self, monkeypatch):
+        service = HumanitarianVerificationService()
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", _make_successful_provider("openai")),
+            ("groq", _make_successful_provider("groq")),
+        ]
+        monkeypatch.setattr(service, "registry", mock_registry)
+        monkeypatch.setattr(service, "_get_model_for_provider", lambda p: "test-model")
+
+        # Trip both circuits
+        for name in ("openai", "groq"):
+            b = service._get_breaker(name)
+            b.failure_threshold = 1
+            b.record_failure()
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            service.verify_claim(aid_claim="all open circuits")
+
+        err = exc_info.value
+        assert err.code == "ALL_PROVIDERS_EXHAUSTED"
+        # Both entries should be in the attempted list, prefixed with "(skipped)"
+        assert all("(skipped)" in a for a in err.attempted_providers)

--- a/app/ai-service/tests/test_versioned_routes.py
+++ b/app/ai-service/tests/test_versioned_routes.py
@@ -51,12 +51,16 @@ def mock_healthy_resources():
 @pytest.fixture(scope="module")
 def client():
     """TestClient that does NOT follow redirects – lets us inspect 308s."""
+    # Reset shutdown flag in case a previous test module's TestClient lifespan
+    # set it to True on the shared app object.
+    app.state.is_shutting_down = False
     return TestClient(app, follow_redirects=False)
 
 
 @pytest.fixture(scope="module")
 def following_client():
     """TestClient that follows redirects transparently."""
+    app.state.is_shutting_down = False
     return TestClient(app, follow_redirects=True)
 
 


### PR DESCRIPTION
## Summary

Implements configurable LLM provider fallback order as requested in issue #982.

Operators can now express a preference such as cheapest-first or lowest-latency-first via a single environment variable — no source edits required.

## Changes

### Configuration (`config.py`)
- New `llm_provider_order: List[str]` field (env: `LLM_PROVIDER_ORDER`, comma-separated).
- Startup validation rejects unknown provider names so misconfiguration is caught at boot, not at runtime.

### Provider response (`services/providers.py`)
- `LLMResponse` gains a `served_by` field (alias of `provider`) so any caller can read which provider answered without knowing internal field names.
- `ProviderRegistry.resolve_llm()` now consults `settings.llm_provider_order` when `preference=="auto"`. Explicit preferences and test mode are unaffected.

### Error handling (`exceptions.py`)
- New `AllProvidersExhaustedError(AIServiceError)` with `code="ALL_PROVIDERS_EXHAUSTED"`, `attempted_providers` list (skipped entries prefixed `"(skipped) "`), and `per_provider_errors` list.

### Verification service (`services/humanitarian_verification.py`)
- Raises `AllProvidersExhaustedError` instead of bare `RuntimeError` on exhaustion.
- Result dict now includes `served_by` key alongside `provider`.

### Documentation (`.env.example`)
- Documents `LLM_PROVIDER_ORDER` with cheapest-first (`groq,openai`) and latency-tuned (`openai,groq`) examples.

## Tests

- New `tests/test_provider_fallback.py` — 22 tests covering all 5 acceptance criteria:
  1. Config validation (valid/invalid/empty order, comma-string coercion)
  2. `served_by` present on `LLMResponse` and on `verify_claim` result
  3. Configured order is respected under `auto`
  4. Open circuit breakers are skipped (not retried)
  5. `AllProvidersExhaustedError` raised on total exhaustion
- Updated `test_humanitarian_verification.py` and `test_circuit_breaker.py` to assert `AllProvidersExhaustedError` instead of `RuntimeError`.
- All 398 non-pre-existing tests pass.

## Acceptance criteria

- [x] Fallback order is defined in configuration and validated at startup
- [x] The provider that actually served a request is recorded on the result
- [x] Providers with an open circuit are skipped rather than retried
- [x] Exhausting all providers yields a distinct, documented error
- [x] Tests cover ordering, skipping, and exhaustion

Closes #982