### PR TITLE
feat(onchain): support package recipient reassignment

### DIFF
--- a/app/onchain/contracts/aid_escrow/EVENTS.md
+++ b/app/onchain/contracts/aid_escrow/EVENTS.md
@@ -33,6 +33,7 @@ section using the `#[contractevent]` derive.
 | `package_created`         | `create_package`    | A single aid package is created (funds locked).        |
 | `package_created` (xN)    | batch create        | One per package created in a batch (see below).        |
 | `batch_created_event`     | batch create        | Summary event for a batch creation.                    |
+| `package_reassigned`      | `reassign_package`  | Admin changes an unclaimed package recipient.         |
 | `package_claimed`         | claim path          | Recipient claims a package (incl. Merkle-proof claim). |
 | `package_disbursed`       | `disburse`          | Admin disburses a package to its recipient.            |
 | `package_revoked`         | `revoke`            | Admin revokes a `Created` package (funds unlocked).    |
@@ -77,6 +78,7 @@ Pool / administrative events:
 | `ActionUnpausedEvent`   | `admin: Address`, `action: Symbol`                                        |
 | `CampaignPausedEvent`   | `admin: Address`, `campaign_ref: String`                                  |
 | `CampaignUnpausedEvent` | `admin: Address`, `campaign_ref: String`                                  |
+| `PackageReassigned`     | `package_id: u64`, `previous_recipient: Address`, `new_recipient: Address`, `actor: Address`, `timestamp: u64` |
 
 ## Identifier stability (audit)
 

--- a/app/onchain/contracts/aid_escrow/README.md
+++ b/app/onchain/contracts/aid_escrow/README.md
@@ -60,6 +60,7 @@ expires and is refunded.
 | `create_package(env, operator, id, recipient, amount, token, expires_at)` | Admin / Distributor | Creates a single aid package with a specific ID. Locks funds from the available pool. |
 | `batch_create_packages(env, operator, recipients, amounts, token, expires_in)` | Admin / Distributor | Creates multiple packages in one transaction using auto-incrementing IDs. |
 | `claim(env, id)` | Recipient | Recipient claims the package. Transfers tokens to recipient and marks package as claimed. |
+| `reassign_package(env, package_id, new_recipient)` | Admin | Reassigns an unclaimed, unexpired package while preserving its ID and history. |
 | `disburse(env, id)` | Admin | Admin manually disburses a package to its recipient. |
 | `revoke(env, id)` | Admin | Admin revokes a package, returning funds to the surplus pool. |
 | `refund(env, id)` | Admin | Refunds an expired or cancelled package to the admin. |
@@ -157,6 +158,7 @@ All state-changing operations emit events with stable topics for indexer consump
 - `EscrowFunded` — pool funded
 - `PackageCreated` — package created
 - `PackageClaimed` — recipient claimed
+- `PackageReassigned` — package recipient changed by the admin
 - `PackageDisbursed` — admin disbursed
 - `PackageRevoked` — admin revoked
 - `PackageRefunded` — admin refunded

--- a/app/onchain/contracts/aid_escrow/src/lib.rs
+++ b/app/onchain/contracts/aid_escrow/src/lib.rs
@@ -179,6 +179,15 @@ pub struct PackageCreated {
 }
 
 #[contractevent]
