### PR TITLE
feat(ai-service): make provider fallback order explicit and configurable

### DIFF
--- a/app/ai-service/.env.example
+++ b/app/ai-service/.env.example
@@ -9,6 +9,17 @@ GROQ_MODEL=llama-3.3-70b-versatile
 AI_DETERMINISTIC_MODE=false
 LLM_TIMEOUT_SECONDS=30
 
+# Provider fallback order for LLM calls (Issue #982).
+# Comma-separated list of provider names that defines the priority order when
+# provider_preference="auto" is used.  Allowed values: openai, groq, test
+# Providers with an open circuit breaker are automatically skipped.
+# If unset, the built-in implicit order (test → openai → groq) is used.
+# Examples:
+#   LLM_PROVIDER_ORDER=groq,openai      # cheapest-first
+#   LLM_PROVIDER_ORDER=openai,groq      # highest-quality-first
+#   LLM_PROVIDER_ORDER=test             # fixture-only (contributors / CI)
+# LLM_PROVIDER_ORDER=
+
 # Demo / contributor mode
 # Set TEST_PROVIDER_MODE=true to use fixture-driven responses without any API
 # keys.  This enables "demo mode" so contributors can run the service locally

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import secrets
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import model_validator, HttpUrl
 from pydantic_core import PydanticUndefined
@@ -77,6 +77,12 @@ class Settings(BaseSettings):
     ai_deterministic_mode: bool = False
     test_provider_mode: bool = False
     llm_timeout_seconds: int = 30
+
+    # Explicit LLM fallback order (comma-separated list of provider names).
+    # Allowed values: openai, groq, test
+    # When unset the registry falls back to the implicit built-in order.
+    # Example: LLM_PROVIDER_ORDER=groq,openai   (try Groq first, then OpenAI)
+    llm_provider_order: Optional[str] = None
 
     # Request throttling
     request_rate_limit: str = "10/minute"
@@ -201,6 +207,29 @@ class Settings(BaseSettings):
 
         def _add(key: str, problem: str) -> None:
             errors.append(f"{key}: {problem}")
+
+        # --- LLM provider order ------------------------------------------
+        _KNOWN_LLM_PROVIDERS = {"openai", "groq", "test"}
+        if self.llm_provider_order is not None:
+            entries = [
+                e.strip() for e in self.llm_provider_order.split(",") if e.strip()
+            ]
+            if not entries:
+                _add(
+                    "LLM_PROVIDER_ORDER",
+                    "must not be blank when set; provide a comma-separated list "
+                    f"of provider names from {sorted(_KNOWN_LLM_PROVIDERS)}",
+                )
+            else:
+                unknown = [e for e in entries if e not in _KNOWN_LLM_PROVIDERS]
+                if unknown:
+                    _add(
+                        "LLM_PROVIDER_ORDER",
+                        f"contains unknown provider(s): {unknown}. "
+                        f"Allowed values: {sorted(_KNOWN_LLM_PROVIDERS)}",
+                    )
+                if len(entries) != len(set(entries)):
+                    _add("LLM_PROVIDER_ORDER", "contains duplicate provider names")
 
         # --- Provider keys: set-but-blank is malformed -------------------
         if self.openai_api_key is not None and not self.openai_api_key.strip():
@@ -342,6 +371,12 @@ class Settings(BaseSettings):
         if self.groq_api_key:
             return "groq"
         return None
