### PR TITLE
Add image quality gates before inference to prevent wasted provider c…

### DIFF
--- a/app/ai-service/api/routes.py
+++ b/app/ai-service/api/routes.py
@@ -72,9 +72,18 @@ async def process_ocr(
             )
 
         start_inference = time.time()
-        result = ocr_service.process_image(
-            img, language_hint=language_hint.value if language_hint else None
-        )
+        try:
+            result = ocr_service.process_image(
+                img, language_hint=language_hint.value if language_hint else None
+            )
+        except ValueError as e:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "image_quality_gate_failed",
+                    "message": str(e),
+                },
+            )
         inference_latency = time.time() - start_inference
 
         metrics.INFERENCE_LATENCY.labels(task_type="ocr").observe(inference_latency)

--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -93,6 +93,13 @@ class Settings(BaseSettings):
     proof_of_life_confidence_threshold: float = 0.65
     proof_of_life_min_face_size: int = 80
 
+    # Image quality gate settings (checked before dispatch to paid providers)
+    image_quality_min_width: int = 200
+    image_quality_min_height: int = 200
+    image_quality_min_brightness: float = 20.0
+    image_quality_max_brightness: float = 235.0
+    image_quality_min_laplacian_variance: float = 80.0
+
     # Verification artifact access settings
     verification_artifacts_dir: str = "./artifacts/verification"
     verification_artifact_url_ttl_seconds: int = 300

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -63,6 +63,13 @@ CACHE_INVALIDATION_TOTAL = Counter(
     ["reason"],
 )
 
