### PR TITLE
Implement queue-aware load shedding (#777)

### DIFF
--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -88,6 +88,9 @@ class Settings(BaseSettings):
     # Load shedding settings
     load_shed_memory_threshold_percent: float = 90.0
     load_shed_max_celery_queue_depth: int = 100
+    load_shed_queue_priority_multiplier: float = 0.5
+    load_shed_high_priority_queue_threshold: int = 150
+    load_shed_provider_degradation_threshold: float = 0.5
 
     # Dead-letter replay settings
     dead_letter_max_replay_attempts: int = 5

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -22,7 +22,17 @@ REQUEST_LATENCY = Histogram(
 REQUESTS_SHED_TOTAL = Counter(
     "requests_shed_total",
     "Requests rejected due to overload (load shedding)",
-    ["reason", "method", "endpoint"],
+    ["reason", "method", "endpoint", "priority", "provider_health"],
+)
+LOAD_SHED_QUEUE_DEPTH = Gauge(
+    "load_shed_queue_depth",
+    "Queue depth at time of load shedding",
+    ["priority"],
+)
+LOAD_SHED_DECISIONS = Counter(
+    "load_shed_decisions_total",
+    "Load shedding decisions made",
+    ["decision", "reason", "priority"],
 )
 CELERY_QUEUE_DEPTH = Gauge(
     "celery_queue_depth", "Pending tasks in the Celery default queue"

--- a/app/ai-service/services/load_shedder.py
+++ b/app/ai-service/services/load_shedder.py
@@ -26,16 +26,44 @@ REASON_MESSAGES = {
     "queue_full": "Service temporarily unavailable: task queue is at capacity",
     "broker_unavailable": "Service temporarily unavailable: task broker is unreachable",
     "provider_down": "Service temporarily unavailable: AI providers are currently down",
+    "provider_degraded": "Service temporarily unavailable: AI providers are degraded",
+    "queue_priority_exceeded": "Service temporarily unavailable: queue depth exceeds priority threshold",
 }
 
 
-def record_shed_request(reason: str, method: str, endpoint: str) -> None:
+def record_shed_request(
+    reason: str,
+    method: str,
+    endpoint: str,
+    queue_depth: Optional[int] = None,
+    priority: Optional[str] = None,
+    provider_health: Optional[str] = None,
+) -> None:
+    priority_label = priority or "normal"
+    provider_health_label = provider_health or "unknown"
+    
     metrics.REQUESTS_SHED_TOTAL.labels(
-        reason=reason, method=method, endpoint=endpoint
+        reason=reason, method=method, endpoint=endpoint, priority=priority_label, provider_health=provider_health_label
     ).inc()
     metrics.REQUEST_COUNT.labels(
         method=method, endpoint=endpoint, http_status=503
     ).inc()
+    metrics.LOAD_SHED_DECISIONS.labels(
+        decision="shed", reason=reason, priority=priority_label
+    ).inc()
+    
+    if queue_depth is not None:
+        metrics.LOAD_SHED_QUEUE_DEPTH.labels(priority=priority_label).set(queue_depth)
+    
+    logger.info(
+        "Load shed request: reason=%s method=%s endpoint=%s queue_depth=%s priority=%s provider_health=%s",
+        reason,
+        method,
+        endpoint,
+        queue_depth,
+        priority,
+        provider_health,
+    )
 
 
 def build_shed_response(
@@ -44,7 +72,13 @@ def build_shed_response(
     endpoint: str,
     details: Optional[Dict[str, Any]] = None,
 ) -> JSONResponse:
-    record_shed_request(reason, method, endpoint)
+    queue_depth = details.get("queue_depth") if details else None
+    priority = details.get("priority") if details else None
+    provider_health = details.get("provider_health") if details else None
+    
+    record_shed_request(
+        reason, method, endpoint, queue_depth, priority, provider_health
+    )
     payload_details: Dict[str, Any] = {"reason": reason, **(details or {})}
     return JSONResponse(
         status_code=503,
@@ -90,7 +124,13 @@ def check_memory_pressure() -> Optional[str]:
     return None
 
 
-def check_queue_pressure() -> Optional[Tuple[str, Dict[str, Any]]]:
+def check_queue_pressure(
+    priority: str = "normal"
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Check queue pressure with priority-aware thresholds.
+    
+    Higher priority jobs get more leniency on queue depth thresholds.
+    """
     if settings.app_env == "test":
         return None
 
@@ -99,30 +139,71 @@ def check_queue_pressure() -> Optional[Tuple[str, Dict[str, Any]]]:
         # Broker unreachable is not a queue-depth overload signal. Let the
         # request proceed so validation and enqueue logic can handle it.
         return None
-    if depth >= settings.load_shed_max_celery_queue_depth:
-        return "queue_full", {
+
+    # Priority-aware threshold calculation
+    if priority == "high":
+        threshold = settings.load_shed_high_priority_queue_threshold
+    elif priority == "low":
+        threshold = int(
+            settings.load_shed_max_celery_queue_depth
+            * settings.load_shed_queue_priority_multiplier
+        )
+    else:  # normal priority
+        threshold = settings.load_shed_max_celery_queue_depth
+
+    if depth >= threshold:
+        return "queue_priority_exceeded" if priority != "normal" else "queue_full", {
             "queue_depth": depth,
-            "max_queue_depth": settings.load_shed_max_celery_queue_depth,
+            "max_queue_depth": threshold,
+            "priority": priority,
         }
     return None
 
 
-def are_llm_providers_down() -> bool:
+def get_provider_health_status() -> str:
+    """Get detailed provider health status.
+    
+    Returns:
+        'healthy': All providers available
+        'degraded': Some providers unavailable but not all
+        'down': All providers unavailable
+    """
     if settings.app_env == "test" or settings.test_provider_mode:
-        return False
+        return "healthy"
 
     try:
         import main as _main
 
-        return _main.humanitarian_verification_service.all_providers_unavailable()
+        service = _main.humanitarian_verification_service
+        providers = service.registry.available_llm_providers()
+        
+        if not providers:
+            return "healthy"
+        
+        unavailable_count = sum(
+            1 for p in providers if not service._get_breaker(p).allow_request()
+        )
+        
+        if unavailable_count == 0:
+            return "healthy"
+        elif unavailable_count == len(providers):
+            return "down"
+        else:
+            degradation_ratio = unavailable_count / len(providers)
+            if degradation_ratio >= settings.load_shed_provider_degradation_threshold:
+                return "degraded"
+            return "healthy"
     except Exception as exc:
         logger.warning("Failed to evaluate LLM provider health: %s", exc)
-        return False
+        return "healthy"
 
 
-def check_provider_pressure() -> Optional[str]:
-    if are_llm_providers_down():
-        return "provider_down"
+def check_provider_pressure() -> Optional[Tuple[str, Dict[str, Any]]]:
+    health_status = get_provider_health_status()
+    if health_status == "down":
+        return "provider_down", {"provider_health": health_status}
+    elif health_status == "degraded":
+        return "provider_degraded", {"provider_health": health_status}
     return None
 
 
@@ -138,9 +219,19 @@ def _is_llm_route(path: str, method: str) -> bool:
     return path.endswith("/ai/humanitarian/verify")
 
 
+def _extract_priority_from_request(request: Request) -> str:
+    """Extract job priority from request body if available."""
+    try:
+        if hasattr(request, "_json") and request._json:
+            return request._json.get("priority", "normal")
+    except Exception:
+        pass
+    return "normal"
+
 def evaluate_load_shed(request: Request) -> Optional[JSONResponse]:
     path = request.url.path
     method = request.method
+    priority = _extract_priority_from_request(request)
 
     memory_reason = check_memory_pressure()
     if memory_reason:
@@ -150,25 +241,35 @@ def evaluate_load_shed(request: Request) -> Optional[JSONResponse]:
             path,
             details={
                 "threshold_percent": settings.load_shed_memory_threshold_percent,
+                "priority": priority,
             },
         )
 
     if _is_job_creation_route(path, method):
-        queue_result = check_queue_pressure()
+        queue_result = check_queue_pressure(priority=priority)
         if queue_result:
             reason, details = queue_result
             return build_shed_response(reason, method, path, details=details)
+        # Record that the request was allowed through
+        metrics.LOAD_SHED_DECISIONS.labels(
+            decision="allow", reason="queue_ok", priority=priority
+        ).inc()
 
     if _is_llm_route(path, method):
-        provider_reason = check_provider_pressure()
-        if provider_reason:
-            return build_shed_response(provider_reason, method, path)
+        provider_result = check_provider_pressure()
+        if provider_result:
+            reason, details = provider_result
+            return build_shed_response(reason, method, path, details=details)
+        # Record that the request was allowed through
+        metrics.LOAD_SHED_DECISIONS.labels(
+            decision="allow", reason="provider_ok", priority=priority
+        ).inc()
 
     return None
 
 
-def ensure_queue_capacity() -> None:
-    queue_result = check_queue_pressure()
+def ensure_queue_capacity(priority: str = "normal") -> None:
+    queue_result = check_queue_pressure(priority=priority)
     if queue_result:
         reason, details = queue_result
         raise LoadShedError(

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -584,7 +584,9 @@ def create_task(task_type: str, payload: Dict[str, Any]) -> str:
     # Initialize task status
     update_task_status(task_id, "pending")
 
-    ensure_queue_capacity()
+    # Extract priority from payload for queue-aware load shedding
+    priority = payload.get("priority", "normal")
+    ensure_queue_capacity(priority=priority)
 
     try:
         # Queue the task using the lazy-registered task

--- a/app/ai-service/tests/test_load_shedder.py
+++ b/app/ai-service/tests/test_load_shedder.py
@@ -17,6 +17,7 @@ from services.load_shedder import (
     evaluate_load_shed,
     ensure_queue_capacity,
     record_shed_request,
+    get_provider_health_status,
 )
 
 
@@ -46,7 +47,7 @@ class TestLoadShedResponse:
         before = metrics.REQUESTS_SHED_TOTAL.labels(
             reason="queue_full", method="POST", endpoint="/v1/ai/inference"
         )._value.get()
-        record_shed_request("queue_full", "POST", "/v1/ai/inference")
+        record_shed_request("queue_full", "POST", "/v1/ai/inference", queue_depth=120, priority="normal")
         after = metrics.REQUESTS_SHED_TOTAL.labels(
             reason="queue_full", method="POST", endpoint="/v1/ai/inference"
         )._value.get()
@@ -70,18 +71,47 @@ class TestQueuePressure:
         ), patch("services.load_shedder.settings") as mock_settings:
             mock_settings.app_env = "production"
             mock_settings.load_shed_max_celery_queue_depth = 100
-            result = check_queue_pressure()
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            result = check_queue_pressure(priority="normal")
         assert result is not None
         reason, details = result
         assert reason == "queue_full"
         assert details["queue_depth"] == 150
+        assert details["priority"] == "normal"
+
+    def test_high_priority_queue_threshold(self):
+        with patch(
+            "services.load_shedder.get_celery_queue_depth", return_value=140
+        ), patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "production"
+            mock_settings.load_shed_max_celery_queue_depth = 100
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            result = check_queue_pressure(priority="high")
+        assert result is None  # High priority gets more leniency
+
+    def test_low_priority_stricter_threshold(self):
+        with patch(
+            "services.load_shedder.get_celery_queue_depth", return_value=60
+        ), patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "production"
+            mock_settings.load_shed_max_celery_queue_depth = 100
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            result = check_queue_pressure(priority="low")
+        assert result is not None
+        reason, details = result
+        assert reason == "queue_priority_exceeded"
+        assert details["queue_depth"] == 60
+        assert details["priority"] == "low"
 
     def test_broker_unavailable_does_not_shed(self):
         with patch(
             "services.load_shedder.get_celery_queue_depth", return_value=None
         ), patch("services.load_shedder.settings") as mock_settings:
             mock_settings.app_env = "production"
-            result = check_queue_pressure()
+            result = check_queue_pressure(priority="normal")
         assert result is None
 
     def test_inference_reaches_validation_when_broker_unreachable(self, client):
@@ -96,10 +126,10 @@ class TestQueuePressure:
     def test_ensure_queue_capacity_raises(self):
         with patch(
             "services.load_shedder.check_queue_pressure",
-            return_value=("queue_full", {"queue_depth": 120}),
+            return_value=("queue_full", {"queue_depth": 120, "priority": "normal"}),
         ):
             with pytest.raises(LoadShedError) as exc_info:
-                ensure_queue_capacity()
+                ensure_queue_capacity(priority="normal")
         assert exc_info.value.reason == "queue_full"
 
 
@@ -121,20 +151,60 @@ class TestMiddlewareLoadShedding:
     def test_inference_shed_when_queue_full(self, client):
         with patch(
             "services.load_shedder.check_queue_pressure",
-            return_value=("queue_full", {"queue_depth": 200}),
+            return_value=("queue_full", {"queue_depth": 200, "priority": "normal"}),
         ):
             response = client.post("/v1/ai/inference", json={"type": "inference"})
         assert response.status_code == 503
         assert_shed_envelope(response.json(), "queue_full")
 
+    def test_inference_with_high_priority_not_shed_at_normal_threshold(self, client):
+        with patch(
+            "services.load_shedder.get_celery_queue_depth", return_value=120
+        ), patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "production"
+            mock_settings.load_shed_max_celery_queue_depth = 100
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            # Mock the request to have high priority
+            with patch(
+                "services.load_shedder._extract_priority_from_request",
+                return_value="high",
+            ):
+                response = client.post(
+                    "/v1/ai/inference", json={"type": "inference", "priority": "high"}
+                )
+        # Should not be shed since high priority threshold is 150
+        assert response.status_code in [200, 202]
+
     def test_humanitarian_shed_when_providers_down(self, client):
-        with patch("services.load_shedder.are_llm_providers_down", return_value=True):
+        with patch(
+            "services.load_shedder.check_provider_pressure",
+            return_value=("provider_down", {"provider_health": "down"}),
+        ):
             response = client.post(
                 "/v1/ai/humanitarian/verify",
                 json={"aid_claim": "Need food assistance"},
             )
         assert response.status_code == 503
         assert_shed_envelope(response.json(), "provider_down")
+
+    def test_humanitarian_shed_when_providers_degraded(self, client):
+        with patch(
+            "services.load_shedder.check_provider_pressure",
+            return_value=("provider_degraded", {"provider_health": "degraded"}),
+        ):
+            response = client.post(
+                "/v1/ai/humanitarian/verify",
+                json={"aid_claim": "Need food assistance"},
+            )
+        assert response.status_code == 503
+        assert_shed_envelope(response.json(), "provider_degraded")
+
+    def test_provider_health_status_healthy(self):
+        with patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "test"
+            status = get_provider_health_status()
+        assert status == "healthy"
 
     def test_metrics_endpoint_exposes_shed_counter(self, client):
         record_shed_request("memory", "POST", "/v1/ai/anonymize")
@@ -155,3 +225,39 @@ class TestLoadShedExceptionHandler:
         response = client.get("/_test/load-shed")
         assert response.status_code == 503
         assert_shed_envelope(response.json(), "broker_unavailable")
+
+
+class TestPriorityAwareLoadShedding:
+    def test_high_priority_gets_higher_threshold(self):
+        with patch(
+            "services.load_shedder.get_celery_queue_depth", return_value=125
+        ), patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "production"
+            mock_settings.load_shed_max_celery_queue_depth = 100
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            
+            # Normal priority should be shed
+            normal_result = check_queue_pressure(priority="normal")
+            assert normal_result is not None
+            
+            # High priority should not be shed
+            high_result = check_queue_pressure(priority="high")
+            assert high_result is None
+
+    def test_low_priority_gets_lower_threshold(self):
+        with patch(
+            "services.load_shedder.get_celery_queue_depth", return_value=40
+        ), patch("services.load_shedder.settings") as mock_settings:
+            mock_settings.app_env = "production"
+            mock_settings.load_shed_max_celery_queue_depth = 100
+            mock_settings.load_shed_queue_priority_multiplier = 0.5
+            mock_settings.load_shed_high_priority_queue_threshold = 150
+            
+            # Normal priority should not be shed
+            normal_result = check_queue_pressure(priority="normal")
+            assert normal_result is None
+            
+            # Low priority should be shed (threshold = 100 * 0.5 = 50)
+            low_result = check_queue_pressure(priority="low")
+            assert low_result is not None


### PR DESCRIPTION
- Add priority-aware queue thresholds (high: 150, normal: 100, low: 50)
- Add provider health degradation detection (healthy/degraded/down)
- Enhance load shedding metrics with queue_depth, priority, and provider_health labels
- Add new shed reasons: provider_degraded, queue_priority_exceeded
- Extract job priority from request payload for queue-aware decisions
- Track both shed and allow decisions via LOAD_SHED_DECISIONS metric
- Update tests for priority-aware load shedding and provider degradation
closes #777