### PR TITLE
Support resumable recipient imports

### DIFF
--- a/app/backend/prisma/migrations/20260826095000_import_job_resume_progress/migration.sql
+++ b/app/backend/prisma/migrations/20260826095000_import_job_resume_progress/migration.sql
@@ -1,0 +1,15 @@
+ALTER TYPE "ImportJobStatus" ADD VALUE IF NOT EXISTS 'cancelled';
+
+ALTER TABLE "Claim"
+  ADD COLUMN "importJobId" TEXT,
+  ADD COLUMN "importRowNumber" INTEGER;
+
+ALTER TABLE "ImportJob"
+  ADD COLUMN "checkpointRow" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "filePath" TEXT,
+  ADD COLUMN "startedAt" TIMESTAMP(3),
+  ADD COLUMN "cancelledAt" TIMESTAMP(3);
+
+CREATE INDEX "Claim_importJobId_idx" ON "Claim"("importJobId");
+CREATE UNIQUE INDEX "Claim_importJobId_importRowNumber_key" ON "Claim"("importJobId", "importRowNumber");
+CREATE INDEX "ImportJob_checkpointRow_idx" ON "ImportJob"("checkpointRow");

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -245,16 +245,21 @@ model Claim {
   /// for off-chain receipt discovery. Set at disbursement time.
   receiptPointer String?
 
+  importJobId    String?
+  importRowNumber Int?
+
   balanceLedger     BalanceLedger[]
   sorobanTransactions SorobanTransaction[]
   sorobanEventCorrelations SorobanEventCorrelation[]
 
   @@index([status])
   @@index([campaignId])
+  @@index([importJobId])
   @@index([createdAt])
   @@index([deletedAt])
   @@index([reissuedFromId])
   @@index([expiresAt])
+  @@unique([importJobId, importRowNumber])
 }
 
 enum SorobanTransactionStatus {
@@ -858,6 +863,7 @@ enum ImportJobStatus {
   processing
   completed
   failed
+  cancelled
 }
 
 model ImportJob {
@@ -870,12 +876,17 @@ model ImportJob {
   errors        String?
   reportUrl     String?
   fileName      String
+  filePath      String?
+  checkpointRow Int             @default(0)
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
+  startedAt     DateTime?
   completedAt   DateTime?
+  cancelledAt   DateTime?
 
   @@index([campaignId])
   @@index([status])
+  @@index([checkpointRow])
 }
 
 enum SorobanEventTopic {

--- a/app/backend/src/claims/claims.service.ts
+++ b/app/backend/src/claims/claims.service.ts
@@ -135,6 +135,8 @@ export class ClaimsService {
           createClaimDto.recipientRef,
         ),
         evidenceRef: createClaimDto.evidenceRef,
+        importJobId: createClaimDto.importJobId,
+        importRowNumber: createClaimDto.importRowNumber,
         expiresAt:
           createClaimDto.expiresAt ??
           new Date(
@@ -642,11 +644,12 @@ export class ClaimsService {
     });
 
     return logs
-      .filter((log) => log.action.startsWith('status_changed_to_'))
-      .map((log) => {
+      .filter(log => log.action.startsWith('status_changed_to_'))
+      .map(log => {
         const metadata = log.metadata as Record<string, any> | null;
         const txHash = metadata?.transactionHash as string | undefined;
-        const network = this.configService.get<string>('STELLAR_NETWORK') ?? 'testnet';
+        const network =
+          this.configService.get<string>('STELLAR_NETWORK') ?? 'testnet';
         return {
           status: log.action.replace('status_changed_to_', ''),
           timestamp: log.timestamp.toISOString(),

--- a/app/backend/src/claims/dto/create-claim.dto.ts
+++ b/app/backend/src/claims/dto/create-claim.dto.ts
@@ -68,4 +68,13 @@ export class CreateClaimDto {
   @Type(() => Date)
   @IsDate()
   expiresAt?: Date;
+
+  @IsOptional()
+  @IsString()
+  importJobId?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  importRowNumber?: number;
 }

--- a/app/backend/src/recipient-import/__tests__/recipient-import.processor.spec.ts
+++ b/app/backend/src/recipient-import/__tests__/recipient-import.processor.spec.ts
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { RecipientImportProcessor } from '../recipient-import.processor';
+import { RecipientImportService } from '../recipient-import.service';
+import { ClaimsService } from '../../claims/claims.service';
+
+describe('RecipientImportProcessor', () => {
+  let tempDir: string;
+  let csvPath: string;
+  let recipientImportService: jest.Mocked<Partial<RecipientImportService>>;
+  let claimsService: jest.Mocked<Partial<ClaimsService>>;
+  let processor: RecipientImportProcessor;
+  let job: any;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'soter-import-test-'));
+    csvPath = join(tempDir, 'recipients.csv');
+    writeFileSync(
+      csvPath,
+      'recipientRef,amount,evidenceRef\nR-001,100,ev-1\nR-002,200,ev-2\nR-003,300,ev-3',
+    );
+
+    recipientImportService = {
+      setJobProcessing: jest.fn().mockResolvedValue(true),
+      getResumeState: jest.fn().mockResolvedValue({
+        id: 'import-job-1',
+        status: 'processing',
+        campaignId: 'campaign-1',
+        fileName: 'recipients.csv',
+        filePath: csvPath,
+        totalRows: 3,
+        processedRows: 0,
+        errorRows: 0,
+        checkpointRow: 0,
+        errors: [],
+      }),
+      parseCsv: jest.fn((content: string) => {
+        const [header, ...rows] = content.split('\n');
+        return {
+          headers: header.split(','),
+          rows: rows.map(row => row.split(',')),
+        };
+      }),
+      validateRow: jest.fn((row: string[], _headers: string[], rowIndex) => ({
+        valid: true,
+        recipientRef: row[0],
+        amount: Number(row[1]),
+        evidenceRef: row[2],
+        errors: [],
+        rowIndex,
+      })),
+      isCancellationRequested: jest.fn().mockResolvedValue(false),
+      hasImportedRow: jest.fn().mockResolvedValue(false),
+      updateJobProgress: jest.fn().mockResolvedValue(undefined),
+      completeJob: jest.fn().mockResolvedValue(undefined),
+    };
+
+    claimsService = {
+      create: jest.fn().mockResolvedValue({ id: 'claim-1' }),
+    };
+
+    processor = new RecipientImportProcessor(
+      recipientImportService as RecipientImportService,
+      claimsService as ClaimsService,
+    );
+
+    job = {
+      id: 'import-job-1',
+      data: {
+        jobId: 'import-job-1',
+        campaignId: 'campaign-1',
+        fileName: 'recipients.csv',
+        filePath: csvPath,
+        totalRows: 3,
+      },
+      updateProgress: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resumes from the last durable checkpoint', async () => {
+    recipientImportService.getResumeState!.mockResolvedValue({
+      id: 'import-job-1',
+      status: 'processing',
+      campaignId: 'campaign-1',
+      fileName: 'recipients.csv',
+      filePath: csvPath,
+      totalRows: 3,
+      processedRows: 1,
+      errorRows: 0,
+      checkpointRow: 1,
+      errors: [],
+    });
+
+    await processor.process(job);
+
+    expect(claimsService.create).toHaveBeenCalledTimes(2);
+    expect(claimsService.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        recipientRef: 'R-002',
+        importJobId: 'import-job-1',
+        importRowNumber: 3,
+      }),
+    );
+    expect(recipientImportService.completeJob).toHaveBeenCalledWith(
+      'import-job-1',
+      3,
+      0,
+      [],
+      null,
+    );
+  });
+
+  it('skips an already imported row when the checkpoint lagged', async () => {
+    recipientImportService.hasImportedRow!.mockImplementation(
+      (_jobId, rowNumber) => Promise.resolve(rowNumber === 2),
+    );
+
+    await processor.process(job);
+
+    expect(claimsService.create).toHaveBeenCalledTimes(2);
+    expect(claimsService.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({ importRowNumber: 2 }),
+    );
+    expect(recipientImportService.updateJobProgress).toHaveBeenCalledWith(
+      'import-job-1',
+      1,
+      0,
+      [],
+    );
+  });
+
+  it('stops promptly when cancellation is requested', async () => {
+    recipientImportService
+      .isCancellationRequested!.mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await processor.process(job);
+
+    expect(claimsService.create).toHaveBeenCalledTimes(1);
+    expect(recipientImportService.completeJob).not.toHaveBeenCalled();
+    expect(recipientImportService.updateJobProgress).toHaveBeenCalledWith(
+      'import-job-1',
+      1,
+      0,
+      [],
+    );
+  });
+});

--- a/app/backend/src/recipient-import/__tests__/recipient-import.service.spec.ts
+++ b/app/backend/src/recipient-import/__tests__/recipient-import.service.spec.ts
@@ -14,6 +14,7 @@ describe('RecipientImportService', () => {
 
   const mockQueue = {
     add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    getJob: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -37,14 +38,23 @@ describe('RecipientImportService', () => {
                 status: 'pending',
                 processedRows: 0,
                 errorRows: 0,
+                checkpointRow: 0,
                 errors: null,
                 reportUrl: null,
+                filePath: '/tmp/recipients.csv',
+                startedAt: null,
                 completedAt: null,
+                cancelledAt: null,
                 createdAt: new Date(),
                 updatedAt: new Date(),
               }),
               findUnique: jest.fn(),
               update: jest.fn().mockResolvedValue({}),
+              updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+              findMany: jest.fn().mockResolvedValue([]),
+            },
+            claim: {
+              findFirst: jest.fn(),
             },
           },
         },
@@ -83,6 +93,7 @@ describe('RecipientImportService', () => {
           data: expect.objectContaining({
             campaignId: 'campaign-1',
             fileName: 'recipients.csv',
+            filePath: '/tmp/recipients.csv',
             totalRows: 100,
           }),
         }),
@@ -124,12 +135,16 @@ describe('RecipientImportService', () => {
         totalRows: 100,
         processedRows: 50,
         errorRows: 5,
+        checkpointRow: 50,
         errors: JSON.stringify([
           { row: 1, field: 'amount', message: 'Invalid' },
         ]),
         reportUrl: null,
+        filePath: '/tmp/recipients.csv',
         status: 'processing',
+        startedAt: new Date(),
         completedAt: null,
+        cancelledAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -141,6 +156,7 @@ describe('RecipientImportService', () => {
       expect(result.totalRows).toBe(100);
       expect(result.processedRows).toBe(50);
       expect(result.errorRows).toBe(5);
+      expect(result.checkpointRow).toBe(50);
       expect(result.progress).toBe(50);
       expect(result.errors).toHaveLength(1);
     });
@@ -161,10 +177,14 @@ describe('RecipientImportService', () => {
         totalRows: 0,
         processedRows: 0,
         errorRows: 0,
+        checkpointRow: 0,
         errors: null,
         reportUrl: null,
+        filePath: '/tmp/recipients.csv',
         status: 'pending',
+        startedAt: null,
         completedAt: null,
+        cancelledAt: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -185,6 +205,7 @@ describe('RecipientImportService', () => {
         data: {
           processedRows: 75,
           errorRows: 3,
+          checkpointRow: 75,
           errors: JSON.stringify([
             { row: 1, field: 'amount', message: 'Invalid' },
           ]),
@@ -200,6 +221,7 @@ describe('RecipientImportService', () => {
         data: {
           processedRows: 100,
           errorRows: 0,
+          checkpointRow: 100,
           errors: null,
         },
       });
@@ -297,12 +319,118 @@ describe('RecipientImportService', () => {
 
   describe('setJobProcessing', () => {
     it('should update status to processing', async () => {
-      await service.setJobProcessing('import-job-1');
+      const result = await service.setJobProcessing('import-job-1');
 
+      expect(result).toBe(true);
+      expect(prismaService.importJob.updateMany).toHaveBeenCalledWith({
+        where: { id: 'import-job-1', status: { not: 'cancelled' } },
+        data: { status: 'processing', startedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('resume and cancellation', () => {
+    it('should return durable resume state', async () => {
+      (prismaService.importJob.findUnique as jest.Mock).mockResolvedValue({
+        id: 'import-job-1',
+        campaignId: 'campaign-1',
+        fileName: 'recipients.csv',
+        filePath: '/tmp/recipients.csv',
+        totalRows: 100,
+        processedRows: 40,
+        errorRows: 1,
+        checkpointRow: 40,
+        errors: JSON.stringify([
+          { row: 3, field: 'amount', message: 'Invalid' },
+        ]),
+        status: 'processing',
+      });
+
+      const result = await service.getResumeState('import-job-1');
+
+      expect(result.checkpointRow).toBe(40);
+      expect(result.errors).toHaveLength(1);
+      expect(result.filePath).toBe('/tmp/recipients.csv');
+    });
+
+    it('should detect an already imported row', async () => {
+      (prismaService.claim.findFirst as jest.Mock).mockResolvedValue({
+        id: 'claim-1',
+      });
+
+      await expect(service.hasImportedRow('import-job-1', 2)).resolves.toBe(
+        true,
+      );
+    });
+
+    it('should cancel a pending job and remove it from the queue', async () => {
+      const queuedJob = { remove: jest.fn().mockResolvedValue(undefined) };
+      mockQueue.getJob.mockResolvedValue(queuedJob);
+      (prismaService.importJob.findUnique as jest.Mock)
+        .mockResolvedValueOnce({
+          id: 'import-job-1',
+          status: 'pending',
+          processedRows: 10,
+          errorRows: 2,
+          checkpointRow: 10,
+        })
+        .mockResolvedValueOnce({
+          id: 'import-job-1',
+          campaignId: 'campaign-1',
+          fileName: 'recipients.csv',
+          filePath: '/tmp/recipients.csv',
+          totalRows: 100,
+          processedRows: 10,
+          errorRows: 2,
+          checkpointRow: 10,
+          errors: null,
+          reportUrl: null,
+          status: 'cancelled',
+          startedAt: null,
+          completedAt: new Date(),
+          cancelledAt: new Date(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+
+      const result = await service.cancelJob('import-job-1');
+
+      expect(queuedJob.remove).toHaveBeenCalled();
       expect(prismaService.importJob.update).toHaveBeenCalledWith({
         where: { id: 'import-job-1' },
-        data: { status: 'processing' },
+        data: {
+          status: 'cancelled',
+          cancelledAt: expect.any(Date),
+          completedAt: expect.any(Date),
+        },
       });
+      expect(result.status).toBe('cancelled');
+    });
+
+    it('should requeue processing jobs with a stored file path on startup', async () => {
+      (prismaService.importJob.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'import-job-1',
+          campaignId: 'campaign-1',
+          fileName: 'recipients.csv',
+          filePath: '/tmp/recipients.csv',
+          totalRows: 100,
+        },
+      ]);
+
+      await service.resumeInterruptedJobs();
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'process-import',
+        {
+          jobId: 'import-job-1',
+          campaignId: 'campaign-1',
+          fileName: 'recipients.csv',
+          filePath: '/tmp/recipients.csv',
+          totalRows: 100,
+        },
+        { jobId: 'import-job-1' },
+      );
     });
   });
 

--- a/app/backend/src/recipient-import/dto/import-job-response.dto.ts
+++ b/app/backend/src/recipient-import/dto/import-job-response.dto.ts
@@ -24,6 +24,9 @@ export class ImportJobResponseDto implements ImportJobStatusResponse {
   @ApiProperty({ description: 'Number of rows that failed processing' })
   errorRows: number;
 
+  @ApiProperty({ description: 'Last durably checkpointed data row offset' })
+  checkpointRow: number;
+
   @ApiPropertyOptional({ description: 'Array of row-level errors' })
   errors: ImportError[] | null;
 
@@ -39,8 +42,14 @@ export class ImportJobResponseDto implements ImportJobStatusResponse {
   @ApiProperty({ description: 'Last update timestamp' })
   updatedAt: Date;
 
+  @ApiPropertyOptional({ description: 'Processing start timestamp' })
+  startedAt: Date | null;
+
   @ApiPropertyOptional({ description: 'Completion timestamp' })
   completedAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'Cancellation timestamp' })
+  cancelledAt: Date | null;
 
   @ApiProperty({
     description: 'Processing progress as a percentage (0–100)',

--- a/app/backend/src/recipient-import/interfaces/import-job.interface.ts
+++ b/app/backend/src/recipient-import/interfaces/import-job.interface.ts
@@ -36,11 +36,27 @@ export interface ImportJobStatusResponse {
   totalRows: number;
   processedRows: number;
   errorRows: number;
+  checkpointRow: number;
   errors: ImportError[] | null;
   reportUrl: string | null;
   fileName: string;
   createdAt: Date;
   updatedAt: Date;
+  startedAt: Date | null;
   completedAt: Date | null;
+  cancelledAt: Date | null;
   progress: number;
+}
+
+export interface ImportJobResumeState {
+  id: string;
+  status: ImportJobStatus;
+  campaignId: string;
+  fileName: string;
+  filePath: string | null;
+  totalRows: number;
+  processedRows: number;
+  errorRows: number;
+  checkpointRow: number;
+  errors: ImportError[];
 }

--- a/app/backend/src/recipient-import/recipient-import.controller.ts
+++ b/app/backend/src/recipient-import/recipient-import.controller.ts
@@ -123,6 +123,19 @@ export class RecipientImportController {
     return this.recipientImportService.getJobStatus(jobId);
   }
 
+  @Post(':jobId/cancel')
+  @ApiOperation({
+    summary: 'Cancel an import job',
+    description:
+      'Requests cancellation for a pending or running import job. Active processors observe cancellation between rows.',
+  })
+  @ApiOkResponse({ type: ImportJobResponseDto })
+  async cancelJob(
+    @Param('jobId') jobId: string,
+  ): Promise<ImportJobResponseDto> {
+    return this.recipientImportService.cancelJob(jobId);
+  }
+
   @Get(':jobId/report')
   @ApiOperation({
     summary: 'Download structured validation report (CSV)',

--- a/app/backend/src/recipient-import/recipient-import.processor.ts
+++ b/app/backend/src/recipient-import/recipient-import.processor.ts
@@ -28,22 +28,56 @@ export class RecipientImportProcessor extends WorkerHost {
         ` (${job.data.totalRows} rows from ${job.data.fileName})`,
     );
 
-    await this.recipientImportService.setJobProcessing(jobId);
+    const started = await this.recipientImportService.setJobProcessing(jobId);
+    if (!started) {
+      this.logger.log(`Import job ${jobId} was cancelled before processing`);
+      return;
+    }
 
-    const allErrors: ImportError[] = [];
-    let processedRows = 0;
-    let errorRows = 0;
+    const resumeState = await this.recipientImportService.getResumeState(jobId);
+    if (resumeState.status === 'cancelled') {
+      this.logger.log(`Import job ${jobId} was cancelled before processing`);
+      return;
+    }
+
+    const allErrors: ImportError[] = [...resumeState.errors];
+    let processedRows = resumeState.processedRows;
+    let errorRows = resumeState.errorRows;
+    const filePath = resumeState.filePath ?? job.data.filePath;
 
     try {
-      const fileContent = readFileSync(job.data.filePath, 'utf-8');
+      const fileContent = readFileSync(filePath, 'utf-8');
       const { headers, rows } =
         this.recipientImportService.parseCsv(fileContent);
 
-      for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      for (
+        let i = resumeState.checkpointRow;
+        i < rows.length;
+        i += BATCH_SIZE
+      ) {
         const batch = rows.slice(i, i + BATCH_SIZE);
 
         for (let j = 0; j < batch.length; j++) {
-          const rowIndex = i + j + 2; // +2 for 1-indexed + header row
+          if (
+            await this.recipientImportService.isCancellationRequested(jobId)
+          ) {
+            this.logger.log(
+              `Import job ${jobId} cancelled at row checkpoint ${processedRows}`,
+            );
+            return;
+          }
+
+          const rowIndex = i + j + 2;
+          const rowOffset = i + j + 1;
+          const alreadyImported =
+            await this.recipientImportService.hasImportedRow(jobId, rowIndex);
+
+          if (alreadyImported) {
+            processedRows = Math.max(processedRows, rowOffset);
+            await this.checkpoint(job, processedRows, errorRows, allErrors);
+            continue;
+          }
+
           const validation = this.recipientImportService.validateRow(
             batch[j],
             headers,
@@ -54,6 +88,7 @@ export class RecipientImportProcessor extends WorkerHost {
             allErrors.push(...validation.errors);
             errorRows++;
             processedRows++;
+            await this.checkpoint(job, processedRows, errorRows, allErrors);
             continue;
           }
 
@@ -63,11 +98,19 @@ export class RecipientImportProcessor extends WorkerHost {
               amount: validation.amount!,
               recipientRef: validation.recipientRef!,
               evidenceRef: validation.evidenceRef,
+              importJobId: jobId,
+              importRowNumber: rowIndex,
               tokenAddress:
                 'GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ5LKG3FZTSZ3NYNEJBBENSN',
             });
             processedRows++;
           } catch (error) {
+            if (this.isDuplicateImportedRow(error)) {
+              processedRows++;
+              await this.checkpoint(job, processedRows, errorRows, allErrors);
+              continue;
+            }
+
             allErrors.push({
               row: rowIndex,
               field: 'claim',
@@ -79,20 +122,9 @@ export class RecipientImportProcessor extends WorkerHost {
             errorRows++;
             processedRows++;
           }
+
+          await this.checkpoint(job, processedRows, errorRows, allErrors);
         }
-
-        await this.recipientImportService.updateJobProgress(
-          jobId,
-          processedRows,
-          errorRows,
-          allErrors,
-        );
-
-        await job.updateProgress({
-          processedRows,
-          errorRows,
-          totalRows: job.data.totalRows,
-        });
       }
 
       const reportUrl =
@@ -121,10 +153,52 @@ export class RecipientImportProcessor extends WorkerHost {
         errorRows,
         allErrors,
         null,
+        'failed',
       );
 
       throw error;
     }
+  }
+
+  private async checkpoint(
+    job: Job<ImportJobData, void, string>,
+    processedRows: number,
+    errorRows: number,
+    errors: ImportError[],
+  ): Promise<void> {
+    const jobId = job.id!;
+    await this.recipientImportService.updateJobProgress(
+      jobId,
+      processedRows,
+      errorRows,
+      errors,
+    );
+
+    await job.updateProgress({
+      processedRows,
+      errorRows,
+      totalRows: job.data.totalRows,
+    });
+  }
+
+  private isDuplicateImportedRow(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const maybePrismaError = error as {
+      code?: string;
+      meta?: { target?: string | string[] };
+    };
+    const target = maybePrismaError.meta?.target;
+
+    return (
+      maybePrismaError.code === 'P2002' &&
+      ((Array.isArray(target) &&
+        target.includes('importJobId') &&
+        target.includes('importRowNumber')) ||
+        target === 'Claim_importJobId_importRowNumber_key')
+    );
   }
 
   @OnWorkerEvent('completed')

--- a/app/backend/src/recipient-import/recipient-import.service.ts
+++ b/app/backend/src/recipient-import/recipient-import.service.ts
@@ -3,11 +3,13 @@ import {
   BadRequestException,
   NotFoundException,
   Logger,
+  OnModuleInit,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import {
   ImportError,
+  ImportJobResumeState,
   ImportJobStatusResponse,
 } from './interfaces/import-job.interface';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -16,7 +18,7 @@ import { Queue } from 'bullmq';
 const BATCH_SIZE = 100;
 
 @Injectable()
-export class RecipientImportService {
+export class RecipientImportService implements OnModuleInit {
   private readonly logger = new Logger(RecipientImportService.name);
 
   constructor(
@@ -25,6 +27,10 @@ export class RecipientImportService {
     @InjectQueue('recipient-import')
     private readonly recipientImportQueue: Queue,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.resumeInterruptedJobs();
+  }
 
   async createJob(
     campaignId: string,
@@ -47,6 +53,7 @@ export class RecipientImportService {
       data: {
         campaignId,
         fileName,
+        filePath,
         totalRows,
         status: 'pending',
       },
@@ -95,14 +102,7 @@ export class RecipientImportService {
         ? Math.round((job.processedRows / job.totalRows) * 100)
         : 0;
 
-    let errors: ImportError[] | null = null;
-    if (job.errors) {
-      try {
-        errors = JSON.parse(job.errors) as ImportError[];
-      } catch {
-        errors = null;
-      }
-    }
+    const parsedErrors = this.parseErrors(job.errors);
 
     return {
       id: job.id,
@@ -111,12 +111,15 @@ export class RecipientImportService {
       totalRows: job.totalRows,
       processedRows: job.processedRows,
       errorRows: job.errorRows,
-      errors,
+      checkpointRow: job.checkpointRow,
+      errors: parsedErrors.length > 0 ? parsedErrors : null,
       reportUrl: job.reportUrl,
       fileName: job.fileName,
       createdAt: job.createdAt,
       updatedAt: job.updatedAt,
+      startedAt: job.startedAt,
       completedAt: job.completedAt,
+      cancelledAt: job.cancelledAt,
       progress,
     };
   }
@@ -132,6 +135,7 @@ export class RecipientImportService {
       data: {
         processedRows,
         errorRows,
+        checkpointRow: processedRows,
         errors: errors.length > 0 ? JSON.stringify(errors) : null,
       },
     });
@@ -143,8 +147,9 @@ export class RecipientImportService {
     errorRows: number,
     errors: ImportError[],
     reportUrl: string | null,
+    statusOverride?: 'completed' | 'failed',
   ): Promise<void> {
-    const status = errorRows > 0 ? 'failed' : 'completed';
+    const status = statusOverride ?? (errorRows > 0 ? 'failed' : 'completed');
 
     await this.prisma.importJob.update({
       where: { id: jobId },
@@ -152,6 +157,7 @@ export class RecipientImportService {
         status,
         processedRows,
         errorRows,
+        checkpointRow: processedRows,
         errors: errors.length > 0 ? JSON.stringify(errors) : null,
         reportUrl,
         completedAt: new Date(),
@@ -171,11 +177,118 @@ export class RecipientImportService {
     );
   }
 
-  async setJobProcessing(jobId: string): Promise<void> {
-    await this.prisma.importJob.update({
-      where: { id: jobId },
-      data: { status: 'processing' },
+  async setJobProcessing(jobId: string): Promise<boolean> {
+    const result = await this.prisma.importJob.updateMany({
+      where: { id: jobId, status: { not: 'cancelled' } },
+      data: { status: 'processing', startedAt: new Date() },
     });
+
+    return result.count > 0;
+  }
+
+  async getResumeState(jobId: string): Promise<ImportJobResumeState> {
+    const job = await this.prisma.importJob.findUnique({
+      where: { id: jobId },
+    });
+    if (!job) {
+      throw new NotFoundException(`Import job ${jobId} not found`);
+    }
+
+    return {
+      id: job.id,
+      status: job.status,
+      campaignId: job.campaignId,
+      fileName: job.fileName,
+      filePath: job.filePath,
+      totalRows: job.totalRows,
+      processedRows: job.processedRows,
+      errorRows: job.errorRows,
+      checkpointRow: job.checkpointRow,
+      errors: this.parseErrors(job.errors),
+    };
+  }
+
+  async hasImportedRow(jobId: string, rowNumber: number): Promise<boolean> {
+    const existing = await this.prisma.claim.findFirst({
+      where: { importJobId: jobId, importRowNumber: rowNumber },
+      select: { id: true },
+    });
+    return !!existing;
+  }
+
+  async isCancellationRequested(jobId: string): Promise<boolean> {
+    const job = await this.prisma.importJob.findUnique({
+      where: { id: jobId },
+      select: { status: true },
+    });
+    return job?.status === 'cancelled';
+  }
+
+  async cancelJob(jobId: string): Promise<ImportJobStatusResponse> {
+    const job = await this.prisma.importJob.findUnique({
+      where: { id: jobId },
+    });
+    if (!job) {
+      throw new NotFoundException(`Import job ${jobId} not found`);
+    }
+
+    if (!['completed', 'failed', 'cancelled'].includes(job.status)) {
+      const queuedJob = await this.recipientImportQueue.getJob(jobId);
+      if (queuedJob) {
+        try {
+          await queuedJob.remove();
+        } catch {
+          // Active jobs cannot be removed; the processor checks cancellation before each row.
+        }
+      }
+
+      await this.prisma.importJob.update({
+        where: { id: jobId },
+        data: {
+          status: 'cancelled',
+          cancelledAt: new Date(),
+          completedAt: new Date(),
+        },
+      });
+
+      await this.auditService.record({
+        actorId: 'system',
+        entity: 'ImportJob',
+        entityId: jobId,
+        action: 'cancelled',
+        metadata: {
+          processedRows: job.processedRows,
+          errorRows: job.errorRows,
+          checkpointRow: job.checkpointRow,
+        },
+      });
+    }
+
+    return this.getJobStatus(jobId);
+  }
+
+  async resumeInterruptedJobs(): Promise<void> {
+    const interruptedJobs = await this.prisma.importJob.findMany({
+      where: { status: 'processing' },
+    });
+
+    for (const job of interruptedJobs) {
+      if (!job.filePath) {
+        continue;
+      }
+
+      await this.recipientImportQueue.add(
+        'process-import',
+        {
+          jobId: job.id,
+          campaignId: job.campaignId,
+          fileName: job.fileName,
+          filePath: job.filePath,
+          totalRows: job.totalRows,
+        },
+        { jobId: job.id },
+      );
+    }
   }
 
   parseCsv(content: string): { headers: string[]; rows: string[][] } {
@@ -299,6 +412,18 @@ export class RecipientImportService {
     return result;
   }
 
+  private parseErrors(rawErrors: string | null): ImportError[] {
+    if (!rawErrors) {
+      return [];
+    }
+
+    try {
+      return JSON.parse(rawErrors) as ImportError[];
+    } catch {
+      return [];
+    }
+  }
+
   getBatchSize(): number {
     return BATCH_SIZE;
   }
@@ -312,14 +437,7 @@ export class RecipientImportService {
       throw new NotFoundException(`Import job ${jobId} not found`);
     }
 
-    let errors: ImportError[] = [];
-    if (job.errors) {
-      try {
-        errors = JSON.parse(job.errors) as ImportError[];
-      } catch {
-        errors = [];
-      }
-    }
+    const errors = this.parseErrors(job.errors);
 
     if (errors.length === 0) {
       return 'row,field,message,value\nNo errors found for this import.';


### PR DESCRIPTION
## Overview

Adds resumable recipient import jobs with durable row checkpoints, live progress fields, row-level idempotency, and cancellation support.

## Related Issue

Closes #950

## Changes

- Persist import job file path, checkpoint row, start/cancel timestamps, and `cancelled` status.
- Requeue interrupted `processing` import jobs on backend startup.
- Checkpoint progress after each row and expose `processedRows`, `totalRows`, `errorRows`, `checkpointRow`, and progress percentage while jobs run.
- Track `importJobId` and `importRowNumber` on created claims with a unique constraint to prevent duplicate row application after restart.
- Add `POST /recipient-import/:jobId/cancel` and cancellation checks between rows.
- Add service and processor tests for resume, idempotent replay, observable progress, and cancellation.

## Verification Results

- `node_modules\.bin\jest.cmd src/recipient-import/__tests__/recipient-import.service.spec.ts src/recipient-import/__tests__/recipient-import.processor.spec.ts --runInBand` — passed, 29 tests.
- `node_modules\.bin\eslint.cmd src/recipient-import/recipient-import.service.ts src/recipient-import/recipient-import.processor.ts src/recipient-import/recipient-import.controller.ts src/recipient-import/interfaces/import-job.interface.ts src/recipient-import/dto/import-job-response.dto.ts src/recipient-import/__tests__/recipient-import.service.spec.ts src/recipient-import/__tests__/recipient-import.processor.spec.ts src/claims/dto/create-claim.dto.ts src/claims/claims.service.ts` — passed with existing unsafe-any warnings in `claims.service.ts`.
- `npx.cmd prisma validate --schema prisma/schema.prisma` — passed.
- `node_modules\.bin\nest.cmd build` — passed.

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Import jobs checkpoint progress and resume from last checkpoint after restart | Done |
| Resuming never double-applies previously imported rows | Done |
| Progress processed/total/error count observable while job runs | Done |
| Cancellation stops promptly and leaves consistent state | Done |
| Tests cover interrupt/resume and cancellation | Done |
