### PR TITLE
feat(evidence-uploads): purge abandoned sessions and expired artifacts (#996)

### DIFF
--- a/app/ai-service/api/v1/uploads.py
+++ b/app/ai-service/api/v1/uploads.py
@@ -46,6 +46,10 @@ EVIDENCE_MAX_UPLOAD_BYTES = int(
 EVIDENCE_UPLOAD_SESSION_TTL_SECONDS = int(
     os.getenv("EVIDENCE_UPLOAD_SESSION_TTL_SECONDS", str(60 * 60))
 )
+EVIDENCE_ARTIFACT_RETENTION_SECONDS = int(
+    os.getenv("EVIDENCE_ARTIFACT_RETENTION_SECONDS", str(30 * 24 * 60 * 60))
+)
+EVIDENCE_PURGE_BATCH_SIZE = int(os.getenv("EVIDENCE_PURGE_BATCH_SIZE", "500"))
 
 upload_session_service = UploadSessionService(
     storage_dir=EVIDENCE_UPLOAD_DIR,
@@ -210,3 +214,48 @@ async def finalize_upload_session(
         total_size=session.total_size,
         status="completed",
     )
+
+
+def run_evidence_upload_purge(dry_run: bool = False) -> dict:
+    """Purge abandoned upload sessions and expired artifacts.
+
+    Used by the scheduled Celery task (``tasks.purge_expired_evidence_uploads``)
+    and available for ad-hoc/dry-run invocation. In-progress (unexpired)
+    sessions are never touched by either pass.
+    """
+    import metrics
+
+    session_result = upload_session_service.purge_abandoned_sessions(dry_run=dry_run)
+    artifact_result = upload_session_service.purge_expired_artifacts(
+        retention_seconds=EVIDENCE_ARTIFACT_RETENTION_SECONDS,
+        batch_size=EVIDENCE_PURGE_BATCH_SIZE,
+        dry_run=dry_run,
+    )
+
+    if not dry_run:
+        metrics.UPLOAD_PURGE_ITEMS_TOTAL.labels(kind="session").inc(
+            session_result.items_purged
+        )
+        metrics.UPLOAD_PURGE_BYTES_RECLAIMED_TOTAL.labels(kind="session").inc(
+            session_result.bytes_reclaimed
+        )
+        metrics.UPLOAD_PURGE_ITEMS_TOTAL.labels(kind="artifact").inc(
+            artifact_result.items_purged
+        )
+        metrics.UPLOAD_PURGE_BYTES_RECLAIMED_TOTAL.labels(kind="artifact").inc(
+            artifact_result.bytes_reclaimed
+        )
+
+    report = {
+        "dry_run": dry_run,
+        "sessions_purged": session_result.items_purged,
+        "session_bytes_reclaimed": session_result.bytes_reclaimed,
+        "artifacts_purged": artifact_result.items_purged,
+        "artifact_bytes_reclaimed": artifact_result.bytes_reclaimed,
+        "errors": session_result.errors + artifact_result.errors,
+    }
+    logger.info(
+        "evidence_upload_purge_completed",
+        extra={"event": "evidence_upload_purge_completed", **report},
+    )
+    return report

--- a/app/ai-service/docker-compose.yml
+++ b/app/ai-service/docker-compose.yml
@@ -57,6 +57,24 @@ services:
       - ./logs:/app/logs
     restart: unless-stopped
 
+  # Celery Beat scheduler for periodic tasks (evidence upload/artifact purge)
+  celery-beat:
+    build:
+      context: .
+      target: production
+    command: celery -A tasks beat --loglevel=info
+    environment:
+      - APP_ENV=production
+      - LOG_LEVEL=INFO
+      - REDIS_URL=redis://redis:6379/0
+      - BACKEND_WEBHOOK_URL=http://localhost:3001/api/v1/webhooks/ai-verification
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./logs:/app/logs
+    restart: unless-stopped
+
   # GPU-enabled AI Service (requires nvidia-docker)
   ai-service-gpu:
     build:

--- a/app/ai-service/metrics.py
+++ b/app/ai-service/metrics.py
@@ -98,6 +98,18 @@ def check_system_resources(memory_threshold_percent: float = 90.0) -> bool:
     return True
 
 
+# Evidence upload/artifact retention purge metrics
+UPLOAD_PURGE_ITEMS_TOTAL = Counter(
+    "upload_purge_items_total",
+    "Items removed by the evidence upload/artifact purge job",
+    ["kind"],
+)
+UPLOAD_PURGE_BYTES_RECLAIMED_TOTAL = Counter(
+    "upload_purge_bytes_reclaimed_total",
+    "Bytes reclaimed by the evidence upload/artifact purge job",
+    ["kind"],
+)
+
 # Cache stampede prevention metrics
 SINGLE_FLIGHT_SUPPRESSED = Counter(
     "cache_single_flight_suppressed_total",

--- a/app/ai-service/services/upload_sessions.py
+++ b/app/ai-service/services/upload_sessions.py
@@ -208,3 +208,104 @@ class UploadSessionService:
     @staticmethod
     def received_chunks_sorted(session: UploadSession) -> List[int]:
         return sorted(session.received_chunks)
+
+    # -- retention / purge ----------------------------------------------------
+
+    def purge_abandoned_sessions(self, dry_run: bool = False) -> "PurgeResult":
+        """Remove upload sessions that expired without being finalized.
+
+        A session is only ever considered here once ``expires_at`` has
+        passed, so an upload that is still in progress is never touched
+        regardless of how long it has been running.
+        """
+        result = PurgeResult(dry_run=dry_run)
+        now = time.time()
+
+        with self._lock:
+            abandoned_ids = [
+                session_id
+                for session_id, session in self._sessions.items()
+                if not session.completed and session.expires_at < now
+            ]
+
+        for session_id in abandoned_ids:
+            session_dir = self._session_dir(session_id)
+            size = self._dir_size(session_dir)
+            if not dry_run:
+                with self._lock:
+                    self._sessions.pop(session_id, None)
+                if os.path.isdir(session_dir):
+                    shutil.rmtree(session_dir, ignore_errors=True)
+            result.items_purged += 1
+            result.bytes_reclaimed += size
+
+        return result
+
+    def purge_expired_artifacts(
+        self,
+        retention_seconds: int,
+        batch_size: int = 500,
+        dry_run: bool = False,
+    ) -> "PurgeResult":
+        """Remove finalized artifacts older than ``retention_seconds``.
+
+        Only files directly under ``storage_dir`` (finalized artifacts) are
+        considered; the ``sessions/`` subdirectory holding in-progress chunk
+        data is never touched by this method. At most ``batch_size``
+        artifacts are removed per call so a large backlog cannot make a
+        single purge run unbounded.
+        """
+        result = PurgeResult(dry_run=dry_run)
+        if not os.path.isdir(self.storage_dir):
+            return result
+
+        cutoff = time.time() - retention_seconds
+        candidates: List[str] = []
+        with os.scandir(self.storage_dir) as entries:
+            for entry in entries:
+                if entry.name == "sessions" or not entry.is_file():
+                    continue
+                try:
+                    mtime = entry.stat().st_mtime
+                except OSError:
+                    continue
+                if mtime < cutoff:
+                    candidates.append(entry.path)
+
+        for path in candidates[:batch_size]:
+            try:
+                size = os.path.getsize(path)
+            except OSError:
+                continue
+            if not dry_run:
+                try:
+                    os.remove(path)
+                except OSError as exc:
+                    result.errors.append(f"{path}: {exc}")
+                    continue
+            result.items_purged += 1
+            result.bytes_reclaimed += size
+
+        return result
+
+    def _dir_size(self, path: str) -> int:
+        total = 0
+        if not os.path.isdir(path):
+            return total
+        for root, _dirs, files in os.walk(path):
+            for name in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, name))
+                except OSError:
+                    pass
+        return total
+
+
+@dataclass
+class PurgeResult:
+    """Outcome of a single purge pass (sessions or artifacts)."""
+
+    dry_run: bool
+    items_purged: int = 0
+    bytes_reclaimed: int = 0
+    errors: List[str] = field(default_factory=list)

--- a/app/ai-service/tasks.py
+++ b/app/ai-service/tasks.py
@@ -4,11 +4,13 @@ Handles background task processing for heavy inference
 """
 
 import logging
+import os
 import uuid
 import time
 from typing import Any, Dict, Optional
 from celery import Celery
 from celery.result import AsyncResult
+from celery.schedules import crontab
 import httpx
 
 import metrics
@@ -55,6 +57,12 @@ def get_celery_app() -> Celery:
                 result_expires=86400,  # Results expire after 24 hours
                 task_acks_late=True,
                 task_reject_on_worker_lost=True,
+                beat_schedule={
+                    "purge-expired-evidence-uploads": {
+                        "task": "purge_expired_evidence_uploads",
+                        "schedule": crontab(minute=0),  # hourly
+                    },
+                },
             )
         except Exception as e:
             logger.warning(
@@ -117,6 +125,27 @@ def get_process_heavy_inference_task():
             raise
 
     return process_heavy_inference_task
+
+
+def get_purge_expired_evidence_uploads_task():
+    """
+    Get the lazily-registered purge_expired_evidence_uploads task.
+
+    Removes abandoned upload sessions and expired evidence artifacts on the
+    schedule configured in ``get_celery_app``. Registered lazily so the task
+    exists only once Celery is actually available, matching the pattern used
+    by ``get_process_heavy_inference_task``.
+    """
+    app = get_celery_app()
+
+    @app.task(name="purge_expired_evidence_uploads")
+    def purge_expired_evidence_uploads_task() -> Dict[str, Any]:
+        from api.v1.uploads import run_evidence_upload_purge
+
+        dry_run = os.getenv("EVIDENCE_PURGE_DRY_RUN", "false").lower() == "true"
+        return run_evidence_upload_purge(dry_run=dry_run)
+
+    return purge_expired_evidence_uploads_task
 
 
 def handle_task_retries_exhausted(
@@ -624,3 +653,9 @@ def expire_task(task_id: str) -> None:
     result = AsyncResult(task_id, app=get_celery_app())
     result.revoke(terminate=True)
     update_task_status(task_id, "expired")
+
+
+# Registered eagerly (unlike the on-demand inference task) so that celery
+# beat, which dispatches purely by task name, always finds it in the worker's
+# registry without needing a request to trigger registration first.
+get_purge_expired_evidence_uploads_task()

--- a/app/ai-service/tests/test_startup_validation.py
+++ b/app/ai-service/tests/test_startup_validation.py
@@ -31,3 +31,12 @@ def test_valid_configuration_boots_and_serves():
     with TestClient(main.app) as client:
         response = client.get("/health")
         assert response.status_code == 200
+
+    # ``main.app`` is a module-level singleton shared by every test file in
+    # the session. Exiting the context manager above runs the lifespan
+    # shutdown path, which permanently flips ``is_shutting_down`` to True.
+    # Other test modules build a plain (non-context-manager) TestClient
+    # around the same app and never re-enter the lifespan, so without this
+    # reset they would start seeing 503 "draining" responses regardless of
+    # test order.
+    main.app.state.is_shutting_down = False

--- a/app/ai-service/tests/test_upload_purge.py
+++ b/app/ai-service/tests/test_upload_purge.py
@@ -1,0 +1,141 @@
+"""
+Tests for scheduled purge of abandoned upload sessions and expired artifacts.
+"""
+
+import os
+import time
+
+from services.upload_sessions import UploadSessionService
+
+ALLOWED_TYPES = {"image/png", "application/pdf"}
+
+
+def _make_service(tmp_path, ttl_seconds=3600, max_bytes=1024):
+    return UploadSessionService(
+        storage_dir=str(tmp_path / "uploads"),
+        allowed_content_types=ALLOWED_TYPES,
+        max_upload_bytes=max_bytes,
+        session_ttl_seconds=ttl_seconds,
+    )
+
+
+def test_purge_removes_abandoned_expired_sessions(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    session.expires_at = time.time() - 1
+
+    result = service.purge_abandoned_sessions()
+
+    assert result.items_purged == 1
+    assert result.bytes_reclaimed == 2
+    assert session.session_id not in service._sessions
+    assert not os.path.isdir(service._session_dir(session.session_id))
+
+
+def test_purge_never_touches_in_progress_sessions(tmp_path):
+    service = _make_service(tmp_path, ttl_seconds=3600)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+
+    result = service.purge_abandoned_sessions()
+
+    assert result.items_purged == 0
+    assert session.session_id in service._sessions
+    assert os.path.isdir(service._session_dir(session.session_id))
+
+
+def test_purge_never_touches_completed_sessions_even_if_ttl_elapsed(tmp_path):
+    service = _make_service(tmp_path, ttl_seconds=3600)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    service.finalize(session.session_id, "user-1")
+
+    session.expires_at = time.time() - 1000  # simulate an old finalized session
+
+    result = service.purge_abandoned_sessions()
+
+    assert result.items_purged == 0
+    assert session.session_id in service._sessions
+
+
+def test_dry_run_reports_without_deleting(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    session.expires_at = time.time() - 1
+
+    result = service.purge_abandoned_sessions(dry_run=True)
+
+    assert result.items_purged == 1
+    assert result.bytes_reclaimed == 2
+    assert session.session_id in service._sessions
+    assert os.path.isdir(service._session_dir(session.session_id))
+
+
+def test_purge_expired_artifacts_removes_old_files(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    finalized = service.finalize(session.session_id, "user-1")
+
+    artifact_path = os.path.join(
+        service.storage_dir, f"{finalized.artifact_id}_e.png"
+    )
+    old_time = time.time() - 1000
+    os.utime(artifact_path, (old_time, old_time))
+
+    result = service.purge_expired_artifacts(retention_seconds=100)
+
+    assert result.items_purged == 1
+    assert result.bytes_reclaimed == 2
+    assert not os.path.exists(artifact_path)
+
+
+def test_purge_expired_artifacts_skips_fresh_files(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+    finalized = service.finalize(session.session_id, "user-1")
+
+    artifact_path = os.path.join(
+        service.storage_dir, f"{finalized.artifact_id}_e.png"
+    )
+
+    result = service.purge_expired_artifacts(retention_seconds=100)
+
+    assert result.items_purged == 0
+    assert os.path.exists(artifact_path)
+
+
+def test_purge_expired_artifacts_ignores_sessions_directory(tmp_path):
+    service = _make_service(tmp_path)
+    session = service.create_session("user-1", "e.png", "image/png", 2, 1)
+    service.save_chunk(session.session_id, "user-1", 0, b"aa")
+
+    session_dir = service._session_dir(session.session_id)
+    old_time = time.time() - 1000
+    os.utime(session_dir, (old_time, old_time))
+
+    result = service.purge_expired_artifacts(retention_seconds=100)
+
+    assert result.items_purged == 0
+    assert os.path.isdir(session_dir)
+
+
+def test_purge_expired_artifacts_respects_batch_size(tmp_path):
+    service = _make_service(tmp_path)
+    old_time = time.time() - 1000
+    for i in range(5):
+        path = os.path.join(service.storage_dir, f"artifact-{i}.bin")
+        with open(path, "wb") as handle:
+            handle.write(b"x")
+        os.utime(path, (old_time, old_time))
+
+    result = service.purge_expired_artifacts(retention_seconds=100, batch_size=2)
+
+    assert result.items_purged == 2
+    remaining = [
+        name for name in os.listdir(service.storage_dir) if name != "sessions"
+    ]
+    assert len(remaining) == 3

--- a/app/ai-service/tests/test_upload_purge.py
+++ b/app/ai-service/tests/test_upload_purge.py
@@ -79,9 +79,7 @@ def test_purge_expired_artifacts_removes_old_files(tmp_path):
     service.save_chunk(session.session_id, "user-1", 0, b"aa")
     finalized = service.finalize(session.session_id, "user-1")
 
-    artifact_path = os.path.join(
-        service.storage_dir, f"{finalized.artifact_id}_e.png"
-    )
+    artifact_path = os.path.join(service.storage_dir, f"{finalized.artifact_id}_e.png")
     old_time = time.time() - 1000
     os.utime(artifact_path, (old_time, old_time))
 
@@ -98,9 +96,7 @@ def test_purge_expired_artifacts_skips_fresh_files(tmp_path):
     service.save_chunk(session.session_id, "user-1", 0, b"aa")
     finalized = service.finalize(session.session_id, "user-1")
 
-    artifact_path = os.path.join(
-        service.storage_dir, f"{finalized.artifact_id}_e.png"
-    )
+    artifact_path = os.path.join(service.storage_dir, f"{finalized.artifact_id}_e.png")
 
     result = service.purge_expired_artifacts(retention_seconds=100)
 
@@ -135,7 +131,5 @@ def test_purge_expired_artifacts_respects_batch_size(tmp_path):
     result = service.purge_expired_artifacts(retention_seconds=100, batch_size=2)
 
     assert result.items_purged == 2
-    remaining = [
-        name for name in os.listdir(service.storage_dir) if name != "sessions"
-    ]
+    remaining = [name for name in os.listdir(service.storage_dir) if name != "sessions"]
     assert len(remaining) == 3


### PR DESCRIPTION
## Summary

Closes #996.

`services/upload_sessions.py` persists resumable upload sessions and their chunks to disk, and finalized artifacts accumulate in the same storage directory, but nothing ever removed abandoned sessions or old artifacts. This adds a scheduled purge job so PII evidence doesn't accumulate indefinitely.

- `UploadSessionService.purge_abandoned_sessions()` removes sessions that are both **expired and never finalized**, deleting their chunk directory. In-progress (unexpired) sessions and completed sessions are never touched, regardless of TTL.
- `UploadSessionService.purge_expired_artifacts()` removes finalized artifact files older than a configurable retention window (`EVIDENCE_ARTIFACT_RETENTION_SECONDS`, default 30 days), in bounded batches (`EVIDENCE_PURGE_BATCH_SIZE`, default 500 per run). It only ever scans files directly under the storage dir, never the `sessions/` subdirectory holding in-progress chunk data.
- Both purge passes support `dry_run=True`, returning counts/bytes without deleting anything.
- `purge_expired_evidence_uploads` Celery task runs hourly via `beat_schedule`; a `celery-beat` service is added to `docker-compose.yml` to run it. Set `EVIDENCE_PURGE_DRY_RUN=true` to run the scheduled job in report-only mode.
- New Prometheus metrics: `upload_purge_items_total{kind="session"|"artifact"}` and `upload_purge_bytes_reclaimed_total{kind="session"|"artifact"}`.

## Acceptance criteria

- [x] A scheduled job removes abandoned upload sessions and their chunks after a configurable window
- [x] Expired artifacts are purged in bounded batches
- [x] A dry-run mode reports what would be removed
- [x] Purge counts and reclaimed bytes are exposed as metrics
- [x] In-progress uploads are never purged

## Test plan

- [x] `pytest tests/test_upload_purge.py tests/test_upload_sessions.py` — 16 passed, covering: abandoned-expired purge, in-progress sessions untouched, completed sessions untouched even past TTL, dry-run leaves disk state unchanged, artifact retention purge (removes old / skips fresh / ignores `sessions/` dir / respects batch size).
- [x] `python -m py_compile` on all touched modules.