+pub struct PackageReassigned {
+    pub package_id: u64,
+    pub previous_recipient: Address,
+    pub new_recipient: Address,
+    pub actor: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
 pub struct PackageClaimed {
     pub package_id: u64,
     pub recipient: Address,
@@ -1410,6 +1419,47 @@ impl AidEscrow {
             actor: admin.clone(),
             timestamp,
             receipt_hash,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Admin reassigns an unclaimed package to a new recipient.
+    pub fn reassign_package(
+        env: Env,
+        package_id: u64,
+        new_recipient: Address,
+    ) -> Result<(), Error> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let key = crate::keys::package_key(package_id);
+        let mut package: Package = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PackageNotFound)?;
+
+        if package.status != PackageStatus::Created {
+            return Err(Error::PackageNotActive);
+        }
+
+        let now = env.ledger().timestamp();
+        if package.expires_at > 0 && now > package.expires_at {
+            return Err(Error::PackageExpired);
+        }
+
+        let previous_recipient = package.recipient.clone();
+        package.recipient = new_recipient.clone();
+        env.storage().persistent().set(&key, &package);
+
+        PackageReassigned {
+            package_id,
+            previous_recipient,
+            new_recipient,
+            actor: admin,
+            timestamp: now,
         }
         .publish(&env);
 

--- a/app/onchain/contracts/aid_escrow/tests/events.rs
+++ b/app/onchain/contracts/aid_escrow/tests/events.rs
@@ -153,6 +153,44 @@ fn test_package_created_event() {
 }
 
 #[test]
+fn test_package_reassigned_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let previous_recipient = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let (token_client, token_admin_client) = setup_token(&env, &admin);
+
+    let contract_id = env.register(AidEscrow, ());
+    let client = AidEscrowClient::new(&env, &contract_id);
+    client.init(&admin);
+    token_admin_client.mint(&admin, &UNIT);
+    client.fund(&token_client.address, &admin, &UNIT);
+    client.create_package(
+        &admin,
+        &7,
+        &previous_recipient,
+        &UNIT,
+        &token_client.address,
+        &0,
+        &Map::new(&env),
+    );
+
+    client.reassign_package(&7, &new_recipient);
+
+    let data = last_event_data(&env, &contract_id, "package_reassigned");
+    assert_eq!(data_u64(&env, &data, "package_id"), 7);
+    assert_eq!(
+        data_address(&env, &data, "previous_recipient"),
+        previous_recipient
+    );
+    assert_eq!(data_address(&env, &data, "new_recipient"), new_recipient);
+    assert_eq!(data_address(&env, &data, "actor"), admin);
+    assert_field_exists(&env, &data, "timestamp");
+}
+
+#[test]
 fn test_package_claimed_event() {
     let env = Env::default();
     env.mock_all_auths();

--- a/app/onchain/contracts/aid_escrow/tests/integration.rs
+++ b/app/onchain/contracts/aid_escrow/tests/integration.rs
@@ -94,6 +94,99 @@ fn test_multiple_packages() {
 }
 
 #[test]
+fn test_reassign_package_updates_recipient_and_counts() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let old_recipient = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let (token_client, token_admin_client) = setup_token(&env, &Address::generate(&env));
+    let client = AidEscrowClient::new(&env, &env.register(AidEscrow, ()));
+    client.init(&admin);
+
+    token_admin_client.mint(&admin, &UNIT);
+    client.fund(&token_client.address, &admin, &UNIT);
+    client.create_package(
+        &admin,
+        &1,
+        &old_recipient,
+        &UNIT,
+        &token_client.address,
+        &0,
+        &Map::new(&env),
+    );
+
+    client.reassign_package(&1, &new_recipient);
+
+    assert_eq!(client.get_package(&1).recipient, new_recipient);
+    assert_eq!(client.get_recipient_package_count(&old_recipient), 0);
+    assert_eq!(client.get_recipient_package_count(&new_recipient), 1);
+}
+
+#[test]
+fn test_reassign_package_rejects_claimed_revoked_and_expired_packages() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let replacement = Address::generate(&env);
+    let (token_client, token_admin_client) = setup_token(&env, &Address::generate(&env));
+    let client = AidEscrowClient::new(&env, &env.register(AidEscrow, ()));
+    client.init(&admin);
+
+    token_admin_client.mint(&admin, &(3 * UNIT));
+    client.fund(&token_client.address, &admin, &(3 * UNIT));
+
+    client.create_package(
+        &admin,
+        &1,
+        &recipient,
+        &UNIT,
+        &token_client.address,
+        &0,
+        &Map::new(&env),
+    );
+    client.claim(&1);
+    assert_eq!(
+        client.try_reassign_package(&1, &replacement),
+        Err(Ok(Error::PackageNotActive))
+    );
+
+    client.create_package(
+        &admin,
+        &2,
+        &recipient,
+        &UNIT,
+        &token_client.address,
+        &0,
+        &Map::new(&env),
+    );
+    client.revoke(&2);
+    assert_eq!(
+        client.try_reassign_package(&2, &replacement),
+        Err(Ok(Error::PackageNotActive))
+    );
+
+    let expires_at = env.ledger().timestamp() + 100;
+    client.create_package(
+        &admin,
+        &3,
+        &recipient,
+        &UNIT,
+        &token_client.address,
+        &expires_at,
+        &Map::new(&env),
+    );
+    env.ledger().set_timestamp(expires_at + 1);
+    assert_eq!(
+        client.try_reassign_package(&3, &replacement),
+        Err(Ok(Error::PackageExpired))
+    );
+}
+
+#[test]
 fn test_error_cases() {
     let env = Env::default();
     env.mock_all_auths();

--- a/docs/pr-package-recipient-reassignment.md
+++ b/docs/pr-package-recipient-reassignment.md
@@ -1,0 +1,58 @@
+# Pull Request: Reassign Package Recipient
+
+## What changed
+
+- Added the admin-only `reassign_package` entry point to the Soroban `aid_escrow` contract.
+- Restricted reassignment to active, unclaimed, unexpired packages.
+- Preserved the package ID, amount, token, metadata, and lifecycle timestamps.
+- Added the `package_reassigned` event containing the previous and new recipients.
+- Added integration coverage for recipient counts and rejected claimed, revoked, and expired states.
+- Added event assertions and updated the contract API and event documentation.
+
+## How to run locally
+
+From the repository root:
+
+```powershell
+Set-Location app/onchain
+cargo test -p aid_escrow
+```
+
+Recommended checks:
+
+```powershell
+cargo fmt --all -- --check
+cargo clippy -p aid_escrow --all-targets -- -D warnings
+cargo check -p aid_escrow --tests
+```
+
+## Test logs
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo check -p aid_escrow --tests`: passed with the installed GNU Rust toolchain.
+- `git diff --check`: passed.
+- `cargo test -p aid_escrow`: could not complete on this Windows environment because the pinned MSVC toolchain requires `link.exe`, which is not installed. The GNU linker alternative reached final linking but failed with `export ordinal too large`.
+
+## File tree excerpt
+
+```text
+docs/
+└── pr-package-recipient-reassignment.md
+app/onchain/contracts/aid_escrow/
+├── EVENTS.md
+├── README.md
+├── src/lib.rs
+└── tests/
+    ├── events.rs
+    └── integration.rs
+```
+
+## Checklist
+
+- [x] Code follows the on-chain Rust naming and formatting conventions.
+- [x] Self-review completed.
+- [x] Documentation updated.
+- [x] Tests added for the new behavior and rejected lifecycle states.
+- [x] Formatting and compile-level checks pass.
+- [ ] Full `cargo test` execution passes locally; blocked by the missing Windows linker described above.
+- [ ] Closes `#<issue_id>`; no GitHub issue number was provided for this task.


### PR DESCRIPTION
# Pull Request: Reassign Package Recipient

## What changed

- Added the admin-only `reassign_package` entry point to the Soroban `aid_escrow` contract.
- Restricted reassignment to active, unclaimed, unexpired packages.
- Preserved the package ID, amount, token, metadata, and lifecycle timestamps.
- Added the `package_reassigned` event containing the previous and new recipients.
- Added integration coverage for recipient counts and rejected claimed, revoked, and expired states.
- Added event assertions and updated the contract API and event documentation.

## How to run locally

From the repository root:

```powershell
Set-Location app/onchain
cargo test -p aid_escrow
```

Recommended checks:

```powershell
cargo fmt --all -- --check
cargo clippy -p aid_escrow --all-targets -- -D warnings
cargo check -p aid_escrow --tests
```

## Test logs

- `cargo fmt --all -- --check`: passed.
- `cargo check -p aid_escrow --tests`: passed with the installed GNU Rust toolchain.
- `git diff --check`: passed.
- `cargo test -p aid_escrow`: could not complete on this Windows environment because the pinned MSVC toolchain requires `link.exe`, which is not installed. The GNU linker alternative reached final linking but failed with `export ordinal too large`.

## File tree excerpt

```text
docs/
└── pr-package-recipient-reassignment.md
app/onchain/contracts/aid_escrow/
├── EVENTS.md
├── README.md
├── src/lib.rs
└── tests/
    ├── events.rs
    └── integration.rs
```

## Checklist

- [x] Code follows the on-chain Rust naming and formatting conventions.
- [x] Self-review completed.
- [x] Documentation updated.
- [x] Tests added for the new behavior and rejected lifecycle states.
- [x] Formatting and compile-level checks pass.
- [ ] Full `cargo test` execution passes locally; blocked by the missing Windows linker described above.
- [ ] Closes `#<issue_id>`; no GitHub issue number was provided for this task.

Closes #972