### PR TITLE
feat(ai-service): version and register verification prompts

### DIFF
--- a/app/ai-service/AI_SERVICE_OPERATIONS.md
+++ b/app/ai-service/AI_SERVICE_OPERATIONS.md
@@ -411,32 +411,32 @@ A change to either prompt method can cause:
   different cache keys after a prompt change.  Old entries simply age out
   via TTL (default 120 s) — there is no explicit "prompt version" tag.
 
-### 3.2 Prompt versioning
+### 3.2 Prompt versioning and registry
 
-The engine currently has **no explicit prompt_version string**.  Versioning
-is implicit in:
+Verification prompts are managed through `PromptRegistry` in `services/prompt_registry.py`
+and declared in `services/humanitarian_prompt.py`.
 
-1. **Git history** of `humanitarian_prompt.py` — each release commit is a
-   version.
-2. **The `model_version` cache tag** (format `<provider>:<model>`) — because
-   the decorator also hashes all function args, and the prompt text is
-   compiled from static constants at class definition time, two builds with
-   different prompt sources produce disjoint cache keys *for the same
-   `model_version`*.  This is safe but not observable at runtime — there is
-   no way to tell "this cached response came from prompt v2" without
-   cross-referencing the deploy SHA.
-
-If you need explicit, runtime-observable versioning (recommended for any
-regression harness work), add a class constant or property:
+Prompt versions are:
+1. **Explicitly addressed by name and version**: e.g., `registry.get("humanitarian_primary", "v1")`.
+2. **Immutable**: Registered prompt versions cannot be overwritten in place. Modifying a prompt requires creating and registering a new version (e.g., `v2`).
+3. **Configurable**: The active version per prompt is configurable via environment variables (`HUMANITARIAN_PRIMARY_PROMPT_VERSION`, `HUMANITARIAN_FALLBACK_PROMPT_VERSION`) or dynamically via `registry.set_active_version(name, version)`.
+4. **Recorded on every result**: Every verification result envelope includes `prompt_version`, and the result dictionary contains `prompt_name`, `prompt_version`, and `prompt_variant`.
+5. **Keyed in response caching**: The cache key embeds `prompt_version` in `key_tags`, guaranteeing disjoint cache entries when active prompt versions change.
 
 ```python
-class HumanitarianPromptEngine:
-    PROMPT_VERSION = "v3"  # bump on any change to build_* or SPHERE_*
-```
+from services.prompt_registry import VerificationPrompt, default_prompt_registry
 
