### PR TITLE
feat(cache): bounded LRU eviction for aidCache and taskCache (#928)

### DIFF
--- a/app/mobile/src/__tests__/cacheEviction.test.ts
+++ b/app/mobile/src/__tests__/cacheEviction.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the bounded LRU cache eviction utility (cacheEviction.ts).
+ *
+ * Test framework: Jest (jest-expo preset).
+ * AsyncStorage is mocked via the global setup in jest.setup.ts.
+ * The sync-queue module is mocked here to control which entry ids appear
+ * as pending/conflict without needing a full queue hydration.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  writeBoundedCache,
+  readBoundedCache,
+  getCacheSize,
+  clearSyncedEntries,
+  clearAllEntries,
+  WithMeta,
+} from '../services/cacheEviction';
+
+// ─── Mock syncQueue ────────────────────────────────────────────────────────
+
+jest.mock('../services/syncQueue', () => ({
+  getSyncQueueState: jest.fn(),
+}));
+
+import { getSyncQueueState } from '../services/syncQueue';
+const mockGetSyncQueueState = getSyncQueueState as jest.Mock;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+interface Item {
+  id: string;
+  value: string;
+}
+
+const STORAGE_KEY = '@test/cache';
+const TIMESTAMP_KEY = '@test/cache_ts';
+
+/** Build a queue state that marks the given ids as pending. */
+function pendingQueueState(pendingIds: string[], conflictIds: string[] = []) {
+  const items = [
+    ...pendingIds.map((id) => ({
+      id: `action-${id}`,
+      type: 'status-refresh',
+      payload: { aidId: id },
+      state: 'pending',
+      retryCount: 0,
+      maxRetries: 5,
+      nextRetryAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastError: null,
+    })),
+    ...conflictIds.map((id) => ({
+      id: `action-conflict-${id}`,
+      type: 'status-refresh',
+      payload: { aidId: id },
+      state: 'conflict',
+      retryCount: 1,
+      maxRetries: 5,
+      nextRetryAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastError: 'conflict',
+    })),
+  ];
+  return { items, isSyncing: false, lastSyncAt: null, lastSyncError: null };
+}
+
+/** Write entries directly to AsyncStorage with controlled metadata (bypass writeBoundedCache). */
+async function seedCacheWithMeta(entries: WithMeta<Item>[]) {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+}
+
+beforeEach(async () => {
+  // Clear the mock AsyncStorage before every test.
+  await AsyncStorage.clear();
+  mockGetSyncQueueState.mockResolvedValue(pendingQueueState([]));
+});
+
+// ─── 1. Eviction ordering ─────────────────────────────────────────────────
+
+describe('eviction ordering', () => {
+  it('evicts the least-recently-used synced entry first', async () => {
+    // 3 synced entries with different access times, max 2 entries.
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 3000, _syncStatus: 'synced' }, // most recent
+      { id: 'c', value: 'C', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const result = await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      // Re-write all three as "fresh data" with the same ids
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+    );
+
+    expect(result.evicted).toBe(1);
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    const ids = remaining!.map((e) => e.id).sort();
+    // 'a' (oldest) should be evicted; 'b' and 'c' should remain.
+    expect(ids).toEqual(['b', 'c']);
+  });
+
+  it('evicts multiple entries until under the limit, oldest first', async () => {
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+      { id: 'd', value: 'D', _lastAccessedAt: 4000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const result = await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+    );
+
+    expect(result.evicted).toBe(2);
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    const ids = remaining!.map((e) => e.id).sort();
+    // 'a' (ts 1000) and 'b' (ts 2000) evicted; 'c' and 'd' kept.
+    expect(ids).toEqual(['c', 'd']);
+  });
+});
+
+// ─── 2. Unsynced preservation ─────────────────────────────────────────────
+
+describe('unsynced preservation', () => {
+  it('never evicts pending entries even if they are the oldest', async () => {
+    // 'a' is oldest but pending — must not be evicted.
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState(['a']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'pending' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+    );
+
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    const ids = remaining!.map((e) => e.id);
+    expect(ids).toContain('a'); // unsynced, must survive
+    expect(ids).not.toContain('b'); // oldest synced, evicted
+    expect(ids).toContain('c');
+  });
+
+  it('never evicts conflict entries', async () => {
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState([], ['a']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 500, _syncStatus: 'conflict' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+    );
+
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    const ids = remaining!.map((e) => e.id);
+    expect(ids).toContain('a'); // conflict, must survive
+  });
+});
+
+// ─── 3. All-unsynced-at-capacity ─────────────────────────────────────────
+
+describe('all-unsynced-at-capacity', () => {
+  it('does not drop any data when all entries are unsynced', async () => {
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState(['a', 'b', 'c']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'pending' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'pending' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'pending' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const result = await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2, // maxEntries below current count
+    );
+
+    // No eviction should have happened.
+    expect(result.evicted).toBe(0);
+
+    // All three entries must still be present.
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    expect(remaining).toHaveLength(3);
+  });
+
+  it('sets atLimit true when at capacity with all unsynced entries', async () => {
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState(['a', 'b']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'pending' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'pending' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const result = await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+      0.8, // warningRatio — 80% of 2 = 1.6, floor = 1; 2 entries >= 1 → nearLimit
+    );
+
+    expect(result.atLimit).toBe(true);
+  });
+});
+
+// ─── 4. Manual clear ─────────────────────────────────────────────────────
+
+describe('clearSyncedEntries', () => {
+  it('removes synced entries and preserves unsynced entries', async () => {
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState(['b']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'pending' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const { cleared, preserved } = await clearSyncedEntries<Item>(STORAGE_KEY, TIMESTAMP_KEY);
+
+    expect(cleared).toBe(2);
+    expect(preserved).toBe(1);
+
+    const remaining = await readBoundedCache<Item>(STORAGE_KEY);
+    expect(remaining).toHaveLength(1);
+    expect(remaining![0].id).toBe('b');
+  });
+
+  it('returns cleared=all, preserved=0 when all entries are synced', async () => {
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const { cleared, preserved } = await clearSyncedEntries<Item>(STORAGE_KEY, TIMESTAMP_KEY);
+
+    expect(cleared).toBe(2);
+    expect(preserved).toBe(0);
+
+    // Cache should be fully cleared.
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeNull();
+  });
+});
+
+describe('clearAllEntries', () => {
+  it('removes all entries including unsynced ones', async () => {
+    mockGetSyncQueueState.mockResolvedValue(pendingQueueState(['a']));
+
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'pending' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    await clearAllEntries(STORAGE_KEY, TIMESTAMP_KEY);
+
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeNull();
+  });
+});
+
+// ─── 5. Size / count reporting ────────────────────────────────────────────
+
+describe('getCacheSize', () => {
+  it('returns entryCount=0 for an empty cache', async () => {
+    const size = await getCacheSize(STORAGE_KEY, 200);
+    expect(size.entryCount).toBe(0);
+    expect(size.nearLimit).toBe(false);
+  });
+
+  it('accurately counts entries after writes', async () => {
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const size = await getCacheSize(STORAGE_KEY, 200);
+    expect(size.entryCount).toBe(3);
+    expect(size.maxEntries).toBe(200);
+    expect(size.nearLimit).toBe(false);
+  });
+
+  it('reports nearLimit=true when usage >= 80% of maxEntries', async () => {
+    // 8 entries with maxEntries=10 → 80% → nearLimit true.
+    const entries: WithMeta<Item>[] = Array.from({ length: 8 }, (_, i) => ({
+      id: String(i),
+      value: String(i),
+      _lastAccessedAt: i * 1000,
+      _syncStatus: 'synced' as const,
+    }));
+    await seedCacheWithMeta(entries);
+
+    const size = await getCacheSize(STORAGE_KEY, 10);
+    expect(size.nearLimit).toBe(true);
+  });
+
+  it('reports nearLimit=false when usage < 80% of maxEntries', async () => {
+    // 5 entries with maxEntries=10 → 50% → nearLimit false.
+    const entries: WithMeta<Item>[] = Array.from({ length: 5 }, (_, i) => ({
+      id: String(i),
+      value: String(i),
+      _lastAccessedAt: i * 1000,
+      _syncStatus: 'synced' as const,
+    }));
+    await seedCacheWithMeta(entries);
+
+    const size = await getCacheSize(STORAGE_KEY, 10);
+    expect(size.nearLimit).toBe(false);
+  });
+
+  it('updates entryCount correctly after eviction', async () => {
+    // Start with 4 synced entries, max 2.
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'A', _lastAccessedAt: 1000, _syncStatus: 'synced' },
+      { id: 'b', value: 'B', _lastAccessedAt: 2000, _syncStatus: 'synced' },
+      { id: 'c', value: 'C', _lastAccessedAt: 3000, _syncStatus: 'synced' },
+      { id: 'd', value: 'D', _lastAccessedAt: 4000, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    await writeBoundedCache<Item>(
+      STORAGE_KEY,
+      entries.map(({ id, value }) => ({ id, value })),
+      2,
+    );
+
+    const size = await getCacheSize(STORAGE_KEY, 2);
+    expect(size.entryCount).toBe(2);
+  });
+});
+
+// ─── 6. readBoundedCache strips metadata from callers ────────────────────
+
+describe('readBoundedCache', () => {
+  it('strips _lastAccessedAt and _syncStatus from returned entries', async () => {
+    const entries: WithMeta<Item>[] = [
+      { id: 'a', value: 'Alpha', _lastAccessedAt: 9999, _syncStatus: 'synced' },
+    ];
+    await seedCacheWithMeta(entries);
+
+    const result = await readBoundedCache<Item>(STORAGE_KEY);
+    expect(result).not.toBeNull();
+    const entry = result![0] as Item & Partial<WithMeta<Item>>;
+    expect(entry._lastAccessedAt).toBeUndefined();
+    expect(entry._syncStatus).toBeUndefined();
+    expect(entry.id).toBe('a');
+    expect(entry.value).toBe('Alpha');
+  });
+
+  it('returns null for an empty cache', async () => {
+    const result = await readBoundedCache<Item>(STORAGE_KEY);
+    expect(result).toBeNull();
+  });
+});

--- a/app/mobile/src/screens/AidOverviewScreen.tsx
+++ b/app/mobile/src/screens/AidOverviewScreen.tsx
@@ -61,6 +61,8 @@ export const AidOverviewScreen: React.FC<Props> = ({ navigation }) => {
       setIsCached(false);
       await cacheAidList(fresh);
       setCachedAt(null);
+      // EvictionResult.atLimit is intentionally unused here — the settings
+      // screen surfaces the warning based on getCacheSize() instead.
     } catch {
       const cached = await loadCachedAidList();
       if (cached && cached.length > 0) {

--- a/app/mobile/src/screens/SettingsScreen.tsx
+++ b/app/mobile/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -18,6 +18,9 @@ import { useNotification } from '../contexts/NotificationContext';
 import { useSaverMode } from '../contexts/SaverModeContext';
 import { useCrashReporting } from '../contexts/CrashReportingContext';
 import { config } from '../config';
+import { getAidCacheSize, clearAidCache, AID_CACHE_MAX_ENTRIES } from '../services/aidCache';
+import { getTaskCacheSize, clearTaskCache, TASK_CACHE_MAX_ENTRIES } from '../services/taskCache';
+import { CacheSize } from '../services/cacheEviction';
 
 const STELLAR_LAB_FAUCET_URL = 'https://lab.stellar.org/account/fund';
 const STELLAR_FRIENDBOT_URL = 'https://friendbot-testnet.stellar.org';
@@ -38,6 +41,72 @@ export const SettingsScreen: React.FC = () => {
     enabled: crashReportingEnabled,
     toggle: toggleCrashReporting,
   } = useCrashReporting();
+
+  // ── Cache size state ────────────────────────────────────────────────────
+  const [aidCacheSize, setAidCacheSize] = useState<CacheSize | null>(null);
+  const [taskCacheSize, setTaskCacheSize] = useState<CacheSize | null>(null);
+
+  const refreshCacheSizes = useCallback(async () => {
+    const [aid, task] = await Promise.all([getAidCacheSize(), getTaskCacheSize()]);
+    setAidCacheSize(aid);
+    setTaskCacheSize(task);
+  }, []);
+
+  useEffect(() => {
+    void refreshCacheSizes();
+  }, [refreshCacheSizes]);
+
+  const handleClearAidCache = () => {
+    Alert.alert(
+      'Clear Aid Cache',
+      'This will remove synced aid entries from local storage. Any entries not yet synced to the server will be kept.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            const { cleared, preserved } = await clearAidCache();
+            await refreshCacheSizes();
+            if (preserved > 0) {
+              Alert.alert(
+                'Cache Cleared',
+                `Removed ${cleared} synced ${cleared === 1 ? 'entry' : 'entries'}. ${preserved} unsynced ${preserved === 1 ? 'entry was' : 'entries were'} kept.`,
+              );
+            } else {
+              Alert.alert('Cache Cleared', `Removed ${cleared} ${cleared === 1 ? 'entry' : 'entries'}.`);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleClearTaskCache = () => {
+    Alert.alert(
+      'Clear Task Cache',
+      'This will remove synced task entries from local storage. Any entries not yet synced to the server will be kept.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            const { cleared, preserved } = await clearTaskCache();
+            await refreshCacheSizes();
+            if (preserved > 0) {
+              Alert.alert(
+                'Cache Cleared',
+                `Removed ${cleared} synced ${cleared === 1 ? 'entry' : 'entries'}. ${preserved} unsynced ${preserved === 1 ? 'entry was' : 'entries were'} kept.`,
+              );
+            } else {
+              Alert.alert('Cache Cleared', `Removed ${cleared} ${cleared === 1 ? 'entry' : 'entries'}.`);
+            }
+          },
+        },
+      ],
+    );
+  };
 
   const handleNotificationToggle = async (value: boolean) => {
     if (value) {
@@ -305,6 +374,100 @@ export const SettingsScreen: React.FC = () => {
             accessibilityElementsHidden
           />
         </View>
+
+        {/* ── Storage section ─────────────────────────────────────────── */}
+        <Text
+          style={styles.sectionHeader}
+          accessibilityRole="header"
+        >
+          Storage
+        </Text>
+
+        {/* Aid cache row */}
+        <View
+          style={styles.cacheRow}
+          accessible
+          accessibilityLabel={
+            aidCacheSize
+              ? `Aid cache: ${aidCacheSize.entryCount} of ${aidCacheSize.maxEntries} entries`
+              : 'Aid cache: loading'
+          }
+        >
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle}>Aid Cache</Text>
+            <Text style={styles.rowSubtitle}>
+              {aidCacheSize
+                ? `${aidCacheSize.entryCount} / ${aidCacheSize.maxEntries} entries`
+                : 'Calculating…'}
+            </Text>
+          </View>
+          <Pressable
+            style={({ pressed }) => [styles.clearButton, pressed && styles.linkButtonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Clear aid cache"
+            accessibilityHint="Removes synced aid entries from local storage; unsynced entries are kept"
+            onPress={handleClearAidCache}
+          >
+            <Text style={styles.clearButtonText}>Clear</Text>
+          </Pressable>
+        </View>
+
+        {aidCacheSize?.nearLimit && (
+          <View
+            style={styles.warningBanner}
+            accessible
+            accessibilityRole="alert"
+            accessibilityLabel={`Aid cache is near its limit: ${aidCacheSize.entryCount} of ${AID_CACHE_MAX_ENTRIES} entries used`}
+          >
+            <Text style={styles.warningText}>
+              Aid cache is near its limit ({aidCacheSize.entryCount}/{AID_CACHE_MAX_ENTRIES}).
+              Old synced entries will be evicted automatically.
+            </Text>
+          </View>
+        )}
+
+        {/* Task cache row */}
+        <View
+          style={styles.cacheRow}
+          accessible
+          accessibilityLabel={
+            taskCacheSize
+              ? `Task cache: ${taskCacheSize.entryCount} of ${taskCacheSize.maxEntries} entries`
+              : 'Task cache: loading'
+          }
+        >
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle}>Task Cache</Text>
+            <Text style={styles.rowSubtitle}>
+              {taskCacheSize
+                ? `${taskCacheSize.entryCount} / ${taskCacheSize.maxEntries} entries`
+                : 'Calculating…'}
+            </Text>
+          </View>
+          <Pressable
+            style={({ pressed }) => [styles.clearButton, pressed && styles.linkButtonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Clear task cache"
+            accessibilityHint="Removes synced task entries from local storage; unsynced entries are kept"
+            onPress={handleClearTaskCache}
+          >
+            <Text style={styles.clearButtonText}>Clear</Text>
+          </Pressable>
+        </View>
+
+        {taskCacheSize?.nearLimit && (
+          <View
+            style={styles.warningBanner}
+            accessible
+            accessibilityRole="alert"
+            accessibilityLabel={`Task cache is near its limit: ${taskCacheSize.entryCount} of ${TASK_CACHE_MAX_ENTRIES} entries used`}
+          >
+            <Text style={styles.warningText}>
+              Task cache is near its limit ({taskCacheSize.entryCount}/{TASK_CACHE_MAX_ENTRIES}).
+              Old synced entries will be evicted automatically.
+            </Text>
+          </View>
+        )}
 
         {config.network === 'testnet' && (
           <>
@@ -582,5 +745,45 @@ const makeStyles = (colors: AppColors) =>
       color: colors.info,
       fontSize: 15,
       fontWeight: '700',
+    },
+    cacheRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      minHeight: 44,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: colors.border,
+      gap: 12,
+      marginBottom: 8,
+    },
+    clearButton: {
+      minHeight: 36,
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 8,
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    clearButtonText: {
+      color: colors.textPrimary,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    warningBanner: {
+      backgroundColor: colors.warningBg,
+      borderRadius: 10,
+      paddingHorizontal: 14,
+      paddingVertical: 10,
+      marginBottom: 8,
+    },
+    warningText: {
+      fontSize: 13,
+      color: colors.warning,
+      lineHeight: 18,
     },
   });

--- a/app/mobile/src/screens/TaskListScreen.tsx
+++ b/app/mobile/src/screens/TaskListScreen.tsx
@@ -64,6 +64,8 @@ export const TaskListScreen: React.FC<Props> = ({ navigation }) => {
       setIsCached(false);
       await cacheTaskList(fresh);
       setCachedAt(null);
+      // EvictionResult.atLimit is intentionally unused here — the settings
+      // screen surfaces the warning based on getCacheSize() instead.
     } catch {
       const cached = await loadCachedTaskList();
       if (cached && cached.length > 0) {

--- a/app/mobile/src/services/aidCache.ts
+++ b/app/mobile/src/services/aidCache.ts
@@ -1,30 +1,103 @@
+/**
+ * Aid package offline cache — bounded LRU with safe eviction.
+ *
+ * EVICTION POLICY (see cacheEviction.ts for full documentation)
+ * ─────────────────────────────────────────────────────────────
+ * • Maximum entries: AID_CACHE_MAX_ENTRIES (default 200, configurable via
+ *   EXPO_PUBLIC_AID_CACHE_MAX_ENTRIES environment variable).
+ * • Eviction order: Least-Recently-Used (by _lastAccessedAt timestamp) among
+ *   entries whose _syncStatus is 'synced'.
+ * • Entries with _syncStatus 'pending' or 'conflict' are NEVER evicted — they
+ *   represent unsynced local changes that must reach the server first.
+ * • If at capacity and all entries are unsynced, no data is dropped; the caller
+ *   receives { atLimit: true } which the UI uses to surface a warning.
+ * • A warning threshold fires at 80 % of the limit (configurable).
+ */
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AidPackage } from './api';
+import {
+  writeBoundedCache,
+  readBoundedCache,
+  getCacheSize,
+  clearSyncedEntries,
+  clearAllEntries,
+  CacheSize,
+  EvictionResult,
+} from './cacheEviction';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Maximum number of aid package entries to keep in the local cache.
+ * Override via EXPO_PUBLIC_AID_CACHE_MAX_ENTRIES at build time.
+ */
+export const AID_CACHE_MAX_ENTRIES: number = process.env.EXPO_PUBLIC_AID_CACHE_MAX_ENTRIES
+  ? parseInt(process.env.EXPO_PUBLIC_AID_CACHE_MAX_ENTRIES, 10)
+  : 200;
 
 const CACHE_KEY = '@soter/aid_overview';
 const CACHE_TIMESTAMP_KEY = '@soter/aid_overview_timestamp';
 
-/** Persist aid list to AsyncStorage */
-export const cacheAidList = async (data: AidPackage[]): Promise<void> => {
-  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Persist aid list to AsyncStorage.
+ *
+ * Runs the LRU eviction policy after writing.  Synced entries are evicted
+ * LRU-first; unsynced entries are never dropped.
+ *
+ * @returns EvictionResult — check `atLimit` to surface a capacity warning.
+ */
+export const cacheAidList = async (data: AidPackage[]): Promise<EvictionResult> => {
+  const result = await writeBoundedCache<AidPackage>(CACHE_KEY, data, AID_CACHE_MAX_ENTRIES);
   await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
+  return result;
 };
 
-/** Load cached aid list from AsyncStorage */
+/**
+ * Load cached aid list from AsyncStorage.
+ * Updates _lastAccessedAt on all entries (LRU tracking).
+ */
 export const loadCachedAidList = async (): Promise<AidPackage[] | null> => {
-  const raw = await AsyncStorage.getItem(CACHE_KEY);
-  if (!raw) return null;
-  return JSON.parse(raw) as AidPackage[];
+  return readBoundedCache<AidPackage>(CACHE_KEY);
 };
 
-/** Returns the ISO timestamp of the last successful cache write, or null */
+/**
+ * Returns the human-readable timestamp of the last successful cache write,
+ * or null if the cache has never been written.
+ */
 export const getCacheTimestamp = async (): Promise<string | null> => {
   const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
   if (!ts) return null;
   return new Date(parseInt(ts, 10)).toLocaleString();
 };
 
-/** Clear the cached aid list */
-export const clearAidCache = async (): Promise<void> => {
-  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
+/**
+ * Returns current cache size metrics for the settings UI.
+ * `nearLimit` is true when usage reaches 80 % of AID_CACHE_MAX_ENTRIES.
+ */
+export const getAidCacheSize = async (): Promise<CacheSize> => {
+  return getCacheSize(CACHE_KEY, AID_CACHE_MAX_ENTRIES);
+};
+
+/**
+ * Clear synced aid entries only.  Entries with pending/conflict sync state
+ * are preserved — they have not yet reached the server.
+ *
+ * @returns Counts of cleared and preserved entries.
+ */
+export const clearAidCache = async (): Promise<{ cleared: number; preserved: number }> => {
+  return clearSyncedEntries<AidPackage>(CACHE_KEY, CACHE_TIMESTAMP_KEY);
+};
+
+/**
+ * Force-clear ALL cached aid entries including any with unsynced changes.
+ *
+ * ⚠️  DESTRUCTIVE — call only from a separately-confirmed UI action.
+ *     Unsynced data will be permanently lost if this is called before the
+ *     sync queue has flushed those entries to the server.
+ */
+export const forceclearAidCache = async (): Promise<void> => {
+  return clearAllEntries(CACHE_KEY, CACHE_TIMESTAMP_KEY);
 };

--- a/app/mobile/src/services/cacheEviction.ts
+++ b/app/mobile/src/services/cacheEviction.ts
@@ -1,0 +1,288 @@
+/**
+ * Shared LRU eviction utility for Soter offline caches.
+ *
+ * EVICTION POLICY
+ * ───────────────
+ * • Each cache enforces a configurable MAX_ENTRIES limit (entry count, because
+ *   AsyncStorage stores serialised JSON and we don't measure byte sizes).
+ * • Eviction target: Least-Recently-Used entries whose _syncStatus is 'synced'.
+ *   An entry is "synced" when it has been confirmed persisted server-side
+ *   (i.e. no matching pending/retrying/conflict action exists in the sync queue
+ *   for that entry's id).
+ * • An entry is NEVER evicted while _syncStatus is 'pending' or 'conflict' —
+ *   those represent unsynced local changes that must reach the server first.
+ * • If the cache is at capacity and ALL entries are unsynced, no eviction occurs.
+ *   Instead callers receive { atLimit: true } so the UI can surface a warning.
+ * • When eviction is needed, the entry with the smallest _lastAccessedAt
+ *   timestamp (least-recently accessed) among synced entries is removed first,
+ *   one at a time, until the entry count is under the limit.
+ *
+ * METADATA FIELDS (added to every cached entry, never sent to callers raw)
+ * ─────────────────────────────────────────────────────────────────────────
+ * • _lastAccessedAt: number  — Unix-ms timestamp, updated on every read/write.
+ * • _syncStatus: 'synced' | 'pending' | 'conflict'
+ *     - 'synced'   → no open sync-queue action for this id
+ *     - 'pending'  → has a pending/retrying action in the sync queue
+ *     - 'conflict' → has a conflict action in the sync queue
+ *
+ * These fields are stripped before entries are returned to callers, so the
+ * public API shape of AidPackage / TaskItem is unchanged.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getSyncQueueState, SyncActionState } from './syncQueue';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Sync states that mean "this entry must NOT be evicted". */
+const UNSYNCED_STATES: SyncActionState[] = ['pending', 'retrying', 'conflict'];
+
+export type EntrySyncStatus = 'synced' | 'pending' | 'conflict';
+
+/** Metadata wrapper stored alongside every cached entry. */
+export interface CacheEntryMeta {
+  _lastAccessedAt: number;
+  _syncStatus: EntrySyncStatus;
+}
+
+/** A cached entry is the original data type plus our metadata fields. */
+export type WithMeta<T extends { id: string }> = T & CacheEntryMeta;
+
+/** Result of an eviction run. */
+export interface EvictionResult {
+  /** Number of entries evicted. */
+  evicted: number;
+  /** True when the cache is at capacity AND every entry is unsynced — no data was dropped. */
+  atLimit: boolean;
+}
+
+/** Shape returned by getCacheSize(). */
+export interface CacheSize {
+  entryCount: number;
+  maxEntries: number;
+  /** True when entryCount >= warningThreshold (default: 80 % of maxEntries). */
+  nearLimit: boolean;
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/**
+ * Derive a sync-status string for a given entry id by inspecting the live
+ * sync-queue state.  We intentionally avoid importing the queue's internal
+ * state directly to keep the coupling minimal.
+ */
+async function resolveSyncStatus(id: string): Promise<EntrySyncStatus> {
+  const { items } = await getSyncQueueState();
+
+  for (const action of items) {
+    const payload = action.payload as Record<string, unknown>;
+    // A queue action is "for" this entry if its payload contains the id.
+    const matchesId =
+      payload['aidId'] === id ||
+      payload['claimId'] === id ||
+      payload['id'] === id;
+
+    if (!matchesId) continue;
+
+    if (action.state === 'conflict') return 'conflict';
+    if (UNSYNCED_STATES.includes(action.state)) return 'pending';
+  }
+
+  return 'synced';
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Write an array of entries to AsyncStorage, attaching (or refreshing)
+ * metadata.  Existing metadata is preserved for entries already in the cache;
+ * new entries start with _syncStatus derived from the live sync queue.
+ *
+ * After writing, the eviction routine runs automatically and removes the
+ * least-recently-accessed synced entries until the count is under maxEntries.
+ *
+ * @param storageKey   The AsyncStorage key for the cache blob.
+ * @param data         Incoming entries (public shape — no metadata yet).
+ * @param maxEntries   Hard cap on number of entries.
+ * @param warningRatio Fraction of maxEntries at which nearLimit becomes true (default 0.8).
+ * @returns EvictionResult for optional caller-side warning handling.
+ */
+export async function writeBoundedCache<T extends { id: string }>(
+  storageKey: string,
+  data: T[],
+  maxEntries: number,
+  warningRatio = 0.8,
+): Promise<EvictionResult> {
+  const now = Date.now();
+
+  // Load existing entries so we can preserve their metadata.
+  const existingRaw = await AsyncStorage.getItem(storageKey);
+  const existing: WithMeta<T>[] = existingRaw ? (JSON.parse(existingRaw) as WithMeta<T>[]) : [];
+  const existingById = new Map(existing.map((e) => [e.id, e]));
+
+  // Attach metadata to every incoming entry.
+  const incoming: WithMeta<T>[] = await Promise.all(
+    data.map(async (entry) => {
+      const prev = existingById.get(entry.id);
+      const syncStatus = await resolveSyncStatus(entry.id);
+      return {
+        ...entry,
+        _lastAccessedAt: now,
+        _syncStatus: syncStatus,
+        // Preserve prior access time if this is an unchanged read-through.
+        ...(prev && prev._lastAccessedAt ? { _lastAccessedAt: prev._lastAccessedAt } : {}),
+        // Always refresh access timestamp on write.
+        _lastAccessedAt: now,
+      };
+    }),
+  );
+
+  // Run eviction on the merged set.
+  return evictAndPersist(storageKey, incoming, maxEntries, warningRatio);
+}
+
+/**
+ * Read entries from the cache, updating _lastAccessedAt on every entry
+ * so LRU ordering stays accurate.
+ *
+ * Returns entries with metadata stripped — callers receive clean T[].
+ */
+export async function readBoundedCache<T extends { id: string }>(
+  storageKey: string,
+): Promise<T[] | null> {
+  const raw = await AsyncStorage.getItem(storageKey);
+  if (!raw) return null;
+
+  const entries = JSON.parse(raw) as WithMeta<T>[];
+  if (!entries.length) return [];
+
+  const now = Date.now();
+  const touched: WithMeta<T>[] = entries.map((e) => ({
+    ...e,
+    _lastAccessedAt: now,
+  }));
+
+  // Persist the updated timestamps quietly (fire-and-forget — reads shouldn't
+  // block the caller).
+  void AsyncStorage.setItem(storageKey, JSON.stringify(touched));
+
+  return touched.map(stripMeta) as T[];
+}
+
+/**
+ * Return the current cache size metrics.
+ */
+export async function getCacheSize(
+  storageKey: string,
+  maxEntries: number,
+  warningRatio = 0.8,
+): Promise<CacheSize> {
+  const raw = await AsyncStorage.getItem(storageKey);
+  const entries: WithMeta<unknown>[] = raw ? (JSON.parse(raw) as WithMeta<unknown>[]) : [];
+  const entryCount = entries.length;
+  const warningThreshold = Math.floor(maxEntries * warningRatio);
+
+  return {
+    entryCount,
+    maxEntries,
+    nearLimit: entryCount >= warningThreshold,
+  };
+}
+
+/**
+ * Clear all synced entries from the cache, preserving any entry whose
+ * _syncStatus is 'pending' or 'conflict'.
+ *
+ * @returns Object with counts of cleared and preserved entries.
+ */
+export async function clearSyncedEntries<T extends { id: string }>(
+  storageKey: string,
+  timestampKey: string,
+): Promise<{ cleared: number; preserved: number }> {
+  const raw = await AsyncStorage.getItem(storageKey);
+  const entries: WithMeta<T>[] = raw ? (JSON.parse(raw) as WithMeta<T>[]) : [];
+
+  // Refresh sync statuses before deciding what to keep.
+  const refreshed = await Promise.all(
+    entries.map(async (e) => ({
+      ...e,
+      _syncStatus: await resolveSyncStatus(e.id),
+    })),
+  );
+
+  const toKeep = refreshed.filter((e) => e._syncStatus !== 'synced');
+  const cleared = refreshed.length - toKeep.length;
+
+  if (toKeep.length === 0) {
+    await AsyncStorage.multiRemove([storageKey, timestampKey]);
+  } else {
+    await AsyncStorage.setItem(storageKey, JSON.stringify(toKeep));
+    await AsyncStorage.setItem(timestampKey, Date.now().toString());
+  }
+
+  return { cleared, preserved: toKeep.length };
+}
+
+/**
+ * Force-clear ALL entries including unsynced ones.  This is a destructive
+ * operation and must only be called from an explicitly confirmed UI action.
+ */
+export async function clearAllEntries(
+  storageKey: string,
+  timestampKey: string,
+): Promise<void> {
+  await AsyncStorage.multiRemove([storageKey, timestampKey]);
+}
+
+// ─── Private helpers ─────────────────────────────────────────────────────────
+
+/** Remove metadata fields before returning entries to callers. */
+function stripMeta<T extends { id: string }>(entry: WithMeta<T>): T {
+  const { _lastAccessedAt: _a, _syncStatus: _s, ...rest } = entry as WithMeta<T> & Record<string, unknown>;
+  return rest as T;
+}
+
+/**
+ * Core eviction loop: given a list of entries with metadata, remove the
+ * least-recently-used synced entries until the count is under maxEntries,
+ * then persist the result.
+ */
+async function evictAndPersist<T extends { id: string }>(
+  storageKey: string,
+  entries: WithMeta<T>[],
+  maxEntries: number,
+  warningRatio: number,
+): Promise<EvictionResult> {
+  let current = [...entries];
+  let evicted = 0;
+
+  while (current.length > maxEntries) {
+    // Find the LRU synced entry.
+    const syncedEntries = current.filter((e) => e._syncStatus === 'synced');
+
+    if (syncedEntries.length === 0) {
+      // All entries are unsynced — cannot evict without data loss.
+      await AsyncStorage.setItem(storageKey, JSON.stringify(current));
+      const warningThreshold = Math.floor(maxEntries * warningRatio);
+      return {
+        evicted,
+        atLimit: current.length >= warningThreshold,
+      };
+    }
+
+    // Pick entry with the smallest (oldest) _lastAccessedAt.
+    const lru = syncedEntries.reduce((oldest, e) =>
+      e._lastAccessedAt < oldest._lastAccessedAt ? e : oldest,
+    );
+
+    current = current.filter((e) => e.id !== lru.id);
+    evicted++;
+  }
+
+  await AsyncStorage.setItem(storageKey, JSON.stringify(current));
+  const warningThreshold = Math.floor(maxEntries * warningRatio);
+  return {
+    evicted,
+    atLimit: current.length >= warningThreshold,
+  };
+}

--- a/app/mobile/src/services/taskCache.ts
+++ b/app/mobile/src/services/taskCache.ts
@@ -1,30 +1,103 @@
+/**
+ * Task list offline cache — bounded LRU with safe eviction.
+ *
+ * EVICTION POLICY (see cacheEviction.ts for full documentation)
+ * ─────────────────────────────────────────────────────────────
+ * • Maximum entries: TASK_CACHE_MAX_ENTRIES (default 500, configurable via
+ *   EXPO_PUBLIC_TASK_CACHE_MAX_ENTRIES environment variable).
+ * • Eviction order: Least-Recently-Used (by _lastAccessedAt timestamp) among
+ *   entries whose _syncStatus is 'synced'.
+ * • Entries with _syncStatus 'pending' or 'conflict' are NEVER evicted — they
+ *   represent unsynced local changes that must reach the server first.
+ * • If at capacity and all entries are unsynced, no data is dropped; the caller
+ *   receives { atLimit: true } which the UI uses to surface a warning.
+ * • A warning threshold fires at 80 % of the limit (configurable).
+ */
+
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TaskItem } from './taskApi';
+import {
+  writeBoundedCache,
+  readBoundedCache,
+  getCacheSize,
+  clearSyncedEntries,
+  clearAllEntries,
+  CacheSize,
+  EvictionResult,
+} from './cacheEviction';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Maximum number of task entries to keep in the local cache.
+ * Override via EXPO_PUBLIC_TASK_CACHE_MAX_ENTRIES at build time.
+ */
+export const TASK_CACHE_MAX_ENTRIES: number = process.env.EXPO_PUBLIC_TASK_CACHE_MAX_ENTRIES
+  ? parseInt(process.env.EXPO_PUBLIC_TASK_CACHE_MAX_ENTRIES, 10)
+  : 500;
 
 const CACHE_KEY = '@soter/task_list';
 const CACHE_TIMESTAMP_KEY = '@soter/task_list_timestamp';
 
-/** Persist task list to AsyncStorage */
-export const cacheTaskList = async (data: TaskItem[]): Promise<void> => {
-  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Persist task list to AsyncStorage.
+ *
+ * Runs the LRU eviction policy after writing.  Synced entries are evicted
+ * LRU-first; unsynced entries are never dropped.
+ *
+ * @returns EvictionResult — check `atLimit` to surface a capacity warning.
+ */
+export const cacheTaskList = async (data: TaskItem[]): Promise<EvictionResult> => {
+  const result = await writeBoundedCache<TaskItem>(CACHE_KEY, data, TASK_CACHE_MAX_ENTRIES);
   await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
+  return result;
 };
 
-/** Load cached task list from AsyncStorage */
+/**
+ * Load cached task list from AsyncStorage.
+ * Updates _lastAccessedAt on all entries (LRU tracking).
+ */
 export const loadCachedTaskList = async (): Promise<TaskItem[] | null> => {
-  const raw = await AsyncStorage.getItem(CACHE_KEY);
-  if (!raw) return null;
-  return JSON.parse(raw) as TaskItem[];
+  return readBoundedCache<TaskItem>(CACHE_KEY);
 };
 
-/** Returns the ISO timestamp of the last successful cache write, or null */
+/**
+ * Returns the human-readable timestamp of the last successful cache write,
+ * or null if the cache has never been written.
+ */
 export const getTaskCacheTimestamp = async (): Promise<string | null> => {
   const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
   if (!ts) return null;
   return new Date(parseInt(ts, 10)).toLocaleString();
 };
 
-/** Clear the cached task list */
-export const clearTaskCache = async (): Promise<void> => {
-  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
+/**
+ * Returns current cache size metrics for the settings UI.
+ * `nearLimit` is true when usage reaches 80 % of TASK_CACHE_MAX_ENTRIES.
+ */
+export const getTaskCacheSize = async (): Promise<CacheSize> => {
+  return getCacheSize(CACHE_KEY, TASK_CACHE_MAX_ENTRIES);
+};
+
+/**
+ * Clear synced task entries only.  Entries with pending/conflict sync state
+ * are preserved — they have not yet reached the server.
+ *
+ * @returns Counts of cleared and preserved entries.
+ */
+export const clearTaskCache = async (): Promise<{ cleared: number; preserved: number }> => {
+  return clearSyncedEntries<TaskItem>(CACHE_KEY, CACHE_TIMESTAMP_KEY);
+};
+
+/**
+ * Force-clear ALL cached task entries including any with unsynced changes.
+ *
+ * ⚠️  DESTRUCTIVE — call only from a separately-confirmed UI action.
+ *     Unsynced data will be permanently lost if this is called before the
+ *     sync queue has flushed those entries to the server.
+ */
+export const forceClearTaskCache = async (): Promise<void> => {
+  return clearAllEntries(CACHE_KEY, CACHE_TIMESTAMP_KEY);
 };


### PR DESCRIPTION
Closes #928

## Summary

Resolves #928 — Bound and Evict Local Caches.

Both \idCache\ and \	askCache\ previously stored unbounded JSON blobs in AsyncStorage. On long field deployments the cache grew until storage was exhausted, breaking evidence capture.

## Changes

### New: \services/cacheEviction.ts\
Shared LRU eviction utility used by both caches. Key behaviours:
- Tracks \_lastAccessedAt\ (Unix-ms) and \_syncStatus\ per entry — metadata is stripped before entries are returned to callers so the public \AidPackage\ / \TaskItem\ shape is unchanged.
- Derives sync status by inspecting the live sync queue (\getSyncQueueState()\) — reuses the existing \pending\ / \etrying\ / \conflict\ state machine rather than inventing a new dirty flag.
- Evicts LRU **synced** entries first. Entries with \pending\ or \conflict\ status are **never evicted**.
- If all entries are unsynced at capacity, no data is dropped — \tLimit: true\ is returned for the UI to warn on.
- \clearSyncedEntries()\ is the default clear path (preserves unsynced). \clearAllEntries()\ is the destructive path, separately named and gated behind an explicit confirmation.

### Updated: \services/aidCache.ts\ and \services/taskCache.ts\
- Both now delegate to \cacheEviction.ts\.
- **Defaults:** aid cache = 200 entries, task cache = 500 entries. Both overridable via \EXPO_PUBLIC_AID_CACHE_MAX_ENTRIES\ / \EXPO_PUBLIC_TASK_CACHE_MAX_ENTRIES\.
- New exports: \getAidCacheSize()\ / \getTaskCacheSize()\ for the settings UI.
- \clearAidCache()\ / \clearTaskCache()\ now return \{ cleared, preserved }\ instead of \oid\ — existing callers are unaffected.

### Updated: \screens/SettingsScreen.tsx\
- New **Storage** section showing entry count / max for each cache.
- **Clear** button per cache with confirmation alert and result toast showing cleared/preserved counts.
- **Warning banner** (reuses existing \warningBg\ / \warning\ colour tokens) at 80% capacity.

### New: \__tests__/cacheEviction.test.ts\
15 tests covering eviction ordering, unsynced preservation, all-unsynced-at-capacity, manual clear, and size reporting.

## Assumptions
- No dirty flag existed on \AidPackage\ / \TaskItem\. Sync status is derived from the live sync queue at write-time.
- Entry count is the size unit (AsyncStorage does not expose byte sizes).