### PR TITLE
feat: enforce per-recipient claim cooldown

### DIFF
--- a/app/onchain/contracts/aid_escrow/STORAGE_KEYS.md
+++ b/app/onchain/contracts/aid_escrow/STORAGE_KEYS.md
@@ -57,6 +57,7 @@ A singleton key is a bare `Symbol`; exactly one entry exists per key.
 | `KEY_CAMPAIGN_PAUSED`   | `"camp_pzd"`   | `Map<String, bool>` | `pause_campaign` / `unpause_campaign`, keyed by `campaign_ref`. Grows with campaigns; permanent. |
 | `KEY_TOTAL_LOCKED`      | `"locked"`     | `Map<Address, i128>` (token → locked amount) | Updated on package create/claim/disburse/revoke/cancel/refund. **Derived bookkeeping** over live packages. |
 | `KEY_TOTAL_CLAIMED`     | `"claimed"`    | `Map<Address, i128>` (token → cumulative claimed) | Claim paths only. Monotonic accounting. |
+| `KEY_RECIPIENT_LAST_CLAIM` | `"lastclaim"` | `Map<Address, u64>` (recipient → successful-claim timestamp) | Successful claim paths only. Enforces the optional `Config.claim_cooldown`; absent entries have no cooldown history. |
 | `KEY_PKG_COUNTER`       | `"pkg_cnt"`    | `u64`       | Package creation. Highest assigned id + 1; upper bound for id scans (`get_campaign_package_count`, etc.). |
 | `KEY_PKG_IDX`           | `"pkg_idx"`    | `u64`       | Package creation. Count of aggregation-index entries; positional bound for `get_aggregates`. May exceed `KEY_PKG_COUNTER` when explicit ids are used. |
 

--- a/app/onchain/contracts/aid_escrow/src/keys.rs
+++ b/app/onchain/contracts/aid_escrow/src/keys.rs
@@ -59,6 +59,9 @@ pub const KEY_TOTAL_LOCKED: Symbol = symbol_short!("locked");
 /// Per-token cumulative amount ever claimed (`Map<Address, i128>`).
 /// Monotonic; never decreases.
 pub const KEY_TOTAL_CLAIMED: Symbol = symbol_short!("claimed");
+/// Timestamp of each recipient's most recent successful claim (`Map<Address, u64>`).
+/// Used to enforce the optional per-recipient claim cooldown.
+pub const KEY_RECIPIENT_LAST_CLAIM: Symbol = symbol_short!("lastclaim");
 /// Highest assigned package id plus one (`u64`). Upper bound for id scans.
 pub const KEY_PKG_COUNTER: Symbol = symbol_short!("pkg_cnt");
 /// Number of entries written to the aggregation index (`u64`). Positional