+
+    def parsed_llm_provider_order(self) -> List[str]:
+        """Return the ordered provider list from LLM_PROVIDER_ORDER, or [] if unset."""
+        if not self.llm_provider_order:
+            return []
+        return [e.strip() for e in self.llm_provider_order.split(",") if e.strip()]
 
     def get_cors_allowed_origins(self) -> list[str]:
         """

--- a/app/ai-service/exceptions.py
+++ b/app/ai-service/exceptions.py
@@ -32,3 +32,33 @@ class LoadShedError(Exception):
         self.message = message
         self.details = details or {}
         super().__init__(message)
+
+
+class AllProvidersExhaustedError(Exception):
+    """Raised when every provider in the fallback list has been tried and failed.
+
+    This is a distinct, documented error so callers can differentiate between
+    a single provider failure and a total loss of LLM availability.
+
+    Attributes:
+        providers_tried: Ordered list of provider names that were attempted.
+        errors: Per-attempt error strings (same order as providers_tried, but
+            may contain multiple entries per provider when prompt variants are
+            retried).
+    """
+
+    def __init__(
+        self,
+        providers_tried: Optional[list] = None,
+        errors: Optional[list] = None,
+        message: Optional[str] = None,
+    ):
+        self.providers_tried: list = providers_tried or []
+        self.errors: list = errors or []
+        if message is None:
+            message = (
+                f"All LLM providers exhausted ({', '.join(self.providers_tried) or 'none'}). "
+                "Errors: " + " | ".join(self.errors)
+            )
+        self.message = message
+        super().__init__(message)

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -7,6 +7,7 @@ import time
 import metrics
 
 from config import settings
+from exceptions import AllProvidersExhaustedError
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
@@ -39,6 +40,19 @@ class HumanitarianVerificationService:
         provider_preference: str = "auto",
         timeout: Optional[float] = None,
     ) -> Dict[str, Any]:
+        """Verify a humanitarian aid claim using configured LLM providers.
+
+        The method iterates through the fallback list in the order defined by
+        ``LLM_PROVIDER_ORDER`` (or the built-in implicit order when unset).
+        Providers with an open circuit breaker are skipped automatically.
+
+        Returns a dict that always contains a ``provider`` key recording which
+        provider actually served the request.
+
+        Raises:
+            AllProvidersExhaustedError: when every provider in the fallback
+                list has been tried (and failed) or is circuit-open.
+        """
         start_time = time.time()
         try:
             evidence = supporting_evidence or []
@@ -55,17 +69,22 @@ class HumanitarianVerificationService:
                 context_factors=context,
             )
 
-            providers = self.registry.resolve_llm(provider_preference)
+            providers = self.registry.resolve_llm(
+                provider_preference, breaker_map=self.breakers
+            )
             if not providers:
-                raise RuntimeError(
-                    "No LLM providers configured for humanitarian verification"
+                raise AllProvidersExhaustedError(
+                    providers_tried=[],
+                    errors=["No LLM providers configured or all circuits are open"],
                 )
 
             errors: List[str] = []
+            providers_tried: List[str] = []
 
             for provider_name, provider in providers:
                 breaker = self._get_breaker(provider_name)
                 if not breaker.allow_request():
+                    # breaker_map already filters these out, but guard defensively
                     logger.warning(
                         "Circuit breaker is OPEN for provider=%s. Skipping.",
                         provider_name,
@@ -75,6 +94,7 @@ class HumanitarianVerificationService:
                     )
                     continue
 
+                providers_tried.append(provider_name)
                 model = self._get_model_for_provider(provider_name)
                 for prompt_variant, prompt in (
                     ("primary", primary_prompt),
@@ -95,6 +115,8 @@ class HumanitarianVerificationService:
                         )
                         parsed = self._parse_json_response(response.content)
                         breaker.record_success()
+                        # ``provider`` is always present in the result dict so
+                        # callers can record which backend served the request.
                         return {
                             "provider": provider_name,
                             "model": model,
@@ -110,8 +132,9 @@ class HumanitarianVerificationService:
                             "Humanitarian verification attempt failed: %s", err
                         )
 
-            raise RuntimeError(
-                "All humanitarian verification attempts failed: " + " | ".join(errors)
+            raise AllProvidersExhaustedError(
+                providers_tried=providers_tried,
+                errors=errors,
             )
         finally:
             latency = time.time() - start_time

--- a/app/ai-service/services/providers.py
+++ b/app/ai-service/services/providers.py
@@ -419,15 +419,36 @@ class ProviderRegistry:
             raise ValueError(f"Unknown provider: {name}") from None
 
     def available_llm_providers(self) -> List[str]:
-        """Return ordered list of available LLM provider names based on config."""
-        available: List[str] = []
+        """Return ordered list of available LLM provider names based on config.
+
+        When ``LLM_PROVIDER_ORDER`` is set in configuration the explicit list
+        drives the ordering.  Only providers that are actually available (API
+        key present, or test/fixture mode active) are included; entries in the
+        configured order that are not available are silently dropped so the
+        fallback list never contains dead entries.
+
+        When ``LLM_PROVIDER_ORDER`` is not set the previous implicit ordering
+        (test → openai → groq) is preserved for backwards compatibility.
+        """
+        # Determine which providers are available at all.
+        available_set: List[str] = []
         if settings.test_provider_mode:
-            available.append("test")
+            available_set.append("test")
         if settings.openai_api_key:
-            available.append("openai")
+            available_set.append("openai")
         if settings.groq_api_key:
-            available.append("groq")
-        return available
+            available_set.append("groq")
+
+        configured_order = settings.parsed_llm_provider_order()
+        if configured_order:
+            # Preserve the configured order but only include available providers.
+            ordered = [p for p in configured_order if p in available_set]
+            # Append any available providers not explicitly listed (safety net).
+            ordered += [p for p in available_set if p not in ordered]
+            return ordered
+
+        # Legacy implicit order.
+        return available_set
 
     def available_ocr_providers(self) -> List[str]:
         """Return ordered list of available OCR provider names."""
@@ -438,24 +459,76 @@ class ProviderRegistry:
         available.append("tesseract")
         return available
 
-    def resolve_llm(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:
-        """Return (name, provider) pairs in attempt order for LLM chat."""
+    def resolve_llm(
+        self,
+        preference: str = "auto",
+        *,
+        breaker_map: Optional[Dict[str, Any]] = None,
+    ) -> List[Tuple[str, ModelProvider]]:
+        """Return (name, provider) pairs in attempt order for LLM chat.
+
+        Args:
+            preference: Provider name to prefer (placed first), or ``"auto"``
+                to use the order from ``LLM_PROVIDER_ORDER`` / the implicit
+                fallback list.  The special value ``"test"`` pins to the
+                fixture provider only.
+            breaker_map: Optional mapping of ``{provider_name: CircuitBreaker}``.
+                When supplied, providers whose circuit breaker is in the OPEN
+                state are excluded from the returned list so callers do not
+                waste attempts on known-failing providers.
+
+        Returns:
+            Ordered list of ``(name, provider)`` tuples ready for sequential
+            fallback.  May be empty if no providers are available or all are
+            circuit-open.
+        """
         available = self.available_llm_providers()
         pref = (preference or "auto").lower()
         if pref == "test" and "test" in available:
-            return [("test", self.get("test"))]
-        if pref in available:
-            ordered = [pref] + [p for p in available if p != pref]
+            candidates = ["test"]
+        elif pref in available:
+            candidates = [pref] + [p for p in available if p != pref]
         else:
-            ordered = available
-        return [(name, self.get(name)) for name in ordered]
+            candidates = available
 
-    def resolve_ocr(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:
-        """Return (name, provider) pairs in attempt order for OCR."""
+        if breaker_map:
+            candidates = [
+                p
+                for p in candidates
+                if p not in breaker_map or breaker_map[p].allow_request()
+            ]
+
+        return [(name, self.get(name)) for name in candidates]
+
+    def resolve_ocr(
+        self,
+        preference: str = "auto",
+        *,
+        breaker_map: Optional[Dict[str, Any]] = None,
+    ) -> List[Tuple[str, ModelProvider]]:
+        """Return (name, provider) pairs in attempt order for OCR.
+
+        Args:
+            preference: Provider name to prefer, or ``"auto"``.
+            breaker_map: Optional mapping of ``{provider_name: CircuitBreaker}``.
+                Open-circuit providers are excluded from the returned list.
+
+        Returns:
+            Ordered list of ``(name, provider)`` tuples ready for sequential
+            fallback.
+        """
         available = self.available_ocr_providers()
         pref = (preference or "auto").lower()
         if pref in available:
-            ordered = [pref] + [p for p in available if p != pref]
+            candidates = [pref] + [p for p in available if p != pref]
         else:
-            ordered = available
-        return [(name, self.get(name)) for name in ordered]
+            candidates = available
+
+        if breaker_map:
+            candidates = [
+                p
+                for p in candidates
+                if p not in breaker_map or breaker_map[p].allow_request()
+            ]
+
+        return [(name, self.get(name)) for name in candidates]

--- a/app/ai-service/tests/test_circuit_breaker.py
+++ b/app/ai-service/tests/test_circuit_breaker.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 from services.circuit_breaker import CircuitBreaker
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.providers import ProviderRegistry, LLMResponse, ModelProvider
-from exceptions import AIServiceError
+from exceptions import AIServiceError, AllProvidersExhaustedError
 from config import settings
 
 
@@ -130,7 +130,7 @@ class TestHumanitarianVerificationServiceCircuitBreaker:
             self.service, "_get_model_for_provider", lambda p: "test-model"
         )
 
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
             self.service.verify_claim(
                 aid_claim="Food aid reached target demographic.",
                 supporting_evidence=[],

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -104,7 +104,9 @@ class TestHumanitarianVerificationService:
         mock_registry.resolve_llm.return_value = []
         monkeypatch.setattr(self.service, "registry", mock_registry)
 
-        with pytest.raises(RuntimeError):
+        from exceptions import AllProvidersExhaustedError
+
+        with pytest.raises(AllProvidersExhaustedError):
             self.service.verify_claim(
                 aid_claim="Food distribution completed.",
                 supporting_evidence=[],

--- a/app/ai-service/tests/test_provider_fallback_order.py
+++ b/app/ai-service/tests/test_provider_fallback_order.py
@@ -1,0 +1,560 @@
+"""Tests for configurable provider fallback order (Issue #982).
+
+Acceptance criteria covered:
+- Fallback order is defined in configuration and validated at startup
+- The provider that actually served a request is recorded on the result
+- Providers with an open circuit are skipped rather than retried
+- Exhausting all providers yields a distinct, documented error
+- Tests cover ordering, skipping, and exhaustion
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from config import Settings, ConfigurationError
+from exceptions import AllProvidersExhaustedError
+from services.circuit_breaker import CircuitBreaker
+from services.providers import ProviderRegistry, LLMResponse, ModelProvider
+from services.humanitarian_verification import HumanitarianVerificationService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_breaker(state: str = "CLOSED") -> CircuitBreaker:
+    """Return a CircuitBreaker pre-set to the given state."""
+    b = CircuitBreaker("test", failure_threshold=3, recovery_timeout=60.0)
+    b.state = state
+    return b
+
+
+def _make_llm_provider(
+    name: str, content: str = '{"verdict":"credible","confidence":0.9,"summary":"ok"}'
+) -> ModelProvider:
+    """Return a mock ModelProvider that succeeds with ``content``."""
+    mock = MagicMock(spec=ModelProvider)
+    mock.name = name
+    mock.llm_chat.return_value = LLMResponse(
+        content=content, provider=name, model=f"{name}-model"
+    )
+    return mock
+
+
+def _make_failing_provider(
+    name: str, error: Exception = RuntimeError("boom")
+) -> ModelProvider:
+    """Return a mock ModelProvider whose llm_chat always raises ``error``."""
+    mock = MagicMock(spec=ModelProvider)
+    mock.name = name
+    mock.llm_chat.side_effect = error
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# 1. Configuration validation for LLM_PROVIDER_ORDER
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderOrderConfigValidation:
+    """validate_configuration() must reject bad LLM_PROVIDER_ORDER values."""
+
+    def _build_valid_settings(self, **overrides):
+        """Return a Settings instance that passes validation for non-order fields."""
+        defaults = dict(
+            openai_api_key="sk-test",
+            groq_api_key=None,
+            app_env="development",
+            redis_url="redis://localhost:6379/0",
+            request_rate_limit="10/minute",
+            dead_letter_replay_rate_limit="10/minute",
+            llm_timeout_seconds=30,
+            cache_ttl_task_status=30,
+            cache_ttl_artifact_access=60,
+            cache_ttl_verification=120,
+            task_retry_delay_seconds=30,
+            verification_artifact_url_ttl_seconds=300,
+            proof_of_life_min_face_size=80,
+            proof_of_life_confidence_threshold=0.65,
+            port=8000,
+            cors_allowed_origins="",
+            cors_custom_origins="",
+        )
+        defaults.update(overrides)
+        # Construct directly, bypassing env file loading.
+        return Settings.model_construct(**defaults)
+
+    def test_valid_order_single(self):
+        s = self._build_valid_settings(llm_provider_order="openai")
+        s.validate_configuration()  # must not raise
+
+    def test_valid_order_multiple(self):
+        s = self._build_valid_settings(llm_provider_order="groq,openai")
+        s.validate_configuration()  # must not raise
+
+    def test_valid_order_all_known(self):
+        s = self._build_valid_settings(llm_provider_order="test,openai,groq")
+        s.validate_configuration()
+
+    def test_none_order_is_allowed(self):
+        s = self._build_valid_settings(llm_provider_order=None)
+        s.validate_configuration()
+
+    def test_unknown_provider_rejected(self):
+        s = self._build_valid_settings(llm_provider_order="openai,badprovider")
+        with pytest.raises(ConfigurationError, match="LLM_PROVIDER_ORDER"):
+            s.validate_configuration()
+
+    def test_duplicate_provider_rejected(self):
+        s = self._build_valid_settings(llm_provider_order="openai,openai")
+        with pytest.raises(ConfigurationError, match="LLM_PROVIDER_ORDER"):
+            s.validate_configuration()
+
+    def test_blank_order_rejected(self):
+        s = self._build_valid_settings(llm_provider_order="   ")
+        with pytest.raises(ConfigurationError, match="LLM_PROVIDER_ORDER"):
+            s.validate_configuration()
+
+    def test_parsed_order_returns_list(self):
+        s = self._build_valid_settings(llm_provider_order="groq,openai")
+        assert s.parsed_llm_provider_order() == ["groq", "openai"]
+
+    def test_parsed_order_none_returns_empty(self):
+        s = self._build_valid_settings(llm_provider_order=None)
+        assert s.parsed_llm_provider_order() == []
+
+
+# ---------------------------------------------------------------------------
+# 2. ProviderRegistry respects configured order
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistryOrder:
+    """available_llm_providers() must honour LLM_PROVIDER_ORDER."""
+
+    def setup_method(self):
+        self.registry = ProviderRegistry()
+
+    def _patch_settings(
+        self, test_mode=False, openai_key=None, groq_key=None, order=None
+    ):
+        m = MagicMock()
+        m.test_provider_mode = test_mode
+        m.openai_api_key = openai_key
+        m.groq_api_key = groq_key
+        m.parsed_llm_provider_order.return_value = (
+            [e.strip() for e in order.split(",") if e.strip()] if order else []
+        )
+        return m
+
+    def test_implicit_order_when_no_config(self):
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = []
+            providers = self.registry.available_llm_providers()
+        # Both present; openai comes before groq in legacy implicit order
+        assert providers.index("openai") < providers.index("groq")
+
+    def test_configured_order_groq_first(self):
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = ["groq", "openai"]
+            providers = self.registry.available_llm_providers()
+        assert providers == ["groq", "openai"]
+
+    def test_configured_order_openai_first(self):
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = ["openai", "groq"]
+            providers = self.registry.available_llm_providers()
+        assert providers == ["openai", "groq"]
+
+    def test_configured_order_drops_unavailable_provider(self):
+        """Providers in the order list that aren't configured are silently dropped."""
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = None  # groq not available
+            ms.parsed_llm_provider_order.return_value = ["groq", "openai"]
+            providers = self.registry.available_llm_providers()
+        assert providers == ["openai"]  # groq absent because no key
+
+    def test_configured_order_appends_unlisted_available_providers(self):
+        """Providers available but not in the explicit list are appended as safety net."""
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = ["openai"]  # groq not listed
+            providers = self.registry.available_llm_providers()
+        assert providers[0] == "openai"
+        assert "groq" in providers  # groq appended
+
+    def test_test_mode_prepends_test_provider(self):
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = True
+            ms.openai_api_key = None
+            ms.groq_api_key = None
+            ms.parsed_llm_provider_order.return_value = []
+            providers = self.registry.available_llm_providers()
+        assert providers == ["test"]
+
+
+# ---------------------------------------------------------------------------
+# 3. resolve_llm respects configured order and breaker_map
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWithBreakerMap:
+    def setup_method(self):
+        self.registry = ProviderRegistry()
+
+    def _base_settings(self):
+        m = MagicMock()
+        m.test_provider_mode = False
+        m.openai_api_key = "key"
+        m.groq_api_key = "key"
+        m.parsed_llm_provider_order.return_value = []
+        return m
+
+    def test_resolve_llm_skips_open_circuit_via_breaker_map(self):
+        openai_breaker = _make_breaker("OPEN")
+        groq_breaker = _make_breaker("CLOSED")
+        breaker_map = {"openai": openai_breaker, "groq": groq_breaker}
+
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = []
+            result = self.registry.resolve_llm("auto", breaker_map=breaker_map)
+
+        names = [n for n, _ in result]
+        assert "openai" not in names, "Open-circuit openai should be skipped"
+        assert "groq" in names
+
+    def test_resolve_llm_no_breaker_map_returns_all(self):
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = []
+            result = self.registry.resolve_llm("auto")
+
+        names = [n for n, _ in result]
+        assert "openai" in names
+        assert "groq" in names
+
+    def test_resolve_llm_all_open_returns_empty(self):
+        openai_breaker = _make_breaker("OPEN")
+        groq_breaker = _make_breaker("OPEN")
+        breaker_map = {"openai": openai_breaker, "groq": groq_breaker}
+
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = []
+            result = self.registry.resolve_llm("auto", breaker_map=breaker_map)
+
+        assert result == []
+
+    def test_resolve_ocr_skips_open_circuit(self):
+        test_breaker = _make_breaker("OPEN")
+        breaker_map = {"test": test_breaker}
+
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = True
+            result = self.registry.resolve_ocr("auto", breaker_map=breaker_map)
+
+        names = [n for n, _ in result]
+        assert "test" not in names
+        assert "tesseract" in names
+
+    def test_resolve_llm_configured_order_respected(self):
+        """The configured order is honoured even inside resolve_llm."""
+        with patch("services.providers.settings") as ms:
+            ms.test_provider_mode = False
+            ms.openai_api_key = "key"
+            ms.groq_api_key = "key"
+            ms.parsed_llm_provider_order.return_value = ["groq", "openai"]
+            result = self.registry.resolve_llm("auto")
+
+        names = [n for n, _ in result]
+        assert names[0] == "groq"
+        assert names[1] == "openai"
+
+
+# ---------------------------------------------------------------------------
+# 4. HumanitarianVerificationService — provider recorded on result
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyClaimProviderRecorded:
+    """The result dict must always carry a ``provider`` key."""
+
+    def setup_method(self):
+        self.service = HumanitarianVerificationService()
+
+    def test_provider_field_present_on_success(self, monkeypatch):
+        openai_provider = _make_llm_provider("openai")
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", openai_provider)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Food aid reached target demographic.",
+            supporting_evidence=[],
+            context_factors={},
+        )
+
+        assert "provider" in result
+        assert result["provider"] == "openai"
+
+    def test_provider_field_reflects_fallback_provider(self, monkeypatch):
+        """When the first provider fails, the result reflects the fallback provider."""
+        failing = _make_failing_provider("openai")
+        succeeding = _make_llm_provider("groq")
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", failing),
+            ("groq", succeeding),
+        ]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Aid delivered on time.",
+            supporting_evidence=[],
+            context_factors={},
+        )
+
+        assert result["provider"] == "groq"
+        failing.llm_chat.assert_called()
+        succeeding.llm_chat.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. Open-circuit providers are skipped
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCircuitSkipped:
+    def setup_method(self):
+        self.service = HumanitarianVerificationService()
+
+    def test_open_circuit_provider_is_skipped(self, monkeypatch):
+        monkeypatch.setattr("config.settings.openai_api_key", "key")
+        monkeypatch.setattr("config.settings.groq_api_key", "key")
+        monkeypatch.setattr("config.settings.test_provider_mode", False)
+        monkeypatch.setattr("config.settings.ai_deterministic_mode", False)
+
+        openai_mock = _make_llm_provider("openai")
+        groq_mock = _make_llm_provider("groq")
+
+        # Pre-open openai's breaker.
+        openai_breaker = self.service._get_breaker("openai")
+        openai_breaker.failure_threshold = 1
+        openai_breaker.record_failure()
+        assert openai_breaker.state == "OPEN"
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        # Simulate registry filtering out openai because its breaker is OPEN.
+        mock_registry.resolve_llm.return_value = [("groq", groq_mock)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Supplies distributed correctly.",
+            supporting_evidence=[],
+            context_factors={},
+        )
+
+        openai_mock.llm_chat.assert_not_called()
+        assert result["provider"] == "groq"
+
+    def test_breakers_passed_to_resolve_llm(self, monkeypatch):
+        """verify_claim must pass its internal breaker dict to resolve_llm."""
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        groq_mock = _make_llm_provider("groq")
+        mock_registry.resolve_llm.return_value = [("groq", groq_mock)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        self.service.verify_claim(
+            aid_claim="Emergency rations provided.",
+            supporting_evidence=[],
+            context_factors={},
+        )
+
+        # resolve_llm must have been called with breaker_map keyword argument.
+        call_kwargs = mock_registry.resolve_llm.call_args.kwargs
+        assert "breaker_map" in call_kwargs
+        # The breaker_map must be the service's own breakers dict.
+        assert call_kwargs["breaker_map"] is self.service.breakers
+
+
+# ---------------------------------------------------------------------------
+# 6. AllProvidersExhaustedError raised when all fail
+# ---------------------------------------------------------------------------
+
+
+class TestAllProvidersExhausted:
+    def setup_method(self):
+        self.service = HumanitarianVerificationService()
+
+    def test_all_providers_fail_raises_distinct_error(self, monkeypatch):
+        failing_openai = _make_failing_provider("openai")
+        failing_groq = _make_failing_provider("groq")
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", failing_openai),
+            ("groq", failing_groq),
+        ]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            self.service.verify_claim(
+                aid_claim="Ration cards verified.",
+                supporting_evidence=[],
+                context_factors={},
+            )
+
+        err = exc_info.value
+        assert isinstance(err, AllProvidersExhaustedError)
+        assert "openai" in err.providers_tried
+        assert "groq" in err.providers_tried
+        assert len(err.errors) > 0
+
+    def test_no_providers_configured_raises_distinct_error(self, monkeypatch):
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = []  # nothing available
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        with pytest.raises(AllProvidersExhaustedError):
+            self.service.verify_claim(
+                aid_claim="No providers configured.",
+                supporting_evidence=[],
+                context_factors={},
+            )
+
+    def test_exhausted_error_is_not_plain_runtime_error(self, monkeypatch):
+        """AllProvidersExhaustedError must be its own class, not RuntimeError."""
+        failing = _make_failing_provider("openai")
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", failing)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        with pytest.raises(AllProvidersExhaustedError):
+            self.service.verify_claim(
+                aid_claim="Single provider exhausted.",
+                supporting_evidence=[],
+                context_factors={},
+            )
+
+    def test_exhausted_error_message_contains_provider_names(self, monkeypatch):
+        failing_openai = _make_failing_provider("openai", RuntimeError("network error"))
+        failing_groq = _make_failing_provider("groq", RuntimeError("timeout"))
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [
+            ("openai", failing_openai),
+            ("groq", failing_groq),
+        ]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda p: "test-model"
+        )
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            self.service.verify_claim(
+                aid_claim="Error context test.",
+                supporting_evidence=[],
+                context_factors={},
+            )
+
+        msg = str(exc_info.value)
+        # The message should identify the exhausted providers and contain errors.
+        assert "openai" in msg or "groq" in msg
+
+    def test_all_providers_circuit_open_raises_exhausted(self, monkeypatch):
+        """When resolve_llm returns empty due to all open circuits, raise AllProvidersExhaustedError."""
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = []  # all filtered out
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            self.service.verify_claim(
+                aid_claim="All circuits open.",
+                supporting_evidence=[],
+                context_factors={},
+            )
+
+        err = exc_info.value
+        assert err.providers_tried == []
+
+
+# ---------------------------------------------------------------------------
+# 7. AllProvidersExhaustedError class properties
+# ---------------------------------------------------------------------------
+
+
+class TestAllProvidersExhaustedErrorClass:
+    def test_is_exception(self):
+        e = AllProvidersExhaustedError()
+        assert isinstance(e, Exception)
+
+    def test_not_runtime_error(self):
+        e = AllProvidersExhaustedError()
+        assert not isinstance(e, RuntimeError)
+
+    def test_default_empty_lists(self):
+        e = AllProvidersExhaustedError()
+        assert e.providers_tried == []
+        assert e.errors == []
+
+    def test_providers_and_errors_stored(self):
+        e = AllProvidersExhaustedError(
+            providers_tried=["openai", "groq"],
+            errors=["openai: boom", "groq: crash"],
+        )
+        assert e.providers_tried == ["openai", "groq"]
+        assert e.errors == ["openai: boom", "groq: crash"]
+
+    def test_default_message_contains_provider_names(self):
+        e = AllProvidersExhaustedError(providers_tried=["openai", "groq"], errors=[])
+        assert "openai" in str(e)
+        assert "groq" in str(e)
+
+    def test_custom_message_accepted(self):
+        e = AllProvidersExhaustedError(message="custom error msg")
+        assert str(e) == "custom error msg"