+# Image quality gate metrics
+IMAGE_QUALITY_GATE_REJECTIONS_TOTAL = Counter(
+    "image_quality_gate_rejections_total",
+    "Images rejected by the quality gate before inference",
+    ["reason"],
+)
+
 
 def check_system_resources(memory_threshold_percent: float = 90.0) -> bool:
     """

--- a/app/ai-service/services/ocr.py
+++ b/app/ai-service/services/ocr.py
@@ -7,7 +7,11 @@ from PIL import Image
 
 import metrics
 from config import settings
-from services.preprocessing import ImagePreprocessor, ImageQualityGate, QualityThresholds
+from services.preprocessing import (
+    ImagePreprocessor,
+    ImageQualityGate,
+    QualityThresholds,
+)
 from services.providers import ProviderRegistry, OCRField, OCRResponse
 
 

--- a/app/ai-service/services/ocr.py
+++ b/app/ai-service/services/ocr.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 import metrics
 from config import settings
-from services.preprocessing import ImagePreprocessor
+from services.preprocessing import ImagePreprocessor, ImageQualityGate, QualityThresholds
 from services.providers import ProviderRegistry, OCRField, OCRResponse
 
 
@@ -78,13 +78,30 @@ class FieldDetector:
 
 class OCRService:
     def __init__(self, registry: Optional[ProviderRegistry] = None):
+        from config import settings
+
         self.preprocessor = ImagePreprocessor()
         self.field_detector = FieldDetector()
         self.registry = registry or ProviderRegistry()
+        self.quality_gate = ImageQualityGate(
+            QualityThresholds(
+                min_width=settings.image_quality_min_width,
+                min_height=settings.image_quality_min_height,
+                min_mean_brightness=settings.image_quality_min_brightness,
+                max_mean_brightness=settings.image_quality_max_brightness,
+                min_laplacian_variance=settings.image_quality_min_laplacian_variance,
+            )
+        )
 
     def process_image(
         self, image: Image.Image, language_hint: Optional[str] = None
     ) -> OCRResult:
+        gate_result = self.quality_gate.run(image)
+        if not gate_result.passed:
+            raise ValueError(
+                "Image quality gate failed: " + "; ".join(gate_result.rejections)
+            )
+
         providers = self.registry.resolve_ocr()
         if not providers:
             return OCRResult(fields={}, raw_text="", processing_time_ms=0)

--- a/app/ai-service/services/preprocessing.py
+++ b/app/ai-service/services/preprocessing.py
@@ -1,13 +1,155 @@
 import cv2
+import logging
 import numpy as np
+from dataclasses import dataclass, field
 from PIL import Image
 import time
 import metrics
 
 
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class QualityThresholds:
+    """Configurable thresholds for image quality gates.
+
+    Defaults are conservative to protect against poor field-upload conditions.
+    Override via the IMAGE_QUALITY_* environment variables (see config.py).
+
+    Attributes:
+        min_width: Minimum image width in pixels.
+        min_height: Minimum image height in pixels.
+        min_mean_brightness: Minimum mean pixel brightness (0-255).
+            Below this the image is considered near-black / under-exposed.
+        max_mean_brightness: Maximum mean pixel brightness (0-255).
+            Above this the image is considered near-white / over-exposed.
+        min_laplacian_variance: Minimum Laplacian variance for blur detection.
+            Lower values indicate a blurrier image.
+    """
+
+    min_width: int = 200
+    min_height: int = 200
+    min_mean_brightness: float = 20.0
+    max_mean_brightness: float = 235.0
+    min_laplacian_variance: float = 80.0
+
+
+@dataclass
+class QualityGateResult:
+    """Result returned by ImageQualityGate.run()."""
+
+    passed: bool
+    rejections: list[str] = field(default_factory=list)
+
+
+class ImageQualityGate:
+    """Pre-inference quality gate that rejects unusable images before they
+    are dispatched to a paid provider.
+
+    Three checks are performed:
+        1. **Resolution** – image dimensions must meet minimum width/height.
+        2. **Exposure** – mean pixel brightness must fall within an acceptable
+           range (not near-black and not near-white).
+        3. **Blur** – the Laplacian variance must exceed a threshold (higher
+           = sharper).
+
+    All thresholds are configurable via ``QualityThresholds``.  Gate
+    rejections are counted in the ``IMAGE_QUALITY_GATE_REJECTIONS_TOTAL``
+    Prometheus counter, labelled by ``reason``.
+    """
+
+    def __init__(self, thresholds: QualityThresholds | None = None):
+        self.thresholds = thresholds or QualityThresholds()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, image: Image.Image) -> QualityGateResult:
+        """Evaluate all quality checks on *image*.
+
+        Returns a ``QualityGateResult`` with ``passed=True`` when every
+        check succeeds, or ``passed=False`` with a list of human-readable
+        rejection reasons.
+        """
+        rejections: list[str] = []
+        self._check_resolution(image, rejections)
+        self._check_exposure(image, rejections)
+        self._check_blur(image, rejections)
+
+        if rejections:
+            for reason in rejections:
+                metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL.labels(
+                    reason=reason
+                ).inc()
+            return QualityGateResult(passed=False, rejections=rejections)
+
+        return QualityGateResult(passed=True)
+
+    # ------------------------------------------------------------------
+    # Individual checks
+    # ------------------------------------------------------------------
+
+    def _check_resolution(
+        self, image: Image.Image, rejections: list[str]
+    ) -> None:
+        width, height = image.size
+        if width < self.thresholds.min_width or height < self.thresholds.min_height:
+            reason = (
+                f"Image too small: {width}x{height}px, "
+                f"minimum is {self.thresholds.min_width}x{self.thresholds.min_height}px"
+            )
+            logger.warning("Quality gate: %s", reason)
+            rejections.append(reason)
+
+    def _check_exposure(
+        self, image: Image.Image, rejections: list[str]
+    ) -> None:
+        gray = image.convert("L")
+        arr = np.array(gray)
+        mean_brightness = float(arr.mean())
+
+        if mean_brightness < self.thresholds.min_mean_brightness:
+            reason = (
+                f"Image too dark: mean brightness {mean_brightness:.1f}, "
+                f"minimum is {self.thresholds.min_mean_brightness}"
+            )
+            logger.warning("Quality gate: %s", reason)
+            rejections.append(reason)
+        elif mean_brightness > self.thresholds.max_mean_brightness:
+            reason = (
+                f"Image too bright: mean brightness {mean_brightness:.1f}, "
+                f"maximum is {self.thresholds.max_mean_brightness}"
+            )
+            logger.warning("Quality gate: %s", reason)
+            rejections.append(reason)
+
+    def _check_blur(
+        self, image: Image.Image, rejections: list[str]
+    ) -> None:
+        gray = image.convert("L")
+        arr = np.array(gray)
+        laplacian_var = float(cv2.Laplacian(arr, cv2.CV_64F).var())
+
+        if laplacian_var < self.thresholds.min_laplacian_variance:
+            reason = (
+                f"Image too blurry: Laplacian variance {laplacian_var:.1f}, "
+                f"minimum is {self.thresholds.min_laplacian_variance}"
+            )
+            logger.warning("Quality gate: %s", reason)
+            rejections.append(reason)
+
+
+
 class ImagePreprocessor:
-    def __init__(self, max_dim: int = 2000):
+    def __init__(
+        self,
+        max_dim: int = 2000,
+        quality_gate: ImageQualityGate | None = None,
+    ):
         self.max_dim = max_dim
+        self.quality_gate = quality_gate
 
     def to_grayscale(self, image: Image.Image) -> Image.Image:
         if image.mode == "L":

--- a/app/ai-service/services/preprocessing.py
+++ b/app/ai-service/services/preprocessing.py
@@ -80,9 +80,7 @@ class ImageQualityGate:
 
         if rejections:
             for reason in rejections:
-                metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL.labels(
-                    reason=reason
-                ).inc()
+                metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL.labels(reason=reason).inc()
             return QualityGateResult(passed=False, rejections=rejections)
 
         return QualityGateResult(passed=True)
@@ -91,9 +89,7 @@ class ImageQualityGate:
     # Individual checks
     # ------------------------------------------------------------------
 
-    def _check_resolution(
-        self, image: Image.Image, rejections: list[str]
-    ) -> None:
+    def _check_resolution(self, image: Image.Image, rejections: list[str]) -> None:
         width, height = image.size
         if width < self.thresholds.min_width or height < self.thresholds.min_height:
             reason = (
@@ -103,11 +99,13 @@ class ImageQualityGate:
             logger.warning("Quality gate: %s", reason)
             rejections.append(reason)
 
-    def _check_exposure(
-        self, image: Image.Image, rejections: list[str]
-    ) -> None:
+    def _check_exposure(self, image: Image.Image, rejections: list[str]) -> None:
+        if image.size[0] == 0 or image.size[1] == 0:
+            return
         gray = image.convert("L")
         arr = np.array(gray)
+        if arr.size == 0:
+            return
         mean_brightness = float(arr.mean())
 
         if mean_brightness < self.thresholds.min_mean_brightness:
@@ -125,11 +123,13 @@ class ImageQualityGate:
             logger.warning("Quality gate: %s", reason)
             rejections.append(reason)
 
-    def _check_blur(
-        self, image: Image.Image, rejections: list[str]
-    ) -> None:
+    def _check_blur(self, image: Image.Image, rejections: list[str]) -> None:
+        if image.size[0] == 0 or image.size[1] == 0:
+            return
         gray = image.convert("L")
         arr = np.array(gray)
+        if arr.size == 0:
+            return
         laplacian_var = float(cv2.Laplacian(arr, cv2.CV_64F).var())
 
         if laplacian_var < self.thresholds.min_laplacian_variance:
@@ -139,7 +139,6 @@ class ImageQualityGate:
             )
             logger.warning("Quality gate: %s", reason)
             rejections.append(reason)
-
 
 
 class ImagePreprocessor:

--- a/app/ai-service/tests/test_ocr.py
+++ b/app/ai-service/tests/test_ocr.py
@@ -98,6 +98,7 @@ class TestOCRService:
         mock_labels.return_value.observe = mock_observe
 
         from PIL import Image
+        from services.preprocessing import QualityGateResult
 
         stub_response = OCRResponse(
             fields={
@@ -113,6 +114,11 @@ class TestOCRService:
         mock_registry = MagicMock(spec=ProviderRegistry)
         mock_registry.resolve_ocr.return_value = [("stub", stub_provider)]
         monkeypatch.setattr(self.ocr, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.ocr.quality_gate,
+            "run",
+            lambda img: QualityGateResult(passed=True),
+        )
 
         img = Image.new("RGB", (200, 100), color="white")
         result = self.ocr.process_image(img)
@@ -127,6 +133,7 @@ class TestOCRService:
         mock_labels.return_value.observe = mock_observe
 
         from PIL import Image
+        from services.preprocessing import QualityGateResult
 
         captured_hints = []
 
@@ -149,6 +156,11 @@ class TestOCRService:
             ("hint_capture", HintCapturingProvider())
         ]
         monkeypatch.setattr(self.ocr, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.ocr.quality_gate,
+            "run",
+            lambda img: QualityGateResult(passed=True),
+        )
 
         img = Image.new("RGB", (200, 100), color="white")
         result = self.ocr.process_image(img, language_hint="fra")
@@ -160,8 +172,8 @@ class TestOCRService:
         from PIL import Image
 
         img = Image.new("RGB", (0, 0), color="white")
-        result = self.ocr.process_image(img)
-        assert isinstance(result, OCRResult)
+        with pytest.raises(ValueError, match="Image quality gate failed"):
+            self.ocr.process_image(img)
 
 
 class TestOCRResult:

--- a/app/ai-service/tests/test_preprocessing.py
+++ b/app/ai-service/tests/test_preprocessing.py
@@ -1,9 +1,15 @@
 import pytest
 import numpy as np
 from PIL import Image
-from services.preprocessing import ImagePreprocessor
-import metrics
 from unittest.mock import patch, MagicMock
+import cv2
+from services.preprocessing import (
+    ImagePreprocessor,
+    ImageQualityGate,
+    QualityThresholds,
+    QualityGateResult,
+)
+import metrics
 
 
 class TestImagePreprocessor:
@@ -93,3 +99,217 @@ class TestImagePreprocessor:
         img = Image.new("RGB", (100, 100), color="blue")
         resized = self.preprocessor.resize_image(img, max_dim=2000)
         assert resized.size == (100, 100)
+
+
+# ---------------------------------------------------------------------------
+# ImageQualityGate tests
+# ---------------------------------------------------------------------------
+
+
+class TestImageQualityGate:
+    """Tests for the pre-inference quality gate (Issue #992)."""
+
+    def setup_method(self):
+        self.gate = ImageQualityGate()
+
+    # -- helpers --------------------------------------------------------
+
+    @staticmethod
+    def _make_image(
+        width: int,
+        height: int,
+        color: tuple[int, int, int] = (128, 128, 128),
+    ) -> Image.Image:
+        """Create a solid-colour RGB image of the given size."""
+        return Image.new("RGB", (width, height), color=color)
+
+    @staticmethod
+    def _make_blurry_image(
+        width: int = 500,
+        height: int = 500,
+    ) -> Image.Image:
+        """Create a very blurry image (low Laplacian variance)."""
+        arr = np.full((height, width), 128, dtype=np.uint8)
+        # Apply heavy Gaussian blur to eliminate edges
+        blurred = np.zeros_like(arr)
+        kernel_size = 31
+        blurred[:] = 128  # uniform = zero variance after Laplacian
+        return Image.fromarray(blurred, mode="L").convert("RGB")
+
+    @staticmethod
+    def _make_textured_image(
+        width: int = 800,
+        height: int = 600,
+    ) -> Image.Image:
+        """Create an image with strong edges that passes the blur check."""
+        # Checkerboard pattern — high Laplacian variance at every boundary
+        block = 20
+        y_idx = (np.arange(height)[:, None] // block).astype(np.uint8)
+        x_idx = (np.arange(width)[None, :] // block).astype(np.uint8)
+        arr = np.where((y_idx + x_idx) % 2 == 0, 200, 40).astype(np.uint8)
+        return Image.fromarray(arr, mode="L").convert("RGB")
+
+    # -- passing --------------------------------------------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_passing_image(self, mock_counter, mock_cv2):
+        # Simulate a sharp image (Laplacian variance > threshold)
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 150.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        img = self._make_textured_image(800, 600)
+        result = self.gate.run(img)
+        assert result.passed is True
+        assert result.rejections == []
+        mock_counter.labels.assert_not_called()
+
+    # -- resolution rejection -------------------------------------------
+
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_too_small_width(self, mock_counter):
+        img = self._make_image(50, 300, color=(128, 128, 128))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        assert any("too small" in r for r in result.rejections)
+        assert any("50x300" in r for r in result.rejections)
+        mock_counter.labels.assert_called()
+
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_too_small_height(self, mock_counter):
+        img = self._make_image(300, 50, color=(128, 128, 128))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        assert any("too small" in r for r in result.rejections)
+
+    # -- exposure rejection ---------------------------------------------
+
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_near_black_image(self, mock_counter):
+        img = self._make_image(800, 600, color=(5, 5, 5))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        assert any("too dark" in r for r in result.rejections)
+        mock_counter.labels.assert_called()
+
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_near_white_image(self, mock_counter):
+        img = self._make_image(800, 600, color=(250, 250, 250))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        assert any("too bright" in r for r in result.rejections)
+        mock_counter.labels.assert_called()
+
+    # -- blur rejection -------------------------------------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_blurry_image(self, mock_counter, mock_cv2):
+        # Simulate a blurry image (Laplacian variance < threshold)
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 5.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        img = self._make_blurry_image(500, 500)
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        assert any("blurry" in r for r in result.rejections)
+        mock_counter.labels.assert_called()
+
+    # -- multiple rejections --------------------------------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejects_image_failing_multiple_checks(self, mock_counter, mock_cv2):
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 5.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        # Tiny, near-black image that is also blurry
+        img = self._make_image(10, 10, color=(2, 2, 2))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        assert result.passed is False
+        # Should have at least 2 distinct rejection reasons
+        assert len(result.rejections) >= 2
+
+    # -- custom thresholds ----------------------------------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_custom_thresholds_respected(self, mock_counter, mock_cv2):
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 300.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        tight = QualityThresholds(
+            min_width=1000,
+            min_height=1000,
+            min_mean_brightness=50.0,
+            max_mean_brightness=200.0,
+            min_laplacian_variance=200.0,
+        )
+        gate = ImageQualityGate(thresholds=tight)
+        img = self._make_image(500, 500, color=(128, 128, 128))
+        mock_counter.labels.return_value = MagicMock()
+        result = gate.run(img)
+        # 500x500 is below 1000x1000 minimum
+        assert result.passed is False
+        assert any("too small" in r for r in result.rejections)
+
+    # -- rejection reasons are actionable strings -----------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_rejection_reasons_contain_expected_parts(self, mock_counter, mock_cv2):
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 5.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        img = self._make_image(10, 10, color=(2, 2, 2))
+        mock_counter.labels.return_value = MagicMock()
+        result = self.gate.run(img)
+        for reason in result.rejections:
+            # Every rejection should contain actual vs expected values
+            assert isinstance(reason, str)
+            assert len(reason) > 10
+
+    # -- defaults are documented ----------------------------------------
+
+    def test_default_thresholds(self):
+        t = QualityThresholds()
+        assert t.min_width == 200
+        assert t.min_height == 200
+        assert t.min_mean_brightness == 20.0
+        assert t.max_mean_brightness == 235.0
+        assert t.min_laplacian_variance == 80.0
+
+    # -- metrics counter increments ------------------------------------
+
+    @patch("services.preprocessing.cv2")
+    @patch("metrics.IMAGE_QUALITY_GATE_REJECTIONS_TOTAL")
+    def test_metrics_counter_increments_per_reason(self, mock_counter, mock_cv2):
+        mock_lap = MagicMock()
+        mock_lap.var.return_value = 5.0
+        mock_cv2.Laplacian.return_value = mock_lap
+        mock_cv2.CV_64F = cv2.CV_64F
+
+        # Image that fails resolution + exposure + blur checks
+        img = self._make_image(10, 10, color=(2, 2, 2))
+        labels_mock = MagicMock()
+        mock_counter.labels.return_value = labels_mock
+        result = self.gate.run(img)
+        # Each rejection should increment the counter once
+        assert labels_mock.inc.call_count == len(result.rejections)
+        assert mock_counter.labels.call_count == len(result.rejections)

--- a/app/ai-service/tests/test_routes.py
+++ b/app/ai-service/tests/test_routes.py
@@ -44,12 +44,43 @@ class TestOCRRoutes:
             "/ai/ocr",
             files={"image": ("test.png", buf.getvalue(), "image/png")},
         )
-        assert response.status_code == 200
+        assert response.status_code == 400
+        # Error is wrapped by main.http_exception_handler into {"error": {"code": ..., "message": ...}}
+        assert "image_quality_gate_failed" in response.text
+        assert "too small" in response.text
 
     def test_ocr_endpoint_processing_time_recorded(self):
         from PIL import Image
+        from api.routes import ocr_service
+        from services.ocr import OCRResult
+        from services.preprocessing import QualityGateResult
 
         img = Image.new("RGB", (100, 100), color="white")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        mock_result = OCRResult(
+            fields={},
+            raw_text="",
+            processing_time_ms=10,
+        )
+        with patch.object(
+            ocr_service.quality_gate, "run", return_value=QualityGateResult(passed=True)
+        ):
+            with patch.object(ocr_service.registry, "resolve_ocr", return_value=[]):
+                response = client.post(
+                    "/ai/ocr",
+                    files={"image": ("test.png", buf.getvalue(), "image/png")},
+                )
+        assert response.status_code == 200
+        data = response.json()
+        # Legacy /ai/ocr returns OCRResponse (old flat shape)
+        assert "processing_time_ms" in data
+
+    def test_ocr_endpoint_quality_gate_rejected(self):
+        from PIL import Image
+
+        img = Image.new("RGB", (10, 10), color="white")
         buf = io.BytesIO()
         img.save(buf, format="PNG")
         buf.seek(0)
@@ -57,10 +88,8 @@ class TestOCRRoutes:
             "/ai/ocr",
             files={"image": ("test.png", buf.getvalue(), "image/png")},
         )
-        assert response.status_code == 200
-        data = response.json()
-        # Legacy /ai/ocr returns OCRResponse (old flat shape)
-        assert "processing_time_ms" in data
+        assert response.status_code == 400
+        assert "image_quality_gate_failed" in response.text
 
     def test_ocr_endpoint_with_language_hint(self):
         from PIL import Image

--- a/app/ai-service/tests/test_test_provider_stability.py
+++ b/app/ai-service/tests/test_test_provider_stability.py
@@ -157,6 +157,11 @@ class TestOCRTestProviderStability:
         monkeypatch.setattr(settings, "test_provider_mode", True)
 
         from PIL import Image
+        from services.preprocessing import QualityGateResult
+
+        monkeypatch.setattr(
+            self.service.quality_gate, "run", lambda img: QualityGateResult(passed=True)
+        )
 
         img = Image.new("RGB", (100, 50), color="white")
 
@@ -171,6 +176,11 @@ class TestOCRTestProviderStability:
         monkeypatch.setattr(settings, "test_provider_mode", True)
 
         from PIL import Image
+        from services.preprocessing import QualityGateResult
+
+        monkeypatch.setattr(
+            self.service.quality_gate, "run", lambda img: QualityGateResult(passed=True)
+        )
 
         img = Image.new("RGB", (200, 100), color="white")
 
@@ -198,10 +208,14 @@ class TestOCRTestProviderStability:
         """Without test_provider_mode, OCR goes through the real dependency path."""
         from unittest.mock import MagicMock
         from PIL import Image
+        from services.preprocessing import QualityGateResult
 
         img = Image.new("RGB", (50, 50), color="red")
 
         monkeypatch.setattr(settings, "test_provider_mode", False)
+        monkeypatch.setattr(
+            self.service.quality_gate, "run", lambda img: QualityGateResult(passed=True)
+        )
 
         failing_provider = MagicMock()
         failing_provider.name = "failing"
@@ -286,6 +300,11 @@ class TestCrossEndpointStability:
         monkeypatch.setattr(settings, "groq_api_key", None)
 
         from PIL import Image
+        from services.preprocessing import QualityGateResult
+
+        monkeypatch.setattr(
+            self.ocr.quality_gate, "run", lambda img: QualityGateResult(passed=True)
+        )
 
         h = self.humanitarian.verify_claim("Test claim.", ["doc"], {})
         o = self.ocr.process_image(Image.new("RGB", (50, 50), color="white"))

--- a/app/ai-service/tests/test_versioned_routes.py
+++ b/app/ai-service/tests/test_versioned_routes.py
@@ -112,14 +112,21 @@ class TestOCRLegacyPath:
 
     def test_legacy_ocr_valid_image_returns_200(self, client):
         from PIL import Image
+        from unittest.mock import patch
+        from services.preprocessing import QualityGateResult
 
         img = Image.new("RGB", (60, 60), color="blue")
         buf = io.BytesIO()
         img.save(buf, format="PNG")
-        response = client.post(
-            "/ai/ocr",
-            files={"image": ("img.png", buf.getvalue(), "image/png")},
-        )
+        # Patch the quality gate so a tiny test image still counts as valid for this legacy test
+        with patch(
+            "api.routes.ocr_service.quality_gate.run",
+            return_value=QualityGateResult(passed=True),
+        ):
+            response = client.post(
+                "/ai/ocr",
+                files={"image": ("img.png", buf.getvalue(), "image/png")},
+            )
         assert response.status_code == 200
 
     def test_legacy_ocr_not_redirected(self, client):


### PR DESCRIPTION
…alls

Unusable images (too small, near-black, or extremely blurry) were being sent to paid OCR/Liveness providers, returning low-quality results at full cost. This adds a pre-inference quality gate that checks resolution, exposure, and blur before dispatch, returning actionable errors when an image fails. Thresholds are configurable via environment variables with documented defaults, and rejections are counted as Prometheus metrics by reason.

Closes #992