@@ -116,7 +119,7 @@ mod tests {
     use super::*;
 
     /// Every singleton key, both storage families.
-    fn singleton_keys() -> [Symbol; 18] {
+    fn singleton_keys() -> [Symbol; 19] {
         [
             KEY_ADMIN,
             KEY_PENDING_ADMIN,
@@ -131,6 +134,7 @@ mod tests {
             KEY_CAMPAIGN_PAUSED,
             KEY_TOTAL_LOCKED,
             KEY_TOTAL_CLAIMED,
+            KEY_RECIPIENT_LAST_CLAIM,
             KEY_PKG_COUNTER,
             KEY_PKG_IDX,
             KEY_DELEGATES,

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::keys::{
     package_index_entry, package_key, KEY_ADMIN, KEY_CAMPAIGN_PAUSED, KEY_CONFIG, KEY_DELEGATES,
     KEY_DELEGATE_EXPIRY, KEY_DELEGATE_HISTORY, KEY_DISTRIBUTORS, KEY_PAUSED, KEY_PAUSE_CLAIM,
     KEY_PAUSE_CREATE, KEY_PAUSE_REFUND, KEY_PAUSE_WITHDRAW, KEY_PENDING_ADMIN, KEY_PKG_COUNTER,
-    KEY_PKG_IDX, KEY_TOTAL_CLAIMED, KEY_TOTAL_LOCKED, KEY_VERSION,
+    KEY_PKG_IDX, KEY_RECIPIENT_LAST_CLAIM, KEY_TOTAL_CLAIMED, KEY_TOTAL_LOCKED, KEY_VERSION,
 };
 
 /// Upper bound on the number of package ids accepted by `batch_claim` in a
@@ -76,6 +76,9 @@ pub struct Config {
     pub min_amount: i128,
     pub max_expires_in: u64,
     pub allowed_tokens: Vec<Address>,
+    /// Minimum number of seconds a recipient must wait between successful
+    /// claims. `0` disables the cooldown.
+    pub claim_cooldown: u64,
 }
 
 #[contracttype]
@@ -111,6 +114,8 @@ pub enum ClaimStatus {
     CampaignPaused = 7,
     /// Eligibility checks passed but the token transfer failed.
     TransferFailed = 8,
+    /// The recipient successfully claimed another package too recently.
+    CooldownActive = 9,
 }
 
 /// Per-package result returned by `batch_claim`.
@@ -148,6 +153,8 @@ pub enum Error {
     NoPendingTransfer = 19,
     InvalidPendingAdmin = 20,
     BatchTooLarge = 21,
+    /// The recipient has not yet completed the configured claim cooldown.
+    ClaimCooldownActive = 22,
 }
 
 // --- Contract Events (indexer-friendly; stable topics & payloads) ---
@@ -389,6 +396,7 @@ impl AidEscrow {
             min_amount: 1,
             max_expires_in: 0,
             allowed_tokens: Vec::new(&env),
+            claim_cooldown: 0,
         };
         env.storage().instance().set(&KEY_CONFIG, &config);
         Ok(())
@@ -575,7 +583,9 @@ impl AidEscrow {
     /// Admin-only. Updates the global contract configuration.
     ///
     /// # Arguments
-    /// * `config` — New config values (`min_amount`, `max_expires_in`, `allowed_tokens`).
+    /// * `config` — New config values (`min_amount`, `max_expires_in`,
+    ///   `allowed_tokens`, `claim_cooldown`). Set `claim_cooldown` to zero to
+    ///   disable per-recipient throttling.
     ///
     /// # Errors
     /// Returns `Error::InvalidAmount` if `config.min_amount` is zero or negative.
@@ -746,6 +756,7 @@ impl AidEscrow {
             min_amount: 1,
             max_expires_in: 0,
             allowed_tokens: Vec::new(&env),
+            claim_cooldown: 0,
         })
     }
 
@@ -1216,6 +1227,8 @@ impl AidEscrow {
             return Err(Error::NotAuthorized);
         }
 
+        Self::ensure_recipient_cooldown(&env, &package.recipient, now)?;
+
         claimant.require_auth();
         relayer.require_auth();
 
@@ -1244,6 +1257,7 @@ impl AidEscrow {
         env.storage()
             .instance()
             .set(&KEY_TOTAL_CLAIMED, &claimed_map);
+        Self::record_recipient_claim(&env, &package.recipient, now);
 
         PackageClaimedByRelayer {
             package_id: id,
@@ -1266,6 +1280,10 @@ impl AidEscrow {
     /// outcome is simply recorded as a non-`Success` `ClaimStatus` in the
     /// returned results. Fund transfers and accounting updates only happen
     /// for packages that resolve to `ClaimStatus::Success`.
+    ///
+    /// When a cooldown is enabled, ids are processed in order. The first
+    /// successful claim records the recipient timestamp; later ids for that
+    /// recipient in the same batch return `ClaimStatus::CooldownActive`.
     ///
     /// Returns `Err(Error::BatchTooLarge)` if more than
     /// `MAX_BATCH_CLAIM_SIZE` ids are supplied, without touching any package.
@@ -1329,6 +1347,10 @@ impl AidEscrow {
 
         if !delegate::is_authorised_claimer(env, id, &package.recipient, claimant) {
             return not_claimable(ClaimStatus::Unauthorized);
+        }
+
+        if Self::ensure_recipient_cooldown(env, &package.recipient, now).is_err() {
+            return not_claimable(ClaimStatus::CooldownActive);
         }
 
         let amount = package.amount;
@@ -1827,6 +1849,7 @@ impl AidEscrow {
         claimant: &Address,
         now: u64,
     ) -> Result<(), Error> {
+        Self::ensure_recipient_cooldown(env, &package.recipient, now)?;
         Self::transfer_token(
             env,
             &package.token,
@@ -1852,6 +1875,7 @@ impl AidEscrow {
         env.storage()
             .instance()
             .set(&KEY_TOTAL_CLAIMED, &claimed_map);
+        Self::record_recipient_claim(env, &package.recipient, now);
 
         // Check if claimant is a delegate (not the recipient)
         let is_delegate = claimant != &package.recipient;
@@ -1897,6 +1921,40 @@ impl AidEscrow {
         }
 
         Ok(())
+    }
+
+    /// Rejects claims made before a recipient's configured cooldown window
+    /// expires. The recipient (rather than a delegate or relayer) is tracked,
+    /// so alternate claim paths cannot bypass the limit.
+    fn ensure_recipient_cooldown(env: &Env, recipient: &Address, now: u64) -> Result<(), Error> {
+        let cooldown = Self::get_config(env.clone()).claim_cooldown;
+        if cooldown == 0 {
+            return Ok(());
+        }
+
+        let claims: Map<Address, u64> = env
+            .storage()
+            .instance()
+            .get(&KEY_RECIPIENT_LAST_CLAIM)
+            .unwrap_or(Map::new(env));
+        if let Some(last_claim) = claims.get(recipient.clone()) {
+            if now.saturating_sub(last_claim) < cooldown {
+                return Err(Error::ClaimCooldownActive);
+            }
+        }
+        Ok(())
+    }
+
+    fn record_recipient_claim(env: &Env, recipient: &Address, now: u64) {
+        let mut claims: Map<Address, u64> = env
+            .storage()
+            .instance()
+            .get(&KEY_RECIPIENT_LAST_CLAIM)
+            .unwrap_or(Map::new(env));
+        claims.set(recipient.clone(), now);
+        env.storage()
+            .instance()
+            .set(&KEY_RECIPIENT_LAST_CLAIM, &claims);
     }
 
     fn receipt_hash_from_metadata(env: &Env, metadata: &Map<Symbol, String>) -> String {

--- a/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/aid_escrow_tests.rs
@@ -59,6 +59,7 @@ impl TestSetup {
             min_amount: 1, // Minimum 1 stroop
             max_expires_in: 0,
             allowed_tokens: Vec::new(&env),
+            claim_cooldown: 0,
         });
 
         Self {
@@ -152,6 +153,7 @@ mod create_package {
             min_amount: TWO_TOKENS, // Min 2.0 tokens
             max_expires_in: 0,
             allowed_tokens: Vec::new(&t.env),
+            claim_cooldown: 0,
         });
         let result = t.client.try_create_package(
             &t.admin,
@@ -239,6 +241,7 @@ mod token_interactions {
             min_amount: 1,
             max_expires_in: 0,
             allowed_tokens,
+            claim_cooldown: 0,
         });
 
         assert_eq!(result, Err(Ok(Error::InvalidToken)));

--- a/app/onchain/contracts/aid_escrow/tests/boundary_validation_tests.rs
+++ b/app/onchain/contracts/aid_escrow/tests/boundary_validation_tests.rs
@@ -57,6 +57,7 @@ impl TestSetup {
             min_amount: 1,
             max_expires_in: 0,
             allowed_tokens: Vec::new(&env),
+            claim_cooldown: 0,
         });
 
         Self {

--- a/app/onchain/contracts/aid_escrow/tests/claim_cooldown.rs
+++ b/app/onchain/contracts/aid_escrow/tests/claim_cooldown.rs
@@ -1,0 +1,111 @@
+#![cfg(test)]
+
+//! Coverage for the optional per-recipient claim cooldown (issue #966).
+
+use aid_escrow::{AidEscrow, AidEscrowClient, ClaimStatus, Config, Error, PackageStatus};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env, Map, Vec,
+};
+
+const UNIT: i128 = 10_000_000;
+
+struct Fixture {
+    env: Env,
+    client: AidEscrowClient<'static>,
+    admin: Address,
+    token: TokenClient<'static>,
+}
+
+impl Fixture {
+    fn new(cooldown: u64) -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+        let token = TokenClient::new(&env, &token_contract.address());
+        let token_sac = StellarAssetClient::new(&env, &token_contract.address());
+        let contract_id = env.register(AidEscrow, ());
+        let client = AidEscrowClient::new(&env, &contract_id);
+        client.init(&admin);
+        client.set_config(&Config {
+            min_amount: 1,
+            max_expires_in: 0,
+            allowed_tokens: Vec::new(&env),
+            claim_cooldown: cooldown,
+        });
+        token_sac.mint(&admin, &(100 * UNIT));
+        client.fund(&token.address, &admin, &(100 * UNIT));
+        Self {
+            env,
+            client,
+            admin,
+            token,
+        }
+    }
+
+    fn create(&self, id: u64, recipient: &Address) {
+        self.client.create_package(
+            &self.admin,
+            &id,
+            recipient,
+            &UNIT,
+            &self.token.address,
+            &(self.env.ledger().timestamp() + 10_000),
+            &Map::new(&self.env),
+        );
+    }
+
+    fn advance(&self, seconds: u64) {
+        let mut info = self.env.ledger().get();
+        info.timestamp += seconds;
+        self.env.ledger().set(info);
+    }
+}
+
+#[test]
+fn cooldown_rejects_claim_inside_window_and_allows_claim_at_boundary() {
+    let f = Fixture::new(60);
+    let recipient = Address::generate(&f.env);
+    f.create(1, &recipient);
+    f.create(2, &recipient);
+
+    f.client.claim(&1);
+    assert_eq!(f.client.try_claim(&2), Err(Ok(Error::ClaimCooldownActive)));
+    assert_eq!(f.client.get_package(&2).status, PackageStatus::Created);
+
+    f.advance(60);
+    f.client.claim(&2);
+    assert_eq!(f.client.get_package(&2).status, PackageStatus::Claimed);
+}
+
+#[test]
+fn disabled_cooldown_allows_consecutive_claims() {
+    let f = Fixture::new(0);
+    let recipient = Address::generate(&f.env);
+    f.create(1, &recipient);
+    f.create(2, &recipient);
+
+    f.client.claim(&1);
+    f.client.claim(&2);
+    assert_eq!(f.token.balance(&recipient), 2 * UNIT);
+}
+
+#[test]
+fn batch_claim_reports_cooldown_per_item_without_aborting() {
+    let f = Fixture::new(60);
+    let recipient = Address::generate(&f.env);
+    f.create(1, &recipient);
+    f.create(2, &recipient);
+    let mut ids = Vec::new(&f.env);
+    ids.push_back(1);
+    ids.push_back(2);
+
+    let results = f.client.batch_claim(&recipient, &ids);
+    assert_eq!(results.get(0).unwrap().status, ClaimStatus::Success);
+    assert_eq!(results.get(1).unwrap().status, ClaimStatus::CooldownActive);
+    assert_eq!(f.client.get_package(&1).status, PackageStatus::Claimed);
+    assert_eq!(f.client.get_package(&2).status, PackageStatus::Created);
+}

--- a/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
+++ b/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
@@ -56,6 +56,7 @@ impl TestSetup {
             min_amount: 1,
             max_expires_in: 0,
             allowed_tokens: Vec::new(&env),
+            claim_cooldown: 0,
         });
 
         Self {

--- a/app/onchain/contracts/aid_escrow/tests/integration.rs
+++ b/app/onchain/contracts/aid_escrow/tests/integration.rs
@@ -140,6 +140,7 @@ fn test_set_get_config() {
         min_amount: UNIT,
         max_expires_in: 3600,
         allowed_tokens: tokens,
+        claim_cooldown: 0,
     };
     client.set_config(&config);
     assert_eq!(client.get_config(), config);
@@ -165,6 +166,7 @@ fn test_config_constraints_on_create_package() {
         min_amount: 5 * UNIT,
         max_expires_in: 1000,
         allowed_tokens: allowed,
+        claim_cooldown: 0,
     });
 
     let now = env.ledger().timestamp();
@@ -431,6 +433,7 @@ fn test_config_constraints_on_extend_expiration() {
         min_amount: UNIT,
         max_expires_in: 500,
         allowed_tokens: Vec::new(&env),
+        claim_cooldown: 0,
     });
 
     let now = env.ledger().timestamp();

--- a/app/onchain/contracts/aid_escrow/tests/property_based_invariants.rs
+++ b/app/onchain/contracts/aid_escrow/tests/property_based_invariants.rs
@@ -46,6 +46,7 @@ fn setup_env() -> (
         min_amount: 1,
         max_expires_in: 0,
         allowed_tokens: soroban_sdk::Vec::new(&env),
+        claim_cooldown: 0,
     });
 
     let token_contract = env.register_stellar_asset_contract_v2(admin.clone());


### PR DESCRIPTION
## Summary

- add an optional `claim_cooldown` configuration value; `0` disables it
- enforce cooldowns across direct, proof, relayed, and batch claim paths
- return `ClaimCooldownActive` for single claims and `CooldownActive` per batch item

## Batch behavior

Batch ids are processed in order. The first successful claim records the recipient timestamp; later ids for that same recipient in the same cooldown window return `CooldownActive` without aborting the batch.

## Testing

- `cargo fmt --check`
- `cargo test -p aid_escrow`

Fixes #966