### PR DESCRIPTION
## Summary

Resolves the issue where the LLM provider fallback order under `auto` was implicit and operators had no way to express preferences such as cheapest-first or lowest-latency-first without editing source code.

## Changes

### New config field: `LLM_PROVIDER_ORDER`
- Comma-separated env var (e.g. `LLM_PROVIDER_ORDER=groq,openai`)
- Validated at startup: unknown names, duplicates, and blank values are all rejected with descriptive errors
- Documented in `.env.example` with usage examples

### ProviderRegistry ordering
- `available_llm_providers()` now respects the configured order
- Providers in the list that are not available (no API key) are silently dropped
- Falls back to the previous implicit order when unset

### Circuit-breaker skipping
- `resolve_llm()` and `resolve_ocr()` accept an optional `breaker_map` kwarg
- `verify_claim()` passes its internal breaker dict so open-circuit providers are excluded before any call

### Provider recorded on result
- `verify_claim()` result dict always contains a `provider` key

### AllProvidersExhaustedError
- New exception class with `providers_tried` and `errors` attributes
- Replaces generic `RuntimeError` when all providers fail

## Tests

Added `tests/test_provider_fallback_order.py` (35 tests) covering all acceptance criteria.

**Test results:** 458 passed (+35 vs baseline), same 26 pre-existing failures.

Closes #982