### PR TITLE
ci: add prisma schema/migration drift check and document workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -52,6 +52,29 @@ jobs:
         env:
           DATABASE_URL: postgresql://soter:soter@localhost:5432/soter_test
 
+      - name: Check for Prisma schema/migration drift
+        working-directory: app/backend
+        run: |
+          set -euo pipefail
+          # Ensure a dedicated, empty shadow database exists so `prisma migrate diff
+          # --from-migrations` has a scratch DB to materialize the migration history.
+          # This is idempotent — it only issues CREATE DATABASE when it is missing.
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
+            SELECT 'CREATE DATABASE soter_shadow'
+            WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'soter_shadow')\gexec
+          SQL
+
+          # Fail the build whenever the migrations history and the Prisma schema
+          # have diverged (exit code 2). schema/prisma.schema is the source of
+          # truth; contributors must add a migration, not edit deployed databases.
+          npx prisma migrate diff \
+            --from-migrations prisma/migrations \
+            --to-schema prisma/schema.prisma \
+            --exit-code
+        env:
+          DATABASE_URL: postgresql://soter:soter@localhost:5432/soter_test
+          SHADOW_DATABASE_URL: postgresql://soter:soter@localhost:5432/soter_shadow
+
       - name: Lint
         run: pnpm --filter backend run lint
 

--- a/app/backend/prisma.config.ts
+++ b/app/backend/prisma.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     url:
       process.env.DATABASE_URL ||
       'postgresql://soter_user:soter123@localhost:5432/soter_db',
+    shadowDatabaseUrl:
+      process.env.SHADOW_DATABASE_URL ||
+      'postgresql://soter_user:soter123@localhost:5432/soter_shadow',
   },
 });

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,108 @@
+# Database Migrations
+
+Soter uses **Prisma** with a PostgreSQL backend. `app/backend/prisma/schema.prisma` is the
+single source of truth for the data model, and `app/backend/prisma/migrations/` holds the
+ordered, applied migration history.
+
+The backend CI (`.github/workflows/backend-ci.yml`) runs a **drift check** that fails the
+build whenever the migration history and the schema diverge. This keeps the schema and the
+migrations in lockstep so a fresh database built only from migrations matches what the code
+expects.
+
+## How the drift check works
+
+```bash
+# from app/backend
+npx prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema prisma/schema.prisma \
+  --exit-code
+```
+
+- `--from-migrations` materializes the full schema produced by replaying every migration in
+  a scratch (shadow) database.
+- `--to-schema` supplies the desired state from `schema.prisma`.
+- `--exit-code` makes the command return a non-zero exit code when the two differ, which
+  fails the CI job.
+
+The shadow database URL is configured in `app/backend/prisma.config.ts` via
+`SHADOW_DATABASE_URL` (defaulting to `soter_shadow`). Prisma requires the shadow database to
+exist, so the CI step creates it idempotently before running the diff.
+
+## When you change the data model
+
+Never edit a committed migration or an already-deployed database directly. The schema is the
+source of truth; any change to it must be paired with a new migration.
+
+### 1. Edit the schema
+
+Update `app/backend/prisma/schema.prisma` (e.g. add a model, column, index, or enum value).
+
+### 2. Create a migration
+
+With a Postgres instance available locally, run:
+
+```bash
+# from app/backend, with DATABASE_URL set to your local database
+DATABASE_URL=postgresql://soter_user:soter123@localhost:5432/soter_db \
+  npx prisma migrate dev --name <short_description>
+```
+
+This generates a new migration directory under `app/backend/prisma/migrations/` (for example
+`20260827000000_add_foo/`) and applies it to your local database.
+
+> `prisma migrate dev` allows you to apply the migration to a development database and is
+> fine for local work. Deployment and CI apply it with `prisma migrate deploy`, which never
+> modifies the schema on its own.
+
+### 3. Verify the drift check passes
+
+Confirm the new migration reconciles the schema exactly:
+
+```bash
+# from app/backend
+SHADOW_DATABASE_URL=postgresql://soter_user:soter123@localhost:5432/soter_shadow \
+  npx prisma migrate diff \
+    --from-migrations prisma/migrations \
+    --to-schema prisma/schema.prisma \
+    --exit-code
+```
+
+`No difference detected` (exit code 0) means the schema and migrations are in sync.
+
+### 4. Commit
+
+Commit the schema change together with the generated migration directory so `migrate deploy`
+can reproduce the schema on a fresh database. If you forget a migration, CI's drift check
+will fail and flag it for you.
+
+## Resolving drift
+
+If the drift check reports a difference you did not intend, inspect the diff summary:
+
+```bash
+# from app/backend
+SHADOW_DATABASE_URL=postgresql://soter_user:soter123@localhost:5432/soter_shadow \
+  npx prisma migrate diff \
+    --from-migrations prisma/migrations \
+    --to-schema prisma/schema.prisma
+```
+
+The output lists the tables/columns Prisma would need to add or change. Either:
+
+- undo the unintended schema edit, or
+- create a migration that captures the intended change (step 2 above).
+
+## Running the backend e2e suite against a fresh database
+
+CI does this automatically, but locally you can reproduce it:
+
+```bash
+# create a fresh database, then
+DATABASE_URL=postgresql://soter_user:soter123@localhost:5432/<fresh_db> \
+  npx prisma migrate deploy
+pnpm --filter backend run test:e2e
+```
+
+Because the drift check guarantees migrations reproduce the schema, a database created only
+from migrations passes the e2e suite.


### PR DESCRIPTION
## Summary

Add a CI drift check that fails the backend build whenever `app/backend/prisma/schema.prisma` and the migration history in `app/backend/prisma/migrations/` diverge, reconcile any existing gap, and document the contributor workflow for adding migrations.

## Changes

### CI drift check (`.github/workflows/backend-ci.yml`)
Add a **"Check for Prisma schema/migration drift"** step, placed right after `prisma migrate deploy`. It runs:

```bash
npx prisma migrate diff \
  --from-migrations prisma/migrations \
  --to-schema prisma/schema.prisma \
  --exit-code
```

- `--from-migrations` replays the migration history into a scratch (shadow) database.
- `--to-schema` supplies the desired state from `schema.prisma`.
- `--exit-code` returns a non-zero code when they differ, failing the job (verified: returns `2` on mismatch, `0` when in sync).
- The step idempotently creates a dedicated `soter_shadow` database before running, since Prisma 7 requires an explicit existing shadow database for `--from-migrations`.

### Prisma shadow database config (`app/backend/prisma.config.ts`)
Add `datasource.shadowDatabaseUrl`, read from `SHADOW_DATABASE_URL` (defaulting to `soter_shadow`). This is required for `prisma migrate diff --from-migrations` to work.

### Reconciliation
The schema and migrations are currently **in sync** — verified both ways:
- `prisma migrate diff --from-migrations --to-schema` -> `No difference detected (exit 0)`
- A fresh database built only from migrations (`migrate deploy`) then diffed against the schema -> `No difference detected`

### Documentation (`docs/database-migrations.md`)
New doc covering:
- How the drift check works and why it fails the build
- The contributor workflow for changing the data model (edit schema -> `prisma migrate dev --name <desc>` -> verify with `migrate diff -> commit schema + migration together)
- How to resolve drift and how to run the e2e suite against a fresh database

## Acceptance criteria

- [x] CI runs a drift check (`prisma migrate diff`) and fails on divergence
- [x] Existing drift reconciled (verified in sync; check enforces it going forward)
- [x] A fresh database created only from migrations matches the schema (verified)
- [x] Contributor workflow for adding migrations is documented

Closes #943