### PR TITLE
feat: add notification outbox dead-letter replay

### DIFF
--- a/app/backend/prisma/migrations/20260827120000_add_notification_dead_letter_status/migration.sql
+++ b/app/backend/prisma/migrations/20260827120000_add_notification_dead_letter_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "NotificationOutboxStatus" ADD VALUE IF NOT EXISTS 'dead_letter';

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -628,6 +628,7 @@ enum NotificationOutboxStatus {
   enqueued
   sent
   failed
+  dead_letter
 }
 
 model NotificationOutbox {

--- a/app/backend/src/notifications/notifications.processor.spec.ts
+++ b/app/backend/src/notifications/notifications.processor.spec.ts
@@ -19,7 +19,6 @@ describe('NotificationProcessor', () => {
     incrementNotificationDeliveryAttempt: jest.Mock;
     incrementNotificationDeliveryFailureByCategory: jest.Mock;
   };
-
   let emailAdapterMock: {
     send: jest.Mock;
   };
@@ -183,7 +182,7 @@ describe('NotificationProcessor', () => {
   });
 
   describe('onFailed', () => {
-    it('should update outbox record to failed with retryCount increment and lastError when outboxId is present and exhausted', async () => {
+    it('should move the outbox record to dead_letter with retryCount increment and lastError when exhausted', async () => {
       const job = makeJob({ outboxId: 'outbox-abc' });
       job.opts = { attempts: 1 };
       job.attemptsMade = 1;
@@ -199,7 +198,7 @@ describe('NotificationProcessor', () => {
       expect(prismaMock.notificationOutbox.update).toHaveBeenCalledWith({
         where: { id: 'outbox-abc' },
         data: {
-          status: 'failed',
+          status: 'dead_letter',
           retryCount: { increment: 1 },
           lastError: 'Something went wrong',
         },

--- a/app/backend/src/notifications/notifications.processor.ts
+++ b/app/backend/src/notifications/notifications.processor.ts
@@ -177,7 +177,7 @@ export class NotificationProcessor extends WorkerHost {
     const maxAttempts =
       typeof job.opts?.attempts === 'number' ? job.opts.attempts : 1;
     const exhausted = job.attemptsMade >= maxAttempts;
-    const status = exhausted ? 'failed' : 'enqueued';
+    const status = exhausted ? 'dead_letter' : 'enqueued';
 
     try {
       await this.prisma.notificationOutbox.update({
@@ -193,6 +193,19 @@ export class NotificationProcessor extends WorkerHost {
       this.logger.error(
         `Failed to update outbox record ${job.data.outboxId} to ${status}: ${err instanceof Error ? err.message : String(err)}`,
       );
+    }
+
+    if (exhausted && this.metricsService.setNotificationDeadLetterDepth) {
+      try {
+        const depth = await this.prisma.notificationOutbox.count({
+          where: { status: 'dead_letter' },
+        });
+        this.metricsService.setNotificationDeadLetterDepth(depth);
+      } catch (err) {
+        this.logger.warn(
+          `Could not refresh notification dead-letter depth: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     const failureCategory = classifyNotificationFailure(error);

--- a/app/backend/src/notifications/notifications.service.spec.ts
+++ b/app/backend/src/notifications/notifications.service.spec.ts
@@ -4,6 +4,8 @@ import { getQueueToken } from '@nestjs/bullmq';
 import { NotificationType } from './interfaces/notification-job.interface';
 import { PrismaService } from '../prisma/prisma.service';
 import { LoggerService } from '../logger/logger.service';
+import { AuditService } from '../audit/audit.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 describe('NotificationsService', () => {
   let service: NotificationsService;
@@ -81,12 +83,11 @@ describe('NotificationsService', () => {
           useValue: loggerMock,
         },
         {
-          provide: require('../audit/audit.service').AuditService,
+          provide: AuditService,
           useValue: { record: jest.fn().mockResolvedValue(undefined) },
         },
         {
-          provide: require('../observability/metrics/metrics.service')
-            .MetricsService,
+          provide: MetricsService,
           useValue: { setNotificationDeadLetterDepth: jest.fn() },
         },
       ],

--- a/app/backend/src/notifications/notifications.service.spec.ts
+++ b/app/backend/src/notifications/notifications.service.spec.ts
@@ -13,9 +13,12 @@ describe('NotificationsService', () => {
     notificationOutbox: {
       create: jest.Mock;
       update: jest.Mock;
+      updateMany: jest.Mock;
       findUnique: jest.Mock;
       findMany: jest.Mock;
+      count: jest.Mock;
     };
+    $transaction: jest.Mock;
   };
 
   const mockOutbox = {
@@ -52,10 +55,15 @@ describe('NotificationsService', () => {
           status: 'enqueued',
           jobId: 'job-123',
         }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
         findUnique: jest.fn().mockResolvedValue(mockOutbox),
         findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
       },
     };
+    prismaMock.$transaction = jest.fn((queries: Promise<unknown>[]) =>
+      Promise.all(queries),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -71,6 +79,15 @@ describe('NotificationsService', () => {
         {
           provide: LoggerService,
           useValue: loggerMock,
+        },
+        {
+          provide: require('../audit/audit.service').AuditService,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: require('../observability/metrics/metrics.service')
+            .MetricsService,
+          useValue: { setNotificationDeadLetterDepth: jest.fn() },
         },
       ],
     }).compile();
@@ -357,6 +374,70 @@ describe('NotificationsService', () => {
       const result = await service.getStuckOutboxRecords();
 
       expect(result).toEqual(stuckRecords);
+    });
+  });
+
+  describe('dead-letter replay', () => {
+    it('lists dead-lettered records with pagination metadata', async () => {
+      const deadLetter = { ...mockOutbox, status: 'dead_letter' };
+      prismaMock.notificationOutbox.findMany.mockResolvedValueOnce([
+        deadLetter,
+      ]);
+      prismaMock.notificationOutbox.count.mockResolvedValueOnce(1);
+
+      await expect(service.getDeadLetterNotifications(2, 10)).resolves.toEqual({
+        items: [deadLetter],
+        total: 1,
+        page: 2,
+        limit: 10,
+      });
+      expect(prismaMock.notificationOutbox.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { status: 'dead_letter' },
+          skip: 10,
+          take: 10,
+        }),
+      );
+    });
+
+    it('claims a dead-letter record once and re-enqueues it', async () => {
+      prismaMock.notificationOutbox.findUnique.mockResolvedValueOnce({
+        ...mockOutbox,
+        status: 'dead_letter',
+      });
+
+      await expect(
+        service.replayDeadLetterNotification('outbox-123', 'admin-1'),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          success: true,
+          outboxId: 'outbox-123',
+          replayedJobId: 'job-123',
+        }),
+      );
+      expect(prismaMock.notificationOutbox.updateMany).toHaveBeenCalledWith({
+        where: { id: 'outbox-123', status: 'dead_letter' },
+        data: {
+          status: 'enqueued',
+          retryCount: { increment: 1 },
+          lastError: null,
+        },
+      });
+    });
+
+    it('does not enqueue when another replay already claimed the record', async () => {
+      prismaMock.notificationOutbox.findUnique.mockResolvedValueOnce({
+        ...mockOutbox,
+        status: 'dead_letter',
+      });
+      prismaMock.notificationOutbox.updateMany.mockResolvedValueOnce({
+        count: 0,
+      });
+
+      await expect(
+        service.replayDeadLetterNotification('outbox-123', 'admin-1'),
+      ).rejects.toThrow('already in progress');
+      expect(queueMock.add).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/backend/src/notifications/notifications.service.ts
+++ b/app/backend/src/notifications/notifications.service.ts
@@ -286,7 +286,9 @@ export class NotificationsService {
     }
 
     const jobName =
-      record.type === NotificationType.SMS ? 'send-sms' : 'send-email';
+      (record.type as NotificationType) === NotificationType.SMS
+        ? 'send-sms'
+        : 'send-email';
     try {
       const job = await this.notificationsQueue.add(
         jobName,

--- a/app/backend/src/notifications/notifications.service.ts
+++ b/app/backend/src/notifications/notifications.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import {
@@ -13,6 +19,8 @@ import {
 } from './interfaces/notification-job.interface';
 import { PrismaService } from '../prisma/prisma.service';
 import { LoggerService } from '../logger/logger.service';
+import { AuditService } from '../audit/audit.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 
 export interface ActivityFeedItem {
   id: string;
@@ -36,6 +44,8 @@ export class NotificationsService {
     @InjectQueue('notifications') private readonly notificationsQueue: Queue,
     private readonly prisma: PrismaService,
     private readonly loggerService: LoggerService,
+    @Optional() private readonly auditService?: AuditService,
+    @Optional() private readonly metricsService?: MetricsService,
   ) {}
 
   async sendEmail(
@@ -230,6 +240,113 @@ export class NotificationsService {
       },
       orderBy: { scheduledFor: 'asc' },
     });
+  }
+
+  async getDeadLetterNotifications(page = 1, limit = 50) {
+    const take = Math.min(Math.max(limit, 1), 200);
+    const currentPage = Math.max(page, 1);
+    const skip = (currentPage - 1) * take;
+    const where = { status: 'dead_letter' as const };
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.notificationOutbox.findMany({
+        where,
+        orderBy: { updatedAt: 'desc' },
+        skip,
+        take,
+      }),
+      this.prisma.notificationOutbox.count({ where }),
+    ]);
+    return { items, total, page: currentPage, limit: take };
+  }
+
+  async replayDeadLetterNotification(id: string, actorId: string) {
+    const record = await this.prisma.notificationOutbox.findUnique({
+      where: { id },
+    });
+    if (!record)
+      throw new NotFoundException(`Outbox record with id "${id}" not found`);
+    if (record.status !== 'dead_letter') {
+      throw new BadRequestException(
+        'Only dead-lettered notifications can be replayed',
+      );
+    }
+
+    const claimed = await this.prisma.notificationOutbox.updateMany({
+      where: { id, status: 'dead_letter' },
+      data: {
+        status: 'enqueued',
+        retryCount: { increment: 1 },
+        lastError: null,
+      },
+    });
+    if (claimed.count !== 1) {
+      throw new BadRequestException(
+        'Notification replay is already in progress',
+      );
+    }
+
+    const jobName =
+      record.type === NotificationType.SMS ? 'send-sms' : 'send-email';
+    try {
+      const job = await this.notificationsQueue.add(
+        jobName,
+        {
+          type: record.type as NotificationType,
+          recipient: record.recipient,
+          ...(record.subject ? { subject: record.subject } : {}),
+          message: record.message,
+          timestamp: Date.now(),
+          outboxId: record.id,
+          correlationId:
+            typeof this.parseMetadata(record.metadata).correlationId ===
+            'string'
+              ? (this.parseMetadata(record.metadata).correlationId as string)
+              : undefined,
+        } satisfies NotificationJobData,
+        { attempts: 3, backoff: { type: 'exponential', delay: 5000 } },
+      );
+      await this.prisma.notificationOutbox.update({
+        where: { id },
+        data: { jobId: String(job.id) },
+      });
+      await this.auditService?.record({
+        actorId,
+        entity: 'NotificationOutbox',
+        entityId: id,
+        action: 'replay_notification_dead_letter',
+        metadata: { jobId: String(job.id), type: record.type },
+      });
+      await this.refreshDeadLetterDepth();
+      return { success: true, outboxId: id, replayedJobId: String(job.id) };
+    } catch (error) {
+      await this.prisma.notificationOutbox.update({
+        where: { id },
+        data: {
+          status: 'dead_letter',
+          lastError: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw error;
+    }
+  }
+
+  async replayDeadLetterNotifications(ids: string[], actorId: string) {
+    const results = await Promise.allSettled(
+      ids.map(id => this.replayDeadLetterNotification(id, actorId)),
+    );
+    return {
+      replayed: results.filter(result => result.status === 'fulfilled').length,
+      skipped: results.filter(result => result.status === 'rejected').length,
+      results,
+    };
+  }
+
+  private async refreshDeadLetterDepth() {
+    if (!this.metricsService) return;
+    const depth = await this.prisma.notificationOutbox.count({
+      where: { status: 'dead_letter' },
+    });
+    this.metricsService.setNotificationDeadLetterDepth(depth);
   }
 
   async getActivityFeed(limit = 30): Promise<ActivityFeedItem[]> {

--- a/app/backend/src/notifications/outbox.controller.ts
+++ b/app/backend/src/notifications/outbox.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Post,
   Param,
   Query,
   NotFoundException,
@@ -17,6 +18,7 @@ import {
   ApiForbiddenResponse,
   ApiBearerAuth,
 } from '@nestjs/swagger';
+import { Body, Req } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { DeliveryAttemptOutcome } from '@prisma/client';
 import { ApiKeyGuard } from '../common/guards/api-key.guard';
@@ -53,6 +55,52 @@ export class OutboxController {
   async listStuck() {
     const records = await this.notificationsService.getStuckOutboxRecords();
     return ApiResponseDto.ok(records, 'Stuck outbox records fetched');
+  }
+
+  @Get('dead-letter')
+  @Roles(AppRole.admin, AppRole.operator)
+  @HttpCode(HttpStatus.OK)
+  async listDeadLetter(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const result = await this.notificationsService.getDeadLetterNotifications(
+      page ? parseInt(page, 10) : 1,
+      limit ? parseInt(limit, 10) : 50,
+    );
+    return ApiResponseDto.ok(result, 'Dead-letter notifications fetched');
+  }
+
+  @Post('dead-letter/:id/replay')
+  @Roles(AppRole.admin, AppRole.operator)
+  @HttpCode(HttpStatus.OK)
+  async replayDeadLetter(
+    @Param('id') id: string,
+    @Req() request: { user?: { id?: string } },
+  ) {
+    return ApiResponseDto.ok(
+      await this.notificationsService.replayDeadLetterNotification(
+        id,
+        request.user?.id ?? 'system',
+      ),
+      'Notification replayed',
+    );
+  }
+
+  @Post('dead-letter/replay')
+  @Roles(AppRole.admin, AppRole.operator)
+  @HttpCode(HttpStatus.OK)
+  async replayDeadLetters(
+    @Body() body: { ids?: string[] },
+    @Req() request: { user?: { id?: string } },
+  ) {
+    return ApiResponseDto.ok(
+      await this.notificationsService.replayDeadLetterNotifications(
+        body.ids ?? [],
+        request.user?.id ?? 'system',
+      ),
+      'Notification replay completed',
+    );
   }
 
   /**

--- a/app/backend/src/observability/metrics/metrics.service.ts
+++ b/app/backend/src/observability/metrics/metrics.service.ts
@@ -367,6 +367,11 @@ export class MetricsService {
     this.claimsInFunnelGauge.set({ status }, count);
   }
 
+  /** Set the current number of notification outbox records awaiting replay. */
+  setNotificationDeadLetterDepth(count: number): void {
+    this.setGauge('notification_dead_letter_depth', count);
+  }
+
   /**
    * Record the duration in seconds a claim spent within a funnel stage before transitioning.
    */


### PR DESCRIPTION
Closes #945

## Summary
- mark exhausted notification outbox deliveries as `dead_letter` with the final failure reason
- add admin/operator pagination plus single and bulk replay endpoints
- make replay claim conditional so concurrent replay requests enqueue at most one job
- record replay attempts in the audit log and expose dead-letter depth

## Verification
- Focused notification suite: 42 passed
- `npm run build`: passed
- `git diff --check`: passed

Replay is limited to admin/operator roles and only dead-lettered records can be replayed.