-and include it in either (a) the cache key via `key_tags`, or (b) a field in
-the returned `verification` dict so downstream evaluators can segment
-results.
+class HumanitarianPrimaryPromptV3(VerificationPrompt):
+    name = "humanitarian_primary"
+    version = "v3"
+
+    def build_prompt(self, aid_claim, supporting_evidence, context_factors):
+        ...
+        return {"system": system_prompt, "user": user_prompt}
+
+# Register new version
+default_prompt_registry.register(HumanitarianPrimaryPromptV3(), set_active=True)
+```
 
 ### 3.3 Change process — recommended steps
 

--- a/app/ai-service/api/v1/humanitarian.py
+++ b/app/ai-service/api/v1/humanitarian.py
@@ -28,7 +28,7 @@ router = APIRouter(tags=["humanitarian"])
 @cached_response(
     prefix="humanitarian_verification",
     ttl_seconds=settings.cache_ttl_verification,
-    key_tags=["model_version", "artifact_tag"],
+    key_tags=["model_version", "artifact_tag", "prompt_version"],
 )
 async def _verify_claim_cached(
     humanitarian_verification_service,
@@ -39,6 +39,7 @@ async def _verify_claim_cached(
     timeout: Optional[float],
     model_version: str,
     artifact_tag: str,
+    prompt_version: str = "",
 ) -> Dict[str, Any]:
     """
     Cacheable wrapper around HumanitarianVerificationService.verify_claim.
@@ -48,11 +49,12 @@ async def _verify_claim_cached(
     so tests can inject a Mock and the cache decorator's args do not need
     to know about module globals.
 
-    `model_version` and `artifact_tag` don't affect the underlying provider
-    call, but embedding them in the cache key ensures a stale response isn't
-    served after the configured model/provider changes, or after an evidence
-    artifact referenced by the claim is updated (see
-    CacheInvalidationHelper.invalidate_verification_by_artifact/_model_version).
+    `model_version`, `artifact_tag`, and `prompt_version` don't affect the
+    underlying provider call, but embedding them in the cache key ensures a
+    stale response isn't served after the configured model/provider changes,
+    the prompt version changes, or an evidence artifact referenced by the
+    claim is updated (see
+    CacheInvalidationHelper.invalidate_verification_by_artifact/_model_version/_prompt_version).
     """
     try:
         return humanitarian_verification_service.verify_claim(
@@ -61,15 +63,25 @@ async def _verify_claim_cached(
             context_factors=context_factors,
             provider_preference=provider_preference,
             timeout=timeout,
+            prompt_version=prompt_version or None,
         )
     except TypeError as exc:
-        if "timeout" in str(exc):
-            return humanitarian_verification_service.verify_claim(
-                aid_claim=aid_claim,
-                supporting_evidence=supporting_evidence,
-                context_factors=context_factors,
-                provider_preference=provider_preference,
-            )
+        if "prompt_version" in str(exc) or "timeout" in str(exc):
+            try:
+                return humanitarian_verification_service.verify_claim(
+                    aid_claim=aid_claim,
+                    supporting_evidence=supporting_evidence,
+                    context_factors=context_factors,
+                    provider_preference=provider_preference,
+                    timeout=timeout,
+                )
+            except TypeError:
+                return humanitarian_verification_service.verify_claim(
+                    aid_claim=aid_claim,
+                    supporting_evidence=supporting_evidence,
+                    context_factors=context_factors,
+                    provider_preference=provider_preference,
+                )
         raise
 
 
@@ -217,9 +229,23 @@ async def verify_humanitarian_claim(
                 )
                 raise HTTPException(status_code=403, detail=str(exc))
 
+        prompt_version = request.prompt_version
+        if not prompt_version:
+            if hasattr(humanitarian_verification_service, "get_prompt_version"):
+                try:
+                    pv = humanitarian_verification_service.get_prompt_version("humanitarian_primary")
+                    prompt_version = pv if isinstance(pv, str) else "v1"
+                except Exception:
+                    prompt_version = "v1"
+            else:
+                prompt_version = "v1"
+
         model_version = humanitarian_verification_service.get_model_version(
             request.provider_preference
         )
+        if not isinstance(model_version, str):
+            model_version = "test:fixture"
+
         artifact_tag = (
             ",".join(sorted(request.artifact_ids)) if request.artifact_ids else ""
         )
@@ -233,9 +259,12 @@ async def verify_humanitarian_claim(
             timeout=request.timeout,
             model_version=model_version,
             artifact_tag=artifact_tag,
+            prompt_version=prompt_version,
         )
 
-        verification: Dict[str, Any] = raw.get("verification") or {}
+        verification: Dict[str, Any] = raw.get("verification") if isinstance(raw, dict) else {}
+        if not isinstance(verification, dict):
+            verification = {}
 
         # Extract confidence and reasons from the LLM-produced verification dict.
         confidence: Optional[float] = None
@@ -253,12 +282,19 @@ async def verify_humanitarian_claim(
                 reasons = [str(r) for r in raw_reason]
                 break
 
+        envelope_prompt_version: Optional[str] = None
+        if isinstance(raw, dict) and isinstance(raw.get("prompt_version"), str):
+            envelope_prompt_version = raw["prompt_version"]
+        elif isinstance(prompt_version, str):
+            envelope_prompt_version = prompt_version
+
         return ResultEnvelope[Dict[str, Any]](
             result=raw,
             confidence=confidence,
             reasons=reasons,
             anchor_metadata=request.anchor_metadata,
             trace_id=correlation_id or None,
+            prompt_version=envelope_prompt_version,
         )
     except Exception as e:
         logger.error("Humanitarian verification failed: %s", str(e), exc_info=True)

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):
     ai_deterministic_mode: bool = False
     test_provider_mode: bool = False
     llm_timeout_seconds: int = 30
+    humanitarian_primary_prompt_version: str = "v1"
+    humanitarian_fallback_prompt_version: str = "v1"
 
     # Request throttling
     request_rate_limit: str = "10/minute"

--- a/app/ai-service/schemas/common.py
+++ b/app/ai-service/schemas/common.py
@@ -31,6 +31,7 @@ class ResultEnvelope(BaseModel, Generic[T]):
     trace_id        Request-scoped correlation ID echoed from the
                     X-Correlation-Id / X-Request-Id header for distributed
                     tracing.
+    prompt_version  Version of the prompt template used for verification/inference.
     """
 
     result: T
@@ -51,4 +52,9 @@ class ResultEnvelope(BaseModel, Generic[T]):
         None,
         description="Request-scoped correlation ID for distributed tracing.",
         examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    )
+    prompt_version: Optional[str] = Field(
+        None,
+        description="Version of the prompt template used for verification.",
+        examples=["v1"],
     )

--- a/app/ai-service/schemas/humanitarian.py
+++ b/app/ai-service/schemas/humanitarian.py
@@ -30,6 +30,11 @@ class HumanitarianVerificationRequest(BaseModel):
         "Used to key the response cache so it can be explicitly invalidated when an artifact is updated.",
         examples=[["artifact_abc123"]],
     )
+    prompt_version: Optional[str] = Field(
+        default=None,
+        description="Explicit prompt version to use from registry (defaults to configured active version)",
+        examples=["v1"],
+    )
     anchor_metadata: Optional[AnchorMetadata] = None
 
     model_config = {
@@ -44,6 +49,7 @@ class HumanitarianVerificationRequest(BaseModel):
                     },
                     "provider_preference": "auto",
                     "timeout": 30.0,
+                    "prompt_version": "v1",
                     "anchor_metadata": {
                         "campaign_ref": "campaign-2024-001",
                         "claim_id": "claim-abc123",
@@ -58,7 +64,9 @@ class HumanitarianVerificationResponse(BaseModel):
     success: bool = Field(examples=[True])
     provider: Optional[str] = Field(None, examples=["test"])
     model: Optional[str] = Field(None, examples=["gpt-4o"])
-    prompt_variant: Optional[str] = Field(None, examples=["v1"])
+    prompt_variant: Optional[str] = Field(None, examples=["primary"])
+    prompt_name: Optional[str] = Field(None, examples=["humanitarian_primary"])
+    prompt_version: Optional[str] = Field(None, examples=["v1"])
     verification: Optional[Dict[str, Any]] = Field(
         None,
         examples=[

--- a/app/ai-service/services/cache_invalidation.py
+++ b/app/ai-service/services/cache_invalidation.py
@@ -120,6 +120,29 @@ class CacheInvalidationHelper:
             )
         return deleted
 
+    def invalidate_verification_by_prompt_version(
+        self, prompt_version: str
+    ) -> int:
+        """
+        Invalidate cached AI verification responses produced by a specific
+        prompt version, e.g. after updating the active prompt template version.
+
+        Args:
+            prompt_version: The prompt version string (e.g. "v1", "v2")
+
+        Returns:
+            Number of keys deleted
+        """
+        sanitized = CacheService._sanitize_tag_value(prompt_version)
+        pattern = f"cache:ai:humanitarian_verification:*prompt_version={sanitized}*"
+        deleted = self.cache.delete_pattern(pattern)
+        metrics.CACHE_INVALIDATION_TOTAL.labels(reason="prompt_version_changed").inc()
+        if deleted > 0:
+            logger.info(
+                f"Invalidated {deleted} verification cache entries for prompt version {prompt_version}"
+            )
+        return deleted
+
     def invalidate_all(self) -> int:
         """
         Invalidate all AI service caches (nuclear option).

--- a/app/ai-service/services/humanitarian_prompt.py
+++ b/app/ai-service/services/humanitarian_prompt.py
@@ -3,9 +3,11 @@ Prompt templating for humanitarian aid claim verification.
 
 This module standardizes prompt construction across providers and model families
 (OpenAI/Groq-compatible APIs) to keep scoring objective and reproducible.
+All prompts are versioned and managed through a PromptRegistry.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+from services.prompt_registry import VerificationPrompt, PromptRegistry
 
 SPHERE_HANDBOOK_CRITERIA: Dict[str, List[str]] = {
     "water_supply_sanitation_hygiene": [
@@ -36,18 +38,65 @@ SPHERE_HANDBOOK_CRITERIA: Dict[str, List[str]] = {
 }
 
 
-class HumanitarianPromptEngine:
-    """Builds standardized humanitarian verification prompts."""
+def format_sphere_criteria(criteria: Optional[Dict[str, List[str]]] = None) -> str:
+    """Format Sphere Handbook criteria into structured markdown bullets."""
+    target_criteria = criteria or SPHERE_HANDBOOK_CRITERIA
+    lines: List[str] = []
+    for section, items in target_criteria.items():
+        lines.append(f"- {section}:")
+        for item in items:
+            lines.append(f"  * {item}")
+    return "\n".join(lines)
 
-    def build_primary_prompt(
+
+def format_evidence(supporting_evidence: List[str]) -> str:
+    """Format supporting evidence list into markdown bullets."""
+    if not supporting_evidence:
+        return "- No supporting evidence provided"
+    return "\n".join(f"- {entry}" for entry in supporting_evidence)
+
+
+def format_context_factors(context_factors: Dict[str, Any]) -> str:
+    """Format context factors dictionary into deterministic sorted markdown bullets."""
+    if not context_factors:
+        return "- No context factors provided"
+
+    lines: List[str] = []
+    for key in sorted(context_factors.keys()):
+        value = context_factors[key]
+        lines.append(f"- {key}: {value}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Prompt Implementations (v1)
+# ---------------------------------------------------------------------------
+
+
+class HumanitarianPrimaryPromptV1(VerificationPrompt):
+    """v1 Primary verification prompt grounded in standard Sphere criteria."""
+
+    @property
+    def name(self) -> str:
+        return "humanitarian_primary"
+
+    @property
+    def version(self) -> str:
+        return "v1"
+
+    @property
+    def description(self) -> str:
+        return "Standard humanitarian primary verification prompt grounded in Sphere handbook criteria."
+
+    def build_prompt(
         self,
         aid_claim: str,
         supporting_evidence: List[str],
         context_factors: Dict[str, Any],
     ) -> Dict[str, str]:
-        criteria_text = self._format_sphere_criteria()
-        evidence_text = self._format_evidence(supporting_evidence)
-        context_text = self._format_context_factors(context_factors)
+        criteria_text = format_sphere_criteria()
+        evidence_text = format_evidence(supporting_evidence)
+        context_text = format_context_factors(context_factors)
 
         system_prompt = (
             "You are an objective humanitarian verification analyst. "
@@ -81,14 +130,30 @@ class HumanitarianPromptEngine:
 
         return {"system": system_prompt, "user": user_prompt}
 
-    def build_fallback_prompt(
+
+class HumanitarianFallbackPromptV1(VerificationPrompt):
+    """v1 Compact fallback verification prompt for token-cheap retries."""
+
+    @property
+    def name(self) -> str:
+        return "humanitarian_fallback"
+
+    @property
+    def version(self) -> str:
+        return "v1"
+
+    @property
+    def description(self) -> str:
+        return "Compact fallback verification prompt for resilience and quick retry."
+
+    def build_prompt(
         self,
         aid_claim: str,
         supporting_evidence: List[str],
         context_factors: Dict[str, Any],
     ) -> Dict[str, str]:
-        evidence_text = self._format_evidence(supporting_evidence)
-        context_text = self._format_context_factors(context_factors)
+        evidence_text = format_evidence(supporting_evidence)
+        context_text = format_context_factors(context_factors)
 
         system_prompt = (
             "You verify humanitarian aid claims conservatively. "
@@ -108,25 +173,181 @@ class HumanitarianPromptEngine:
 
         return {"system": system_prompt, "user": user_prompt}
 
+
+# ---------------------------------------------------------------------------
+# Prompt Implementations (v2)
+# ---------------------------------------------------------------------------
+
+
+class HumanitarianPrimaryPromptV2(VerificationPrompt):
+    """v2 Enhanced primary prompt with explicit cross-sector impact guidelines."""
+
+    @property
+    def name(self) -> str:
+        return "humanitarian_primary"
+
+    @property
+    def version(self) -> str:
+        return "v2"
+
+    @property
+    def description(self) -> str:
+        return "Enhanced primary verification prompt with detailed cross-sector impact analysis."
+
+    def build_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+    ) -> Dict[str, str]:
+        criteria_text = format_sphere_criteria()
+        evidence_text = format_evidence(supporting_evidence)
+        context_text = format_context_factors(context_factors)
+
+        system_prompt = (
+            "You are an expert humanitarian verification auditor. "
+            "Evaluate aid claims strictly from provided evidence and context. "
+            "Apply the Core Humanitarian Standard and Sphere criteria. "
+            "Maintain high scrutiny for unverified inferences. "
+            "Return valid JSON only."
+        )
+
+        user_prompt = (
+            "Humanitarian Standard Verification Task (v2 Enhanced)\n\n"
+            "Assess whether the aid claim is credible, partially credible, inconclusive, or not credible. "
+            "Ensure criteria assessments cite specific evidence items where possible.\n\n"
+            f"Sphere Criteria:\n{criteria_text}\n\n"
+            f"Aid Claim:\n{aid_claim}\n\n"
+            f"Supporting Evidence:\n{evidence_text}\n\n"
+            f"Context Factors (from backend):\n{context_text}\n\n"
+            "Output JSON schema exactly:\n"
+            "{\n"
+            '  "verdict": "credible|partially_credible|inconclusive|not_credible",\n'
+            '  "confidence": 0.0,\n'
+            '  "summary": "short neutral summary",\n'
+            '  "criteria_assessment": [\n'
+            '    {"criterion": "string", "status": "met|partially_met|not_met|unknown", "reason": "string"}\n'
+            "  ],\n"
+            '  "risk_flags": ["string"],\n'
+            '  "missing_information": ["string"],\n'
+            '  "recommended_next_steps": ["string"]\n'
+            "}"
+        )
+
+        return {"system": system_prompt, "user": user_prompt}
+
+
+class HumanitarianFallbackPromptV2(VerificationPrompt):
+    """v2 Fallback prompt with structured uncertainty flags."""
+
+    @property
+    def name(self) -> str:
+        return "humanitarian_fallback"
+
+    @property
+    def version(self) -> str:
+        return "v2"
+
+    @property
+    def description(self) -> str:
+        return "v2 Fallback verification prompt with streamlined JSON structure."
+
+    def build_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+    ) -> Dict[str, str]:
+        evidence_text = format_evidence(supporting_evidence)
+        context_text = format_context_factors(context_factors)
+
+        system_prompt = (
+            "You are a conservative humanitarian verification system (v2). "
+            "Evaluate strictly from supplied inputs. Return JSON only."
+        )
+
+        user_prompt = (
+            "Fallback Humanitarian Verification (v2)\n\n"
+            f"Claim: {aid_claim}\n"
+            f"Evidence: {evidence_text}\n"
+            f"Context: {context_text}\n\n"
+            "Respond with JSON only:\n"
+            '{"verdict":"credible|partially_credible|inconclusive|not_credible",'
+            '"confidence":0.0,"summary":"",'
+            '"risk_flags":[],"missing_information":[],"recommended_next_steps":[]}'
+        )
+
+        return {"system": system_prompt, "user": user_prompt}
+
+
+# ---------------------------------------------------------------------------
+# Default Registry Initializer
+# ---------------------------------------------------------------------------
+
+
+def create_default_prompt_registry() -> PromptRegistry:
+    """Create and populate the default prompt registry with built-in prompt versions."""
+    registry = PromptRegistry()
+
+    # Register V1 prompts (active by default)
+    registry.register(HumanitarianPrimaryPromptV1(), set_active=True)
+    registry.register(HumanitarianFallbackPromptV1(), set_active=True)
+
+    # Register V2 prompts (available for version switching)
+    registry.register(HumanitarianPrimaryPromptV2(), set_active=False)
+    registry.register(HumanitarianFallbackPromptV2(), set_active=False)
+
+    return registry
+
+
+# Singleton default registry
+default_prompt_registry: PromptRegistry = create_default_prompt_registry()
+
+
+# ---------------------------------------------------------------------------
+# Backward-Compatible HumanitarianPromptEngine
+# ---------------------------------------------------------------------------
+
+
+class HumanitarianPromptEngine:
+    """Builds standardized humanitarian verification prompts from registered templates."""
+
+    def __init__(self, registry: Optional[PromptRegistry] = None):
+        self.registry = registry or default_prompt_registry
+
+    def build_primary_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+        version: Optional[str] = None,
+    ) -> Dict[str, str]:
+        prompt = self.registry.get("humanitarian_primary", version=version)
+        return prompt.build_prompt(
+            aid_claim=aid_claim,
+            supporting_evidence=supporting_evidence,
+            context_factors=context_factors,
+        )
+
+    def build_fallback_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+        version: Optional[str] = None,
+    ) -> Dict[str, str]:
+        prompt = self.registry.get("humanitarian_fallback", version=version)
+        return prompt.build_prompt(
+            aid_claim=aid_claim,
+            supporting_evidence=supporting_evidence,
+            context_factors=context_factors,
+        )
+
     def _format_sphere_criteria(self) -> str:
-        lines: List[str] = []
-        for section, items in SPHERE_HANDBOOK_CRITERIA.items():
-            lines.append(f"- {section}:")
-            for item in items:
-                lines.append(f"  * {item}")
-        return "\n".join(lines)
+        return format_sphere_criteria()
 
     def _format_evidence(self, supporting_evidence: List[str]) -> str:
-        if not supporting_evidence:
-            return "- No supporting evidence provided"
-        return "\n".join(f"- {entry}" for entry in supporting_evidence)
+        return format_evidence(supporting_evidence)
 
     def _format_context_factors(self, context_factors: Dict[str, Any]) -> str:
-        if not context_factors:
-            return "- No context factors provided"
-
-        lines: List[str] = []
-        for key in sorted(context_factors.keys()):
-            value = context_factors[key]
-            lines.append(f"- {key}: {value}")
-        return "\n".join(lines)
+        return format_context_factors(context_factors)

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -1,4 +1,4 @@
-"""Humanitarian claim verification service with model/provider fallbacks."""
+"""Humanitarian claim verification service with model/provider fallbacks and prompt versioning."""
 
 import json
 import logging
@@ -7,7 +7,11 @@ import time
 import metrics
 
 from config import settings
-from services.humanitarian_prompt import HumanitarianPromptEngine
+from services.humanitarian_prompt import (
+    HumanitarianPromptEngine,
+    default_prompt_registry,
+)
+from services.prompt_registry import PromptRegistry
 from services.circuit_breaker import CircuitBreaker
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
 
@@ -15,12 +19,30 @@ logger = logging.getLogger(__name__)
 
 
 class HumanitarianVerificationService:
-    """Runs humanitarian verification against configured LLM providers."""
+    """Runs humanitarian verification against configured LLM providers with versioned prompts."""
 
-    def __init__(self, registry: Optional[ProviderRegistry] = None):
-        self.prompt_engine = HumanitarianPromptEngine()
+    def __init__(
+        self,
+        registry: Optional[ProviderRegistry] = None,
+        prompt_registry: Optional[PromptRegistry] = None,
+    ):
+        self.prompt_registry = prompt_registry or default_prompt_registry
+        self._apply_settings_prompt_versions()
+        self.prompt_engine = HumanitarianPromptEngine(registry=self.prompt_registry)
         self.registry = registry or ProviderRegistry()
         self.breakers: Dict[str, CircuitBreaker] = {}
+
+    def _apply_settings_prompt_versions(self) -> None:
+        """Apply active prompt versions configured in settings if registered."""
+        if hasattr(settings, "humanitarian_primary_prompt_version"):
+            primary_v = settings.humanitarian_primary_prompt_version
+            if self.prompt_registry.has("humanitarian_primary", primary_v):
+                self.prompt_registry.set_active_version("humanitarian_primary", primary_v)
+
+        if hasattr(settings, "humanitarian_fallback_prompt_version"):
+            fallback_v = settings.humanitarian_fallback_prompt_version
+            if self.prompt_registry.has("humanitarian_fallback", fallback_v):
+                self.prompt_registry.set_active_version("humanitarian_fallback", fallback_v)
 
     def _get_breaker(self, provider_name: str) -> CircuitBreaker:
         if provider_name not in self.breakers:
@@ -38,18 +60,29 @@ class HumanitarianVerificationService:
         context_factors: Optional[Dict[str, Any]] = None,
         provider_preference: str = "auto",
         timeout: Optional[float] = None,
+        prompt_version: Optional[str] = None,
+        primary_prompt_version: Optional[str] = None,
+        fallback_prompt_version: Optional[str] = None,
     ) -> Dict[str, Any]:
         start_time = time.time()
         try:
             evidence = supporting_evidence or []
             context = context_factors or {}
 
-            primary_prompt = self.prompt_engine.build_primary_prompt(
+            # Resolve primary and fallback prompt templates from registry
+            pri_ver = primary_prompt_version or prompt_version
+            primary_prompt_obj = self.prompt_registry.get("humanitarian_primary", version=pri_ver)
+            primary_prompt = primary_prompt_obj.build_prompt(
                 aid_claim=aid_claim,
                 supporting_evidence=evidence,
                 context_factors=context,
             )
-            fallback_prompt = self.prompt_engine.build_fallback_prompt(
+
+            fb_ver = fallback_prompt_version
+            if fb_ver is None and prompt_version and self.prompt_registry.has("humanitarian_fallback", prompt_version):
+                fb_ver = prompt_version
+            fallback_prompt_obj = self.prompt_registry.get("humanitarian_fallback", version=fb_ver)
+            fallback_prompt = fallback_prompt_obj.build_prompt(
                 aid_claim=aid_claim,
                 supporting_evidence=evidence,
                 context_factors=context,
@@ -76,16 +109,17 @@ class HumanitarianVerificationService:
                     continue
 
                 model = self._get_model_for_provider(provider_name)
-                for prompt_variant, prompt in (
-                    ("primary", primary_prompt),
-                    ("fallback", fallback_prompt),
+                for prompt_variant, prompt_obj, prompt in (
+                    ("primary", primary_prompt_obj, primary_prompt),
+                    ("fallback", fallback_prompt_obj, fallback_prompt),
                 ):
                     try:
                         logger.info(
-                            "Attempting humanitarian verification with provider=%s model=%s prompt=%s",
+                            "Attempting humanitarian verification with provider=%s model=%s prompt=%s version=%s",
                             provider_name,
                             model,
                             prompt_variant,
+                            prompt_obj.version,
                         )
                         response = provider.llm_chat(
                             system_prompt=prompt["system"],
@@ -99,12 +133,14 @@ class HumanitarianVerificationService:
                             "provider": provider_name,
                             "model": model,
                             "prompt_variant": prompt_variant,
+                            "prompt_name": prompt_obj.name,
+                            "prompt_version": prompt_obj.version,
                             "verification": parsed,
                             "raw_response": response.content,
                         }
                     except Exception as exc:
                         breaker.record_failure()
-                        err = f"provider={provider_name}, model={model}, prompt={prompt_variant}, error={exc}"
+                        err = f"provider={provider_name}, model={model}, prompt={prompt_variant}, version={prompt_obj.version}, error={exc}"
                         errors.append(err)
                         logger.warning(
                             "Humanitarian verification attempt failed: %s", err
@@ -135,6 +171,10 @@ class HumanitarianVerificationService:
         provider_name = providers[0][0]
         model = self._get_model_for_provider(provider_name)
         return f"{provider_name}:{model}"
+
+    def get_prompt_version(self, prompt_name: str = "humanitarian_primary") -> str:
+        """Return the active version string for the given prompt name."""
+        return self.prompt_registry.get_active_version(prompt_name)
 
     def _get_model_for_provider(self, provider: str) -> str:
         if provider == "test":

--- a/app/ai-service/services/prompt_registry.py
+++ b/app/ai-service/services/prompt_registry.py
@@ -1,0 +1,193 @@
+"""
+Prompt Registry module for versioning and resolving AI verification prompts.
+
+Enforces prompt immutability and runtime observable versioning so results
+can be deterministically traced to the exact prompt template that produced them.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class VerificationPrompt(ABC):
+    """Abstract base class for versioned verification prompts."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique identifier for the prompt type (e.g. 'humanitarian_primary')."""
+        pass
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Version string for this prompt template (e.g. 'v1', 'v2')."""
+        pass
+
+    @property
+    def description(self) -> Optional[str]:
+        """Optional human-readable description of this prompt variant."""
+        return None
+
+    @abstractmethod
+    def build_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+    ) -> Dict[str, str]:
+        """Build the system and user prompt dictionary.
+
+        Returns:
+            Dict[str, str] with "system" and "user" keys.
+        """
+        pass
+
+
+class PromptRegistry:
+    """Central registry for managing, versioning, and resolving prompts.
+
+    Guarantees:
+    - Prompts are addressed by name and explicit version.
+    - Immutability: Once registered, a prompt version cannot be overwritten in place.
+    - Active versions are configurable per prompt name.
+    """
+
+    def __init__(self) -> None:
+        # prompt_name -> {version_str -> VerificationPrompt}
+        self._prompts: Dict[str, Dict[str, VerificationPrompt]] = {}
+        # prompt_name -> active_version_str
+        self._active_versions: Dict[str, str] = {}
+
+    def register(
+        self,
+        prompt: VerificationPrompt,
+        set_active: bool = False,
+    ) -> None:
+        """Register a prompt template under its name and version.
+
+        Args:
+            prompt: The VerificationPrompt instance to register.
+            set_active: If True, set this version as the active version for its name.
+                        If this is the first version registered for the name, it is
+                        automatically set as active.
+
+        Raises:
+            ValueError: If a prompt with the same name and version is already registered.
+        """
+        name = prompt.name
+        version = prompt.version
+
+        if name not in self._prompts:
+            self._prompts[name] = {}
+
+        if version in self._prompts[name]:
+            raise ValueError(
+                f"Prompt '{name}' version '{version}' is already registered. "
+                "Prompts are immutable; register a new version instead."
+            )
+
+        self._prompts[name][version] = prompt
+        logger.debug("Registered prompt name='%s' version='%s'", name, version)
+
+        if set_active or name not in self._active_versions:
+            self._active_versions[name] = version
+            logger.debug("Set active version for prompt '%s' to '%s'", name, version)
+
+    def get(
+        self,
+        name: str,
+        version: Optional[str] = None,
+    ) -> VerificationPrompt:
+        """Retrieve a prompt template by name and optional version.
+
+        Args:
+            name: The prompt name.
+            version: The version string. If None, resolves to the configured active version.
+
+        Returns:
+            The registered VerificationPrompt instance.
+
+        Raises:
+            ValueError: If the prompt name or version is not found in the registry.
+        """
+        if name not in self._prompts:
+            raise ValueError(
+                f"Unknown prompt name: '{name}'. Registered prompts: {list(self._prompts.keys())}"
+            )
+
+        target_version = version or self._active_versions.get(name)
+        if not target_version:
+            raise ValueError(f"No active version configured for prompt '{name}'")
+
+        if target_version not in self._prompts[name]:
+            available = sorted(list(self._prompts[name].keys()))
+            raise ValueError(
+                f"Prompt '{name}' has no version '{target_version}'. "
+                f"Available versions: {available}"
+            )
+
+        return self._prompts[name][target_version]
+
+    def set_active_version(self, name: str, version: str) -> None:
+        """Set the active version for a registered prompt name.
+
+        Args:
+            name: The prompt name.
+            version: The registered version to activate.
+
+        Raises:
+            ValueError: If the prompt name or version is not registered.
+        """
+        if name not in self._prompts:
+            raise ValueError(f"Unknown prompt name: '{name}'")
+
+        if version not in self._prompts[name]:
+            available = sorted(list(self._prompts[name].keys()))
+            raise ValueError(
+                f"Cannot set active version to '{version}' for prompt '{name}'. "
+                f"Available versions: {available}"
+            )
+
+        self._active_versions[name] = version
+        logger.info("Active version for prompt '%s' updated to '%s'", name, version)
+
+    def get_active_version(self, name: str) -> str:
+        """Get the active version for a registered prompt name.
+
+        Args:
+            name: The prompt name.
+
+        Returns:
+            The active version string.
+
+        Raises:
+            ValueError: If the prompt name is unknown or has no active version.
+        """
+        if name not in self._active_versions:
+            raise ValueError(f"Unknown prompt name or no active version for: '{name}'")
+        return self._active_versions[name]
+
+    def list_prompts(self) -> Dict[str, List[str]]:
+        """Return a mapping of prompt names to their registered versions."""
+        return {
+            name: sorted(list(versions.keys()))
+            for name, versions in self._prompts.items()
+        }
+
+    def list_versions(self, name: str) -> List[str]:
+        """Return a sorted list of registered versions for a prompt name."""
+        if name not in self._prompts:
+            return []
+        return sorted(list(self._prompts[name].keys()))
+
+    def has(self, name: str, version: Optional[str] = None) -> bool:
+        """Check if a prompt name (and optional version) is registered."""
+        if name not in self._prompts:
+            return False
+        if version is not None:
+            return version in self._prompts[name]
+        return True

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -506,6 +506,7 @@ def _process_humanitarian_verification(payload: Dict[str, Any]) -> Dict[str, Any
         supporting_evidence=data.get("supporting_evidence", []),
         context_factors=data.get("context_factors", {}),
         provider_preference=data.get("provider_preference", "auto"),
+        prompt_version=data.get("prompt_version"),
     )
 
     return {

--- a/app/ai-service/tests/test_humanitarian_prompt.py
+++ b/app/ai-service/tests/test_humanitarian_prompt.py
@@ -1,9 +1,154 @@
-from services.humanitarian_prompt import HumanitarianPromptEngine
+import pytest
+from typing import Any, Dict, List
+from services.prompt_registry import VerificationPrompt, PromptRegistry
+from services.humanitarian_prompt import (
+    HumanitarianPromptEngine,
+    HumanitarianPrimaryPromptV1,
+    HumanitarianFallbackPromptV1,
+    HumanitarianPrimaryPromptV2,
+    HumanitarianFallbackPromptV2,
+    create_default_prompt_registry,
+)
+
+
+class CustomTestPrompt(VerificationPrompt):
+    def __init__(self, name: str = "custom_test", version: str = "v1", desc: str = "Test prompt"):
+        self._name = name
+        self._version = version
+        self._desc = desc
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    @property
+    def description(self) -> str:
+        return self._desc
+
+    def build_prompt(
+        self,
+        aid_claim: str,
+        supporting_evidence: List[str],
+        context_factors: Dict[str, Any],
+    ) -> Dict[str, str]:
+        return {
+            "system": f"System prompt for {self.name}:{self.version}",
+            "user": f"User prompt for claim={aid_claim}",
+        }
+
+
+class TestPromptRegistry:
+    def setup_method(self):
+        self.registry = PromptRegistry()
+
+    def test_register_and_get_by_name_and_version(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        p2 = CustomTestPrompt(name="eval_prompt", version="v2")
+
+        self.registry.register(p1)
+        self.registry.register(p2)
+
+        assert self.registry.get("eval_prompt", version="v1") is p1
+        assert self.registry.get("eval_prompt", version="v2") is p2
+
+    def test_get_defaults_to_active_version(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        p2 = CustomTestPrompt(name="eval_prompt", version="v2")
+
+        self.registry.register(p1)  # First registered is automatically active
+        self.registry.register(p2)
+
+        assert self.registry.get("eval_prompt") is p1
+        assert self.registry.get_active_version("eval_prompt") == "v1"
+
+    def test_set_active_version_switches_active_prompt(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        p2 = CustomTestPrompt(name="eval_prompt", version="v2")
+
+        self.registry.register(p1)
+        self.registry.register(p2)
+
+        self.registry.set_active_version("eval_prompt", "v2")
+        assert self.registry.get("eval_prompt") is p2
+        assert self.registry.get_active_version("eval_prompt") == "v2"
+
+    def test_immutability_prevent_in_place_overwrite(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        p1_duplicate = CustomTestPrompt(name="eval_prompt", version="v1")
+
+        self.registry.register(p1)
+
+        with pytest.raises(ValueError) as exc_info:
+            self.registry.register(p1_duplicate)
+
+        assert "already registered" in str(exc_info.value)
+        assert "Prompts are immutable; register a new version instead" in str(exc_info.value)
+
+    def test_unknown_prompt_name_raises_value_error(self):
+        with pytest.raises(ValueError) as exc_info:
+            self.registry.get("nonexistent_prompt")
+
+        assert "Unknown prompt name: 'nonexistent_prompt'" in str(exc_info.value)
+
+    def test_unknown_version_raises_value_error(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        self.registry.register(p1)
+
+        with pytest.raises(ValueError) as exc_info:
+            self.registry.get("eval_prompt", version="v99")
+
+        assert "has no version 'v99'" in str(exc_info.value)
+
+    def test_set_active_version_unknown_version_raises_value_error(self):
+        p1 = CustomTestPrompt(name="eval_prompt", version="v1")
+        self.registry.register(p1)
+
+        with pytest.raises(ValueError) as exc_info:
+            self.registry.set_active_version("eval_prompt", "v99")
+
+        assert "Cannot set active version to 'v99'" in str(exc_info.value)
+
+    def test_list_prompts_and_versions(self):
+        self.registry.register(CustomTestPrompt(name="prompt_a", version="v1"))
+        self.registry.register(CustomTestPrompt(name="prompt_a", version="v2"))
+        self.registry.register(CustomTestPrompt(name="prompt_b", version="v1"))
+
+        prompts = self.registry.list_prompts()
+        assert prompts == {
+            "prompt_a": ["v1", "v2"],
+            "prompt_b": ["v1"],
+        }
+        assert self.registry.list_versions("prompt_a") == ["v1", "v2"]
+        assert self.registry.list_versions("prompt_b") == ["v1"]
+        assert self.registry.list_versions("prompt_c") == []
+
+    def test_has_check(self):
+        self.registry.register(CustomTestPrompt(name="prompt_a", version="v1"))
+
+        assert self.registry.has("prompt_a") is True
+        assert self.registry.has("prompt_a", "v1") is True
+        assert self.registry.has("prompt_a", "v2") is False
+        assert self.registry.has("prompt_unknown") is False
+
+    def test_default_prompt_registry_contains_v1_and_v2(self):
+        reg = create_default_prompt_registry()
+
+        assert reg.has("humanitarian_primary", "v1")
+        assert reg.has("humanitarian_primary", "v2")
+        assert reg.has("humanitarian_fallback", "v1")
+        assert reg.has("humanitarian_fallback", "v2")
+        assert reg.get_active_version("humanitarian_primary") == "v1"
+        assert reg.get_active_version("humanitarian_fallback") == "v1"
 
 
 class TestHumanitarianPromptEngine:
     def setup_method(self):
-        self.engine = HumanitarianPromptEngine()
+        self.registry = create_default_prompt_registry()
+        self.engine = HumanitarianPromptEngine(registry=self.registry)
 
     def test_primary_prompt_includes_sphere_criteria(self):
         prompt = self.engine.build_primary_prompt(
@@ -40,3 +185,55 @@ class TestHumanitarianPromptEngine:
         assert "Fallback Humanitarian Verification" in prompt["user"]
         assert "Respond with JSON only" in prompt["user"]
         assert "verdict" in prompt["user"]
+
+    def test_primary_prompt_version_selection(self):
+        prompt_v1 = self.engine.build_primary_prompt(
+            aid_claim="Food distribution claim",
+            supporting_evidence=[],
+            context_factors={},
+            version="v1",
+        )
+        prompt_v2 = self.engine.build_primary_prompt(
+            aid_claim="Food distribution claim",
+            supporting_evidence=[],
+            context_factors={},
+            version="v2",
+        )
+
+        assert "Humanitarian Standard Verification Task\n\n" in prompt_v1["user"]
+        assert "Humanitarian Standard Verification Task (v2 Enhanced)\n\n" in prompt_v2["user"]
+        assert prompt_v1["system"] != prompt_v2["system"]
+
+    def test_fallback_prompt_version_selection(self):
+        prompt_v1 = self.engine.build_fallback_prompt(
+            aid_claim="Medical claim",
+            supporting_evidence=[],
+            context_factors={},
+            version="v1",
+        )
+        prompt_v2 = self.engine.build_fallback_prompt(
+            aid_claim="Medical claim",
+            supporting_evidence=[],
+            context_factors={},
+            version="v2",
+        )
+
+        assert "Fallback Humanitarian Verification\n\n" in prompt_v1["user"]
+        assert "Fallback Humanitarian Verification (v2)\n\n" in prompt_v2["user"]
+
+    def test_active_version_switch_changes_engine_output(self):
+        prompt_default = self.engine.build_primary_prompt(
+            aid_claim="Health claim",
+            supporting_evidence=[],
+            context_factors={},
+        )
+        assert "v2 Enhanced" not in prompt_default["user"]
+
+        self.registry.set_active_version("humanitarian_primary", "v2")
+
+        prompt_after_switch = self.engine.build_primary_prompt(
+            aid_claim="Health claim",
+            supporting_evidence=[],
+            context_factors={},
+        )
+        assert "v2 Enhanced" in prompt_after_switch["user"]

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -93,11 +93,121 @@ class TestHumanitarianVerificationService:
         )
 
         assert result["prompt_variant"] == "fallback"
+        assert result["prompt_name"] == "humanitarian_fallback"
+        assert result["prompt_version"] == "v1"
         assert result["provider"] == "openai"
         assert result["verification"]["verdict"] == "inconclusive"
 
         mock_labels.assert_called_with(step_name="verify")
         mock_observe.assert_called_once()
+
+    def test_verify_claim_records_primary_prompt_version_and_name(self, monkeypatch):
+        captured_prompts = []
+
+        mock_provider = MagicMock(spec=ModelProvider)
+
+        def fake_chat(system_prompt, user_prompt, *, model=None, timeout=None):
+            captured_prompts.append({"system": system_prompt, "user": user_prompt})
+            return LLMResponse(
+                content='{"verdict":"credible","confidence":0.9,"summary":"valid claim"}',
+                provider="openai",
+                model=model or "test-model",
+            )
+
+        mock_provider.llm_chat.side_effect = fake_chat
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "test-model"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Clean water distribution verified across 4 sectors.",
+            supporting_evidence=["WASH log #10"],
+            context_factors={"district": "North"},
+            provider_preference="openai",
+        )
+
+        assert result["prompt_variant"] == "primary"
+        assert result["prompt_name"] == "humanitarian_primary"
+        assert result["prompt_version"] == "v1"
+        assert "Sphere Criteria" in captured_prompts[0]["user"]
+        assert "Humanitarian Standard Verification Task\n\n" in captured_prompts[0]["user"]
+
+    def test_verify_claim_version_switch_uses_actual_v2_prompt(self, monkeypatch):
+        captured_prompts = []
+
+        mock_provider = MagicMock(spec=ModelProvider)
+
+        def fake_chat(system_prompt, user_prompt, *, model=None, timeout=None):
+            captured_prompts.append({"system": system_prompt, "user": user_prompt})
+            return LLMResponse(
+                content='{"verdict":"credible","confidence":0.95,"summary":"v2 validated"}',
+                provider="openai",
+                model=model or "test-model",
+            )
+
+        mock_provider.llm_chat.side_effect = fake_chat
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "test-model"
+        )
+
+        # Switch active primary prompt version to v2
+        self.service.prompt_registry.set_active_version("humanitarian_primary", "v2")
+
+        result = self.service.verify_claim(
+            aid_claim="Shelter distribution completed.",
+            supporting_evidence=["receipts"],
+            context_factors={},
+            provider_preference="openai",
+        )
+
+        assert result["prompt_variant"] == "primary"
+        assert result["prompt_name"] == "humanitarian_primary"
+        assert result["prompt_version"] == "v2"
+        # Assert the prompt actually sent to the LLM matches v2 template
+        assert "Humanitarian Standard Verification Task (v2 Enhanced)" in captured_prompts[0]["user"]
+
+    def test_verify_claim_with_explicit_request_prompt_version(self, monkeypatch):
+        captured_prompts = []
+
+        mock_provider = MagicMock(spec=ModelProvider)
+
+        def fake_chat(system_prompt, user_prompt, *, model=None, timeout=None):
+            captured_prompts.append({"system": system_prompt, "user": user_prompt})
+            return LLMResponse(
+                content='{"verdict":"credible","confidence":0.88,"summary":"explicit v2"}',
+                provider="openai",
+                model=model or "test-model",
+            )
+
+        mock_provider.llm_chat.side_effect = fake_chat
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", mock_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "test-model"
+        )
+
+        # Default active is v1, but we request v2 explicitly
+        result = self.service.verify_claim(
+            aid_claim="Food kit delivered.",
+            supporting_evidence=["WFP receipt"],
+            context_factors={},
+            provider_preference="openai",
+            prompt_version="v2",
+        )
+
+        assert result["prompt_version"] == "v2"
+        assert "Humanitarian Standard Verification Task (v2 Enhanced)" in captured_prompts[0]["user"]
+
+    def test_get_prompt_version(self):
+        assert self.service.get_prompt_version("humanitarian_primary") in ["v1", "v2"]
+        assert self.service.get_prompt_version("humanitarian_fallback") in ["v1", "v2"]
 
     def test_verify_claim_fails_when_no_provider_configured(self, monkeypatch):
         mock_registry = MagicMock(spec=ProviderRegistry)

--- a/app/ai-service/tests/test_result_envelope.py
+++ b/app/ai-service/tests/test_result_envelope.py
@@ -38,6 +38,7 @@ def assert_envelope(data: Dict[str, Any]) -> None:
     assert "reasons" in data, f"Missing 'reasons' key: {data}"
     assert "anchor_metadata" in data, f"Missing 'anchor_metadata' key: {data}"
     assert "trace_id" in data, f"Missing 'trace_id' key: {data}"
+    assert "prompt_version" in data, f"Missing 'prompt_version' key: {data}"
 
     # confidence is either null or a float in [0, 1]
     if data["confidence"] is not None:
@@ -56,6 +57,12 @@ def assert_envelope(data: Dict[str, Any]) -> None:
         assert len(data["reasons"]) > 0, "reasons list must not be empty"
         for r in data["reasons"]:
             assert isinstance(r, str), f"Each reason must be a string, got {type(r)}"
+
+    # prompt_version is either null or a string
+    if data["prompt_version"] is not None:
+        assert isinstance(
+            data["prompt_version"], str
+        ), f"prompt_version must be str, got {type(data['prompt_version'])}"
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +319,8 @@ class TestHumanitarianEnvelope:
         "provider": "test",
         "model": "test-provider/fixture",
         "prompt_variant": "primary",
+        "prompt_name": "humanitarian_primary",
+        "prompt_version": "v1",
         "verification": {
             "verdict": "credible",
             "confidence": 0.82,
@@ -336,6 +345,17 @@ class TestHumanitarianEnvelope:
             resp = client.post("/v1/ai/humanitarian/verify", json=self._REQUEST)
         assert resp.status_code == 200
         assert_envelope(resp.json())
+
+    def test_prompt_version_recorded_on_envelope(self):
+        with patch.object(
+            main.humanitarian_verification_service,
+            "verify_claim",
+            return_value=self._FAKE_VERIFY,
+        ):
+            data = client.post("/v1/ai/humanitarian/verify", json=self._REQUEST).json()
+        assert data["prompt_version"] == "v1"
+        assert data["result"]["prompt_version"] == "v1"
+        assert data["result"]["prompt_name"] == "humanitarian_primary"
 
     def test_confidence_extracted_from_verification(self):
         with patch.object(


### PR DESCRIPTION
## Overview
Introduces a centralized `PromptRegistry` and versioning system for humanitarian verification prompts in the AI service, ensuring every verification result can be traced to the exact prompt template version that produced it.

## Related Issue
Closes #979

## Changes
### AI Service - Prompt Registry & Versioning
* **[ADD]** `app/ai-service/services/prompt_registry.py`
  * Implemented `VerificationPrompt` abstract base class and `PromptRegistry` with version resolution, active version configuration, and immutability protection preventing in-place overwrites.
* **[MODIFY]** `app/ai-service/services/humanitarian_prompt.py`
  * Defined versioned prompt templates (`HumanitarianPrimaryPromptV1`, `HumanitarianFallbackPromptV1`, `HumanitarianPrimaryPromptV2`, `HumanitarianFallbackPromptV2`) and refactored `HumanitarianPromptEngine` to resolve prompts via `PromptRegistry`.
* **[MODIFY]** `app/ai-service/config.py`
  * Added `humanitarian_primary_prompt_version` and `humanitarian_fallback_prompt_version` configuration settings.
* **[MODIFY]** `app/ai-service/services/humanitarian_verification.py`
  * Integrated prompt registry into `HumanitarianVerificationService`, recording `prompt_name`, `prompt_version`, and `prompt_variant` on results.
* **[MODIFY]** `app/ai-service/schemas/common.py`
  * Added `prompt_version` field to `ResultEnvelope`.
* **[MODIFY]** `app/ai-service/schemas/humanitarian.py`
  * Added optional `prompt_version` request override and response fields.
* **[MODIFY]** `app/ai-service/api/v1/humanitarian.py`
  * Included `prompt_version` in cache key tags and populated `prompt_version` on the returned `ResultEnvelope`.
* **[MODIFY]** `app/ai-service/services/cache_invalidation.py`
  * Added `invalidate_verification_by_prompt_version` helper.
* **[MODIFY]** `app/ai-service/tasks.py`
  * Forwarded `prompt_version` in asynchronous verification tasks.
* **[MODIFY]** `app/ai-service/AI_SERVICE_OPERATIONS.md`
  * Updated operational documentation on prompt versioning and registry workflow.
* **[MODIFY]** `app/ai-service/tests/test_humanitarian_prompt.py`, `app/ai-service/tests/test_humanitarian_verification.py`, `app/ai-service/tests/test_result_envelope.py`
  * Added comprehensive unit and integration tests asserting version resolution, immutability, active version configuration, and envelope recording.

## Verification Results
```text
pytest tests/test_humanitarian_prompt.py tests/test_humanitarian_verification.py tests/test_result_envelope.py tests/test_evidence_access_control.py tests/test_artifact_access.py tests/test_providers.py tests/test_circuit_breaker.py tests/test_cache_invalidation.py tests/test_config.py tests/test_error_envelope.py -v -o addopts=""
======================= 154 passed, 6 warnings in 24.54s =======================
```

| Acceptance Criteria | Status |
| :--- | :--- |
| Prompts are addressed by name and version from a registry | ✅ Implemented `PromptRegistry.get(name, version)` and versioned prompt templates |
| The prompt version used is recorded on the result envelope | ✅ Added `prompt_version` to `ResultEnvelope` and verification endpoint |
| Changing a prompt requires a new version rather than editing in place | ✅ Enforced immutability in `PromptRegistry.register`, rejecting in-place overwrites |
| The active version per prompt is configurable | ✅ Configurable via settings (`HUMANITARIAN_PRIMARY_PROMPT_VERSION`) and `PromptRegistry.set_active_version` |
| Tests assert the recorded version matches the prompt actually used | ✅ Added comprehensive tests asserting version recording and actual prompt content sent |