### PR TITLE
feat(backend): publish canonical API error code catalog and update gl…

### DIFF
--- a/app/backend/ERROR_HANDLING.md
+++ b/app/backend/ERROR_HANDLING.md
@@ -1,38 +1,67 @@
-# Global Error Handling and Consistent API Error Schema
+# Global Error Handling and Canonical API Error Code Catalog
 
 ## Overview
 
-This implementation provides a standardized error handling mechanism across the entire backend application. All errors follow a consistent JSON envelope with `traceId` tracking and comprehensive logging.
+This implementation provides a standardized error handling mechanism and a canonical machine-readable error code catalog across the entire backend application. All errors follow a consistent JSON envelope with `traceId` tracking, stable string `errorCode` identifiers, and comprehensive logging.
 
 ## Error Response Envelope
 
-Every error response follows this shape:
+Every error response follows this canonical shape:
 
 ```json
 {
   "code": 400,
+  "errorCode": "BAD_REQUEST",
   "message": "Human-readable error message",
   "details": { "...additional context..." },
   "traceId": "M1ABC2DEF3G",
   "timestamp": "2026-01-23T12:30:00.000Z",
-  "path": "/api/v1/resource"
+  "path": "/api/v1/resource",
+  "correlationId": "M1ABC2DEF3G"
 }
 ```
 
-| Field       | Type             | Description                                       |
-|-------------|------------------|---------------------------------------------------|
-| `code`      | `number`         | HTTP status code                                  |
-| `message`   | `string`         | Human-readable error message                      |
-| `details`   | `object \| null` | Additional error-specific information (optional)  |
-| `traceId`   | `string`         | Request trace ID from `X-Request-ID` header       |
-| `timestamp` | `string`         | ISO 8601 timestamp of when the error occurred     |
-| `path`      | `string`         | The API endpoint that caused the error            |
+| Field           | Type             | Description                                                 |
+|-----------------|------------------|-------------------------------------------------------------|
+| `code`          | `number`         | HTTP status code                                            |
+| `errorCode`     | `string`         | Stable machine-readable canonical error code identifier     |
+| `message`       | `string`         | Human-readable error message                                |
+| `details`       | `object \| null` | Additional error-specific information (optional)            |
+| `traceId`       | `string`         | Request trace ID from `X-Request-ID` / correlation headers  |
+| `timestamp`     | `string`         | ISO 8601 timestamp of when the error occurred               |
+| `path`          | `string`         | The API endpoint that caused the error                      |
+| `correlationId` | `string`         | Correlation ID for distributed request tracing              |
 
 ## Architecture
 
+### Canonical Error Code Catalog
+
+All error codes are defined in `src/common/constants/error-codes.ts` and re-exported through `src/common/dto/error-response.dto.ts` and `src/common/index.ts` for client consumption.
+
+Error code categories include:
+- **Base / HTTP Errors**: `BAD_REQUEST`, `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `CONFLICT`, `UNPROCESSABLE_ENTITY`, `RATE_LIMIT_EXCEEDED`, `INTERNAL_SERVER_ERROR`, `SERVICE_UNAVAILABLE`, `GATEWAY_TIMEOUT`, `TIMEOUT`, `INVALID_OPERATION`, `DEPENDENCY_FAILURE`
+- **Validation**: `VALIDATION_ERROR`, `INVALID_INPUT`, `MISSING_REQUIRED_FIELD`, `INVALID_FORMAT`
+- **Database / Prisma**: `DATABASE_ERROR`, `RECORD_NOT_FOUND`, `UNIQUE_CONSTRAINT_VIOLATION`, `FOREIGN_KEY_VIOLATION`, `VALUE_TOO_LONG`
+- **Auth & API Keys**: `UNAUTHENTICATED`, `INVALID_CREDENTIALS`, `TOKEN_EXPIRED`, `INVALID_TOKEN`, `API_KEY_NOT_FOUND`, `API_KEY_REVOKED`, `API_KEY_EXPIRED`, `API_KEY_INVALID`, `INSUFFICIENT_PERMISSIONS`, `SCOPE_REQUIRED`
+- **Domain (Claims & Campaigns)**: `CLAIM_NOT_FOUND`, `CLAIM_ALREADY_CANCELLED`, `CLAIM_ALREADY_REISSUED`, `CAMPAIGN_NOT_FOUND`, `CAMPAIGN_FUNDING_CAP_EXCEEDED`, `CAMPAIGN_EXPIRED`, `SESSION_NOT_FOUND`, etc.
+- **Integrations**: AI (`AI_SERVICE_UNAVAILABLE`, `AI_SERVICE_TIMEOUT`, etc.), Onchain (`ONCHAIN_TRANSACTION_FAILED`, `ONCHAIN_CONTRACT_ERROR`, etc.), Evidence (`EVIDENCE_UPLOAD_FAILED`, etc.), Webhooks (`WEBHOOK_DUPLICATE_EVENT`, `WEBHOOK_INVALID_SIGNATURE`, etc.)
+
 ### Single Global Exception Filter
 
-All errors are handled by `AllExceptionsFilter` in `src/common/filters/http-exception.filter.ts`. It is registered via DI in `AppModule` using the `APP_FILTER` token, which ensures it receives `LoggerService` injection.
+All errors are handled by `AllExceptionsFilter` in `src/common/filters/http-exception.filter.ts`. It is registered via DI in `AppModule` using the `APP_FILTER` token, ensuring proper logger injection and consistent response transformation.
+
+### Typed AppException
+
+For domain logic where a specific canonical error code should be emitted, `AppException` is thrown:
+
+```typescript
+throw new AppException(
+  ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+  503,
+  'AI service is temporarily unavailable',
+  { retryAfterSeconds: 30 }
+);
+```
 
 ### Request Trace ID
 
@@ -41,48 +70,39 @@ The `RequestIdInterceptor` in `src/common/interceptors/request-id.interceptor.ts
 ## Error Types Handled
 
 ### HTTP Exceptions
-All NestJS HTTP exceptions (BadRequest, Unauthorized, NotFound, Forbidden, etc.) are mapped to the envelope with the correct status code.
+All NestJS HTTP exceptions (BadRequest, Unauthorized, NotFound, Forbidden, etc.) are mapped to canonical codes and emitted within the standardized envelope.
 
 ### Prisma Database Errors
-| Prisma Code | HTTP Status | Message                         |
-|-------------|-------------|---------------------------------|
-| `P2002`     | 409         | Unique constraint violation     |
-| `P2025`     | 404         | Record not found                |
-| `P2003`     | 400         | Foreign key constraint violation|
-| `P2000`     | 400         | Value too long for column       |
+| Prisma Code | HTTP Status | Error Code                     | Message                          |
+|-------------|-------------|--------------------------------|----------------------------------|
+| `P2002`     | 409         | `UNIQUE_CONSTRAINT_VIOLATION`  | Unique constraint violation      |
+| `P2025`     | 404         | `RECORD_NOT_FOUND`             | Record not found                 |
+| `P2003`     | 400         | `FOREIGN_KEY_VIOLATION`        | Foreign key constraint violation |
+| `P2000`     | 400         | `VALUE_TOO_LONG`               | Value too long for column        |
 
 ### Validation Errors
-Class-validator errors return `422 Unprocessable Entity` with structured `details.errors`.
+Class-validator errors return `422 Unprocessable Entity` with `errorCode: VALIDATION_ERROR` and structured `details.errors`.
 
 ### Generic Errors
-Unknown exceptions return `500 Internal Server Error` with `error_type` in details. Stack traces are only included when `NODE_ENV=development`.
+Unknown exceptions return `500 Internal Server Error` with `errorCode: INTERNAL_SERVER_ERROR` and `error_type` in details. Stack traces are only included when `NODE_ENV=development`.
 
 ## Testing
 
-### Test Error Endpoints
-
-The `TestErrorController` at `/api/v1/test-error/` provides endpoints for each error type:
-
-| Endpoint                    | Method | Error Type           |
-|-----------------------------|--------|----------------------|
-| `/generic-error`            | GET    | Generic Error (500)  |
-| `/bad-request`              | GET    | BadRequest (400)     |
-| `/internal-server-error`    | GET    | InternalServer (500) |
-| `/unauthorized`             | GET    | Unauthorized (401)   |
-| `/forbidden`                | GET    | Forbidden (403)      |
-| `/not-found`                | GET    | NotFound (404)       |
-| `/validation-error`         | POST   | Validation (400/422) |
-| `/prisma-error-simulation`  | GET    | Prisma P2002 (409)   |
-
-### Running Tests
+### Unit and E2E Tests
 
 ```bash
+# Unit tests for the canonical error catalog
+npx jest src/common/constants/error-codes.spec.ts --verbose
+
 # Unit tests for the exception filter
 npx jest src/common/filters/all-exceptions.filter.spec.ts --verbose
 
+# Unit tests for integration error codes
+npx jest src/common/constants/integration-error-codes.spec.ts --verbose
+
+# E2E error envelope tests
+npx jest --config ./test/jest-e2e.json test/error-envelope.e2e-spec.ts --verbose
+
 # E2E error handling tests
 npx jest --config ./test/jest-e2e.json test/error-handling.e2e-spec.ts --verbose
-
-# Shell script (start server first)
-./test-errors.sh
 ```

--- a/app/backend/src/common/constants/error-codes.spec.ts
+++ b/app/backend/src/common/constants/error-codes.spec.ts
@@ -1,0 +1,154 @@
+import {
+  ERROR_CODES,
+  API_ERROR_CODES,
+  BASE_ERROR_CODES,
+  VALIDATION_ERROR_CODES,
+  DATABASE_ERROR_CODES,
+  AUTH_ERROR_CODES,
+  DOMAIN_ERROR_CODES,
+  INTEGRATION_ERROR_CODES,
+  ApiErrorCode,
+  ErrorCode,
+  ERROR_CODE_METADATA,
+  getErrorCodeFromStatus,
+  AppException,
+} from './error-codes';
+
+describe('Canonical API Error Code Catalog', () => {
+  describe('Catalog Completeness & Integrity', () => {
+    it('API_ERROR_CODES should be identical to ERROR_CODES', () => {
+      expect(API_ERROR_CODES).toBe(ERROR_CODES);
+    });
+
+    it('every code in ERROR_CODES should match its key name as a stable string', () => {
+      for (const [key, value] of Object.entries(ERROR_CODES)) {
+        expect(value).toBe(key);
+        expect(typeof value).toBe('string');
+      }
+    });
+
+    it('includes all BASE_ERROR_CODES', () => {
+      for (const key of Object.keys(BASE_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (BASE_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('includes all VALIDATION_ERROR_CODES', () => {
+      for (const key of Object.keys(VALIDATION_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (VALIDATION_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('includes all DATABASE_ERROR_CODES', () => {
+      for (const key of Object.keys(DATABASE_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (DATABASE_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('includes all AUTH_ERROR_CODES', () => {
+      for (const key of Object.keys(AUTH_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (AUTH_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('includes all DOMAIN_ERROR_CODES', () => {
+      for (const key of Object.keys(DOMAIN_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (DOMAIN_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('includes all INTEGRATION_ERROR_CODES', () => {
+      for (const key of Object.keys(INTEGRATION_ERROR_CODES)) {
+        expect((ERROR_CODES as Record<string, string>)[key]).toBe(
+          (INTEGRATION_ERROR_CODES as Record<string, string>)[key],
+        );
+      }
+    });
+
+    it('ApiErrorCode enum contains matching values', () => {
+      expect(ApiErrorCode.BAD_REQUEST).toBe('BAD_REQUEST');
+      expect(ApiErrorCode.NOT_FOUND).toBe('NOT_FOUND');
+      expect(ApiErrorCode.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+      expect(ApiErrorCode.UNAUTHORIZED).toBe('UNAUTHORIZED');
+      expect(ApiErrorCode.FORBIDDEN).toBe('FORBIDDEN');
+      expect(ApiErrorCode.INTERNAL_SERVER_ERROR).toBe('INTERNAL_SERVER_ERROR');
+      expect(ApiErrorCode.AI_SERVICE_UNAVAILABLE).toBe('AI_SERVICE_UNAVAILABLE');
+      expect(ApiErrorCode.ONCHAIN_TRANSACTION_FAILED).toBe('ONCHAIN_TRANSACTION_FAILED');
+      expect(ApiErrorCode.EVIDENCE_UPLOAD_FAILED).toBe('EVIDENCE_UPLOAD_FAILED');
+      expect(ApiErrorCode.WEBHOOK_INVALID_SIGNATURE).toBe('WEBHOOK_INVALID_SIGNATURE');
+    });
+  });
+
+  describe('getErrorCodeFromStatus', () => {
+    it.each([
+      [400, ERROR_CODES.BAD_REQUEST],
+      [401, ERROR_CODES.UNAUTHORIZED],
+      [403, ERROR_CODES.FORBIDDEN],
+      [404, ERROR_CODES.NOT_FOUND],
+      [405, ERROR_CODES.METHOD_NOT_ALLOWED],
+      [409, ERROR_CODES.CONFLICT],
+      [422, ERROR_CODES.VALIDATION_ERROR],
+      [429, ERROR_CODES.RATE_LIMIT_EXCEEDED],
+      [500, ERROR_CODES.INTERNAL_SERVER_ERROR],
+      [501, ERROR_CODES.NOT_IMPLEMENTED],
+      [502, ERROR_CODES.BAD_GATEWAY],
+      [503, ERROR_CODES.SERVICE_UNAVAILABLE],
+      [504, ERROR_CODES.GATEWAY_TIMEOUT],
+    ])('maps status %i to error code %s', (status: number, expectedCode: ErrorCode) => {
+      expect(getErrorCodeFromStatus(status)).toBe(expectedCode);
+    });
+
+    it('defaults unmapped status to INTERNAL_SERVER_ERROR', () => {
+      expect(getErrorCodeFromStatus(418)).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
+      expect(getErrorCodeFromStatus(999)).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe('ERROR_CODE_METADATA', () => {
+    it('has metadata entries for catalog error codes', () => {
+      for (const [key, code] of Object.entries(ERROR_CODES)) {
+        const meta = ERROR_CODE_METADATA[code as ErrorCode];
+        expect(meta).toBeDefined();
+        expect(meta.code).toBe(code);
+        expect(typeof meta.httpStatus).toBe('number');
+        expect(typeof meta.description).toBe('string');
+        expect(meta.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('AppException with Catalog Codes', () => {
+    it('instantiates correctly with catalog code and status', () => {
+      const ex = new AppException(
+        ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+        503,
+        'AI service is unavailable',
+        { retryAfter: 30 },
+      );
+
+      expect(ex.name).toBe('AppException');
+      expect(ex.errorCode).toBe(ERROR_CODES.AI_SERVICE_UNAVAILABLE);
+      expect(ex.statusCode).toBe(503);
+      expect(ex.message).toBe('AI service is unavailable');
+      expect(ex.details).toEqual({ retryAfter: 30 });
+    });
+
+    it('works without optional details', () => {
+      const ex = new AppException(ERROR_CODES.CLAIM_NOT_FOUND, 404, 'Claim not found');
+
+      expect(ex.errorCode).toBe(ERROR_CODES.CLAIM_NOT_FOUND);
+      expect(ex.statusCode).toBe(404);
+      expect(ex.details).toBeUndefined();
+    });
+  });
+});

--- a/app/backend/src/common/constants/error-codes.ts
+++ b/app/backend/src/common/constants/error-codes.ts
@@ -1,0 +1,657 @@
+/**
+ * Canonical API Error Code Catalog
+ *
+ * This module defines the single canonical enumerated catalog of error codes
+ * with stable machine-readable string identifiers used across backend, frontend,
+ * and mobile clients.
+ *
+ * Naming convention: <DOMAIN>_<REASON> or <REASON> for generic HTTP/system codes.
+ */
+
+import {
+  INTEGRATION_ERROR_CODES,
+  AppException,
+  type IntegrationErrorCode,
+} from './integration-error-codes';
+
+// Re-export integration codes and AppException for seamless imports
+export { INTEGRATION_ERROR_CODES, AppException, type IntegrationErrorCode };
+
+// ---------------------------------------------------------------------------
+// Base / HTTP Error Codes
+// ---------------------------------------------------------------------------
+export const BASE_ERROR_CODES = {
+  BAD_REQUEST: 'BAD_REQUEST',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  FORBIDDEN: 'FORBIDDEN',
+  NOT_FOUND: 'NOT_FOUND',
+  METHOD_NOT_ALLOWED: 'METHOD_NOT_ALLOWED',
+  CONFLICT: 'CONFLICT',
+  UNPROCESSABLE_ENTITY: 'UNPROCESSABLE_ENTITY',
+  RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+  NOT_IMPLEMENTED: 'NOT_IMPLEMENTED',
+  BAD_GATEWAY: 'BAD_GATEWAY',
+  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
+  GATEWAY_TIMEOUT: 'GATEWAY_TIMEOUT',
+  TIMEOUT: 'TIMEOUT',
+  INVALID_OPERATION: 'INVALID_OPERATION',
+  DEPENDENCY_FAILURE: 'DEPENDENCY_FAILURE',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Validation Error Codes
+// ---------------------------------------------------------------------------
+export const VALIDATION_ERROR_CODES = {
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  INVALID_INPUT: 'INVALID_INPUT',
+  MISSING_REQUIRED_FIELD: 'MISSING_REQUIRED_FIELD',
+  INVALID_FORMAT: 'INVALID_FORMAT',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Database / Persistence Error Codes
+// ---------------------------------------------------------------------------
+export const DATABASE_ERROR_CODES = {
+  DATABASE_ERROR: 'DATABASE_ERROR',
+  RECORD_NOT_FOUND: 'RECORD_NOT_FOUND',
+  UNIQUE_CONSTRAINT_VIOLATION: 'UNIQUE_CONSTRAINT_VIOLATION',
+  FOREIGN_KEY_VIOLATION: 'FOREIGN_KEY_VIOLATION',
+  VALUE_TOO_LONG: 'VALUE_TOO_LONG',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Auth & Security Error Codes
+// ---------------------------------------------------------------------------
+export const AUTH_ERROR_CODES = {
+  UNAUTHENTICATED: 'UNAUTHENTICATED',
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  INVALID_TOKEN: 'INVALID_TOKEN',
+  API_KEY_NOT_FOUND: 'API_KEY_NOT_FOUND',
+  API_KEY_REVOKED: 'API_KEY_REVOKED',
+  API_KEY_EXPIRED: 'API_KEY_EXPIRED',
+  API_KEY_INVALID: 'API_KEY_INVALID',
+  INSUFFICIENT_PERMISSIONS: 'INSUFFICIENT_PERMISSIONS',
+  SCOPE_REQUIRED: 'SCOPE_REQUIRED',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Domain: Claims & Campaigns Error Codes
+// ---------------------------------------------------------------------------
+export const DOMAIN_ERROR_CODES = {
+  CLAIM_NOT_FOUND: 'CLAIM_NOT_FOUND',
+  CLAIM_ALREADY_CANCELLED: 'CLAIM_ALREADY_CANCELLED',
+  CLAIM_ALREADY_REISSUED: 'CLAIM_ALREADY_REISSUED',
+  CLAIM_EXPIRED: 'CLAIM_EXPIRED',
+  CLAIM_INVALID_STATE: 'CLAIM_INVALID_STATE',
+  CAMPAIGN_NOT_FOUND: 'CAMPAIGN_NOT_FOUND',
+  CAMPAIGN_FUNDING_CAP_EXCEEDED: 'CAMPAIGN_FUNDING_CAP_EXCEEDED',
+  CAMPAIGN_EXPIRED: 'CAMPAIGN_EXPIRED',
+  CAMPAIGN_INACTIVE: 'CAMPAIGN_INACTIVE',
+  SESSION_NOT_FOUND: 'SESSION_NOT_FOUND',
+  SESSION_EXPIRED: 'SESSION_EXPIRED',
+  SESSION_INVALID_STATE: 'SESSION_INVALID_STATE',
+  INVALID_DATE_RANGE: 'INVALID_DATE_RANGE',
+  AUDIT_LOG_NOT_FOUND: 'AUDIT_LOG_NOT_FOUND',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Canonical Aggregated Catalog
+// ---------------------------------------------------------------------------
+export const ERROR_CODES = {
+  ...BASE_ERROR_CODES,
+  ...VALIDATION_ERROR_CODES,
+  ...DATABASE_ERROR_CODES,
+  ...AUTH_ERROR_CODES,
+  ...DOMAIN_ERROR_CODES,
+  ...INTEGRATION_ERROR_CODES,
+} as const;
+
+/**
+ * Alias for ERROR_CODES representing the canonical API error code catalog
+ */
+export const API_ERROR_CODES = ERROR_CODES;
+
+/**
+ * String union of all valid error code identifiers
+ */
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+/**
+ * Enumeration of error codes for typed client usage
+ */
+export enum ApiErrorCode {
+  // Base / HTTP
+  BAD_REQUEST = 'BAD_REQUEST',
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  FORBIDDEN = 'FORBIDDEN',
+  NOT_FOUND = 'NOT_FOUND',
+  METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED',
+  CONFLICT = 'CONFLICT',
+  UNPROCESSABLE_ENTITY = 'UNPROCESSABLE_ENTITY',
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
+  NOT_IMPLEMENTED = 'NOT_IMPLEMENTED',
+  BAD_GATEWAY = 'BAD_GATEWAY',
+  SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
+  GATEWAY_TIMEOUT = 'GATEWAY_TIMEOUT',
+  TIMEOUT = 'TIMEOUT',
+  INVALID_OPERATION = 'INVALID_OPERATION',
+  DEPENDENCY_FAILURE = 'DEPENDENCY_FAILURE',
+
+  // Validation
+  VALIDATION_ERROR = 'VALIDATION_ERROR',
+  INVALID_INPUT = 'INVALID_INPUT',
+  MISSING_REQUIRED_FIELD = 'MISSING_REQUIRED_FIELD',
+  INVALID_FORMAT = 'INVALID_FORMAT',
+
+  // Database
+  DATABASE_ERROR = 'DATABASE_ERROR',
+  RECORD_NOT_FOUND = 'RECORD_NOT_FOUND',
+  UNIQUE_CONSTRAINT_VIOLATION = 'UNIQUE_CONSTRAINT_VIOLATION',
+  FOREIGN_KEY_VIOLATION = 'FOREIGN_KEY_VIOLATION',
+  VALUE_TOO_LONG = 'VALUE_TOO_LONG',
+
+  // Auth & Security
+  UNAUTHENTICATED = 'UNAUTHENTICATED',
+  INVALID_CREDENTIALS = 'INVALID_CREDENTIALS',
+  TOKEN_EXPIRED = 'TOKEN_EXPIRED',
+  INVALID_TOKEN = 'INVALID_TOKEN',
+  API_KEY_NOT_FOUND = 'API_KEY_NOT_FOUND',
+  API_KEY_REVOKED = 'API_KEY_REVOKED',
+  API_KEY_EXPIRED = 'API_KEY_EXPIRED',
+  API_KEY_INVALID = 'API_KEY_INVALID',
+  INSUFFICIENT_PERMISSIONS = 'INSUFFICIENT_PERMISSIONS',
+  SCOPE_REQUIRED = 'SCOPE_REQUIRED',
+
+  // Domain
+  CLAIM_NOT_FOUND = 'CLAIM_NOT_FOUND',
+  CLAIM_ALREADY_CANCELLED = 'CLAIM_ALREADY_CANCELLED',
+  CLAIM_ALREADY_REISSUED = 'CLAIM_ALREADY_REISSUED',
+  CLAIM_EXPIRED = 'CLAIM_EXPIRED',
+  CLAIM_INVALID_STATE = 'CLAIM_INVALID_STATE',
+  CAMPAIGN_NOT_FOUND = 'CAMPAIGN_NOT_FOUND',
+  CAMPAIGN_FUNDING_CAP_EXCEEDED = 'CAMPAIGN_FUNDING_CAP_EXCEEDED',
+  CAMPAIGN_EXPIRED = 'CAMPAIGN_EXPIRED',
+  CAMPAIGN_INACTIVE = 'CAMPAIGN_INACTIVE',
+  SESSION_NOT_FOUND = 'SESSION_NOT_FOUND',
+  SESSION_EXPIRED = 'SESSION_EXPIRED',
+  SESSION_INVALID_STATE = 'SESSION_INVALID_STATE',
+  INVALID_DATE_RANGE = 'INVALID_DATE_RANGE',
+  AUDIT_LOG_NOT_FOUND = 'AUDIT_LOG_NOT_FOUND',
+
+  // AI Integration
+  AI_SERVICE_UNAVAILABLE = 'AI_SERVICE_UNAVAILABLE',
+  AI_SERVICE_TIMEOUT = 'AI_SERVICE_TIMEOUT',
+  AI_INVALID_RESPONSE = 'AI_INVALID_RESPONSE',
+  AI_QUOTA_EXCEEDED = 'AI_QUOTA_EXCEEDED',
+  AI_VERIFICATION_FAILED = 'AI_VERIFICATION_FAILED',
+
+  // Onchain Integration
+  ONCHAIN_NETWORK_UNREACHABLE = 'ONCHAIN_NETWORK_UNREACHABLE',
+  ONCHAIN_TRANSACTION_TIMEOUT = 'ONCHAIN_TRANSACTION_TIMEOUT',
+  ONCHAIN_TRANSACTION_FAILED = 'ONCHAIN_TRANSACTION_FAILED',
+  ONCHAIN_CONTRACT_ERROR = 'ONCHAIN_CONTRACT_ERROR',
+  ONCHAIN_INSUFFICIENT_FUNDS = 'ONCHAIN_INSUFFICIENT_FUNDS',
+  ONCHAIN_PACKAGE_NOT_FOUND = 'ONCHAIN_PACKAGE_NOT_FOUND',
+  ONCHAIN_PACKAGE_EXPIRED = 'ONCHAIN_PACKAGE_EXPIRED',
+  ONCHAIN_INVALID_STATE = 'ONCHAIN_INVALID_STATE',
+  ONCHAIN_NOT_AUTHORIZED = 'ONCHAIN_NOT_AUTHORIZED',
+  ONCHAIN_CONTRACT_PAUSED = 'ONCHAIN_CONTRACT_PAUSED',
+  ONCHAIN_TOKEN_TRANSFER_FAILED = 'ONCHAIN_TOKEN_TRANSFER_FAILED',
+  ONCHAIN_RPC_ERROR = 'ONCHAIN_RPC_ERROR',
+
+  // Evidence Integration
+  EVIDENCE_UPLOAD_FAILED = 'EVIDENCE_UPLOAD_FAILED',
+  EVIDENCE_INVALID_FILE_TYPE = 'EVIDENCE_INVALID_FILE_TYPE',
+  EVIDENCE_FILE_TOO_LARGE = 'EVIDENCE_FILE_TOO_LARGE',
+  EVIDENCE_MISSING_FILE = 'EVIDENCE_MISSING_FILE',
+  EVIDENCE_NOT_FOUND = 'EVIDENCE_NOT_FOUND',
+  EVIDENCE_ACCESS_DENIED = 'EVIDENCE_ACCESS_DENIED',
+  EVIDENCE_CORRUPT_FILE = 'EVIDENCE_CORRUPT_FILE',
+
+  // Webhooks Integration
+  WEBHOOK_DUPLICATE_EVENT = 'WEBHOOK_DUPLICATE_EVENT',
+  WEBHOOK_SESSION_NOT_FOUND = 'WEBHOOK_SESSION_NOT_FOUND',
+  WEBHOOK_STEP_NOT_FOUND = 'WEBHOOK_STEP_NOT_FOUND',
+  WEBHOOK_INVALID_SIGNATURE = 'WEBHOOK_INVALID_SIGNATURE',
+  WEBHOOK_DELIVERY_FAILED = 'WEBHOOK_DELIVERY_FAILED',
+  WEBHOOK_INVALID_PAYLOAD = 'WEBHOOK_INVALID_PAYLOAD',
+}
+
+/**
+ * Map HTTP status codes to standard catalog error codes
+ */
+export function getErrorCodeFromStatus(status: number): ErrorCode {
+  const statusMap: Record<number, ErrorCode> = {
+    400: ERROR_CODES.BAD_REQUEST,
+    401: ERROR_CODES.UNAUTHORIZED,
+    403: ERROR_CODES.FORBIDDEN,
+    404: ERROR_CODES.NOT_FOUND,
+    405: ERROR_CODES.METHOD_NOT_ALLOWED,
+    409: ERROR_CODES.CONFLICT,
+    422: ERROR_CODES.VALIDATION_ERROR,
+    429: ERROR_CODES.RATE_LIMIT_EXCEEDED,
+    500: ERROR_CODES.INTERNAL_SERVER_ERROR,
+    501: ERROR_CODES.NOT_IMPLEMENTED,
+    502: ERROR_CODES.BAD_GATEWAY,
+    503: ERROR_CODES.SERVICE_UNAVAILABLE,
+    504: ERROR_CODES.GATEWAY_TIMEOUT,
+  };
+  return statusMap[status] || ERROR_CODES.INTERNAL_SERVER_ERROR;
+}
+
+/**
+ * Metadata descriptor for an error code
+ */
+export interface ErrorCodeDescriptor {
+  code: ErrorCode;
+  httpStatus: number;
+  description: string;
+}
+
+/**
+ * Catalog metadata mapping error codes to default HTTP statuses and descriptions
+ */
+export const ERROR_CODE_METADATA: Record<ErrorCode, ErrorCodeDescriptor> = {
+  [ERROR_CODES.BAD_REQUEST]: {
+    code: ERROR_CODES.BAD_REQUEST,
+    httpStatus: 400,
+    description: 'The request could not be understood or was missing required parameters',
+  },
+  [ERROR_CODES.UNAUTHORIZED]: {
+    code: ERROR_CODES.UNAUTHORIZED,
+    httpStatus: 401,
+    description: 'Authentication is required and has failed or has not been provided',
+  },
+  [ERROR_CODES.FORBIDDEN]: {
+    code: ERROR_CODES.FORBIDDEN,
+    httpStatus: 403,
+    description: 'The authenticated user does not have permission to access this resource',
+  },
+  [ERROR_CODES.NOT_FOUND]: {
+    code: ERROR_CODES.NOT_FOUND,
+    httpStatus: 404,
+    description: 'The requested resource was not found',
+  },
+  [ERROR_CODES.METHOD_NOT_ALLOWED]: {
+    code: ERROR_CODES.METHOD_NOT_ALLOWED,
+    httpStatus: 405,
+    description: 'The HTTP method is not supported for this endpoint',
+  },
+  [ERROR_CODES.CONFLICT]: {
+    code: ERROR_CODES.CONFLICT,
+    httpStatus: 409,
+    description: 'The request conflicts with the current state of the target resource',
+  },
+  [ERROR_CODES.UNPROCESSABLE_ENTITY]: {
+    code: ERROR_CODES.UNPROCESSABLE_ENTITY,
+    httpStatus: 422,
+    description: 'The request was well-formed but was unable to be followed due to semantic errors',
+  },
+  [ERROR_CODES.RATE_LIMIT_EXCEEDED]: {
+    code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
+    httpStatus: 429,
+    description: 'Too many requests were sent within a given time window',
+  },
+  [ERROR_CODES.INTERNAL_SERVER_ERROR]: {
+    code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+    httpStatus: 500,
+    description: 'An unexpected internal server error occurred',
+  },
+  [ERROR_CODES.NOT_IMPLEMENTED]: {
+    code: ERROR_CODES.NOT_IMPLEMENTED,
+    httpStatus: 501,
+    description: 'The requested functionality is not yet implemented',
+  },
+  [ERROR_CODES.BAD_GATEWAY]: {
+    code: ERROR_CODES.BAD_GATEWAY,
+    httpStatus: 502,
+    description: 'Received an invalid response from an upstream server',
+  },
+  [ERROR_CODES.SERVICE_UNAVAILABLE]: {
+    code: ERROR_CODES.SERVICE_UNAVAILABLE,
+    httpStatus: 503,
+    description: 'The service is temporarily unavailable or undergoing maintenance',
+  },
+  [ERROR_CODES.GATEWAY_TIMEOUT]: {
+    code: ERROR_CODES.GATEWAY_TIMEOUT,
+    httpStatus: 504,
+    description: 'An upstream server failed to send a response in time',
+  },
+  [ERROR_CODES.TIMEOUT]: {
+    code: ERROR_CODES.TIMEOUT,
+    httpStatus: 504,
+    description: 'The operation timed out',
+  },
+  [ERROR_CODES.INVALID_OPERATION]: {
+    code: ERROR_CODES.INVALID_OPERATION,
+    httpStatus: 400,
+    description: 'The requested operation is not valid for the current resource state',
+  },
+  [ERROR_CODES.DEPENDENCY_FAILURE]: {
+    code: ERROR_CODES.DEPENDENCY_FAILURE,
+    httpStatus: 502,
+    description: 'A required downstream service failed to execute properly',
+  },
+  [ERROR_CODES.VALIDATION_ERROR]: {
+    code: ERROR_CODES.VALIDATION_ERROR,
+    httpStatus: 422,
+    description: 'Input payload failed schema validation',
+  },
+  [ERROR_CODES.INVALID_INPUT]: {
+    code: ERROR_CODES.INVALID_INPUT,
+    httpStatus: 400,
+    description: 'Supplied input parameters are invalid',
+  },
+  [ERROR_CODES.MISSING_REQUIRED_FIELD]: {
+    code: ERROR_CODES.MISSING_REQUIRED_FIELD,
+    httpStatus: 400,
+    description: 'One or more required fields are missing from the request',
+  },
+  [ERROR_CODES.INVALID_FORMAT]: {
+    code: ERROR_CODES.INVALID_FORMAT,
+    httpStatus: 400,
+    description: 'Data format is invalid or cannot be parsed',
+  },
+  [ERROR_CODES.DATABASE_ERROR]: {
+    code: ERROR_CODES.DATABASE_ERROR,
+    httpStatus: 500,
+    description: 'A database error occurred while executing the query',
+  },
+  [ERROR_CODES.RECORD_NOT_FOUND]: {
+    code: ERROR_CODES.RECORD_NOT_FOUND,
+    httpStatus: 404,
+    description: 'The database record was not found',
+  },
+  [ERROR_CODES.UNIQUE_CONSTRAINT_VIOLATION]: {
+    code: ERROR_CODES.UNIQUE_CONSTRAINT_VIOLATION,
+    httpStatus: 409,
+    description: 'A resource with unique properties already exists',
+  },
+  [ERROR_CODES.FOREIGN_KEY_VIOLATION]: {
+    code: ERROR_CODES.FOREIGN_KEY_VIOLATION,
+    httpStatus: 400,
+    description: 'Referenced foreign key entity does not exist',
+  },
+  [ERROR_CODES.VALUE_TOO_LONG]: {
+    code: ERROR_CODES.VALUE_TOO_LONG,
+    httpStatus: 400,
+    description: 'Field value exceeds maximum allowed length',
+  },
+  [ERROR_CODES.UNAUTHENTICATED]: {
+    code: ERROR_CODES.UNAUTHENTICATED,
+    httpStatus: 401,
+    description: 'User is not authenticated',
+  },
+  [ERROR_CODES.INVALID_CREDENTIALS]: {
+    code: ERROR_CODES.INVALID_CREDENTIALS,
+    httpStatus: 401,
+    description: 'Provided credentials are invalid',
+  },
+  [ERROR_CODES.TOKEN_EXPIRED]: {
+    code: ERROR_CODES.TOKEN_EXPIRED,
+    httpStatus: 401,
+    description: 'Authentication token has expired',
+  },
+  [ERROR_CODES.INVALID_TOKEN]: {
+    code: ERROR_CODES.INVALID_TOKEN,
+    httpStatus: 401,
+    description: 'Authentication token is malformed or invalid',
+  },
+  [ERROR_CODES.API_KEY_NOT_FOUND]: {
+    code: ERROR_CODES.API_KEY_NOT_FOUND,
+    httpStatus: 401,
+    description: 'API key was not found',
+  },
+  [ERROR_CODES.API_KEY_REVOKED]: {
+    code: ERROR_CODES.API_KEY_REVOKED,
+    httpStatus: 401,
+    description: 'API key has been revoked',
+  },
+  [ERROR_CODES.API_KEY_EXPIRED]: {
+    code: ERROR_CODES.API_KEY_EXPIRED,
+    httpStatus: 401,
+    description: 'API key has expired',
+  },
+  [ERROR_CODES.API_KEY_INVALID]: {
+    code: ERROR_CODES.API_KEY_INVALID,
+    httpStatus: 401,
+    description: 'API key is invalid or header format is incorrect',
+  },
+  [ERROR_CODES.INSUFFICIENT_PERMISSIONS]: {
+    code: ERROR_CODES.INSUFFICIENT_PERMISSIONS,
+    httpStatus: 403,
+    description: 'User lacks required permissions or roles',
+  },
+  [ERROR_CODES.SCOPE_REQUIRED]: {
+    code: ERROR_CODES.SCOPE_REQUIRED,
+    httpStatus: 403,
+    description: 'API key lacks the required scope for this operation',
+  },
+  [ERROR_CODES.CLAIM_NOT_FOUND]: {
+    code: ERROR_CODES.CLAIM_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Claim was not found',
+  },
+  [ERROR_CODES.CLAIM_ALREADY_CANCELLED]: {
+    code: ERROR_CODES.CLAIM_ALREADY_CANCELLED,
+    httpStatus: 400,
+    description: 'Claim is already in cancelled state',
+  },
+  [ERROR_CODES.CLAIM_ALREADY_REISSUED]: {
+    code: ERROR_CODES.CLAIM_ALREADY_REISSUED,
+    httpStatus: 400,
+    description: 'Claim has already been reissued',
+  },
+  [ERROR_CODES.CLAIM_EXPIRED]: {
+    code: ERROR_CODES.CLAIM_EXPIRED,
+    httpStatus: 400,
+    description: 'Claim validity period has expired',
+  },
+  [ERROR_CODES.CLAIM_INVALID_STATE]: {
+    code: ERROR_CODES.CLAIM_INVALID_STATE,
+    httpStatus: 400,
+    description: 'Claim is not in an actionable state for this operation',
+  },
+  [ERROR_CODES.CAMPAIGN_NOT_FOUND]: {
+    code: ERROR_CODES.CAMPAIGN_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Campaign was not found',
+  },
+  [ERROR_CODES.CAMPAIGN_FUNDING_CAP_EXCEEDED]: {
+    code: ERROR_CODES.CAMPAIGN_FUNDING_CAP_EXCEEDED,
+    httpStatus: 400,
+    description: 'Campaign funding cap has been reached or exceeded',
+  },
+  [ERROR_CODES.CAMPAIGN_EXPIRED]: {
+    code: ERROR_CODES.CAMPAIGN_EXPIRED,
+    httpStatus: 400,
+    description: 'Campaign has ended',
+  },
+  [ERROR_CODES.CAMPAIGN_INACTIVE]: {
+    code: ERROR_CODES.CAMPAIGN_INACTIVE,
+    httpStatus: 400,
+    description: 'Campaign is not currently active',
+  },
+  [ERROR_CODES.SESSION_NOT_FOUND]: {
+    code: ERROR_CODES.SESSION_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Verification session not found',
+  },
+  [ERROR_CODES.SESSION_EXPIRED]: {
+    code: ERROR_CODES.SESSION_EXPIRED,
+    httpStatus: 400,
+    description: 'Verification session has expired',
+  },
+  [ERROR_CODES.SESSION_INVALID_STATE]: {
+    code: ERROR_CODES.SESSION_INVALID_STATE,
+    httpStatus: 400,
+    description: 'Verification session is not in a valid state',
+  },
+  [ERROR_CODES.INVALID_DATE_RANGE]: {
+    code: ERROR_CODES.INVALID_DATE_RANGE,
+    httpStatus: 400,
+    description: 'Specified date query parameters are invalid or start date is after end date',
+  },
+  [ERROR_CODES.AUDIT_LOG_NOT_FOUND]: {
+    code: ERROR_CODES.AUDIT_LOG_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Audit log entry was not found',
+  },
+  // AI
+  [ERROR_CODES.AI_SERVICE_UNAVAILABLE]: {
+    code: ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+    httpStatus: 503,
+    description: 'External AI/OCR service did not respond or circuit breaker is open',
+  },
+  [ERROR_CODES.AI_SERVICE_TIMEOUT]: {
+    code: ERROR_CODES.AI_SERVICE_TIMEOUT,
+    httpStatus: 504,
+    description: 'AI service call exceeded timeout deadline',
+  },
+  [ERROR_CODES.AI_INVALID_RESPONSE]: {
+    code: ERROR_CODES.AI_INVALID_RESPONSE,
+    httpStatus: 502,
+    description: 'AI service returned malformed or unexpected response',
+  },
+  [ERROR_CODES.AI_QUOTA_EXCEEDED]: {
+    code: ERROR_CODES.AI_QUOTA_EXCEEDED,
+    httpStatus: 429,
+    description: 'AI provider quota or rate limit exceeded',
+  },
+  [ERROR_CODES.AI_VERIFICATION_FAILED]: {
+    code: ERROR_CODES.AI_VERIFICATION_FAILED,
+    httpStatus: 422,
+    description: 'AI verification pipeline produced a low confidence or un-reviewable result',
+  },
+  // Onchain
+  [ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE]: {
+    code: ERROR_CODES.ONCHAIN_NETWORK_UNREACHABLE,
+    httpStatus: 503,
+    description: 'Soroban RPC endpoint could not be reached',
+  },
+  [ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT]: {
+    code: ERROR_CODES.ONCHAIN_TRANSACTION_TIMEOUT,
+    httpStatus: 504,
+    description: 'Blockchain transaction submission or polling timed out',
+  },
+  [ERROR_CODES.ONCHAIN_TRANSACTION_FAILED]: {
+    code: ERROR_CODES.ONCHAIN_TRANSACTION_FAILED,
+    httpStatus: 400,
+    description: 'Onchain transaction execution failed or was rejected',
+  },
+  [ERROR_CODES.ONCHAIN_CONTRACT_ERROR]: {
+    code: ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
+    httpStatus: 400,
+    description: 'Smart contract returned an error',
+  },
+  [ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS]: {
+    code: ERROR_CODES.ONCHAIN_INSUFFICIENT_FUNDS,
+    httpStatus: 400,
+    description: 'Escrow or account has insufficient funds for operation',
+  },
+  [ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND]: {
+    code: ERROR_CODES.ONCHAIN_PACKAGE_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Aid package not found on blockchain',
+  },
+  [ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED]: {
+    code: ERROR_CODES.ONCHAIN_PACKAGE_EXPIRED,
+    httpStatus: 400,
+    description: 'Aid package claim window is closed',
+  },
+  [ERROR_CODES.ONCHAIN_INVALID_STATE]: {
+    code: ERROR_CODES.ONCHAIN_INVALID_STATE,
+    httpStatus: 400,
+    description: 'Invalid package state transition onchain',
+  },
+  [ERROR_CODES.ONCHAIN_NOT_AUTHORIZED]: {
+    code: ERROR_CODES.ONCHAIN_NOT_AUTHORIZED,
+    httpStatus: 403,
+    description: 'Signer is not authorized for contract operation',
+  },
+  [ERROR_CODES.ONCHAIN_CONTRACT_PAUSED]: {
+    code: ERROR_CODES.ONCHAIN_CONTRACT_PAUSED,
+    httpStatus: 503,
+    description: 'Smart contract is paused',
+  },
+  [ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED]: {
+    code: ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED,
+    httpStatus: 400,
+    description: 'Token transfer failed on blockchain',
+  },
+  [ERROR_CODES.ONCHAIN_RPC_ERROR]: {
+    code: ERROR_CODES.ONCHAIN_RPC_ERROR,
+    httpStatus: 502,
+    description: 'Soroban JSON-RPC error',
+  },
+  // Evidence
+  [ERROR_CODES.EVIDENCE_UPLOAD_FAILED]: {
+    code: ERROR_CODES.EVIDENCE_UPLOAD_FAILED,
+    httpStatus: 500,
+    description: 'Evidence file could not be stored or encrypted',
+  },
+  [ERROR_CODES.EVIDENCE_INVALID_FILE_TYPE]: {
+    code: ERROR_CODES.EVIDENCE_INVALID_FILE_TYPE,
+    httpStatus: 400,
+    description: 'Evidence file MIME type or format is not supported',
+  },
+  [ERROR_CODES.EVIDENCE_FILE_TOO_LARGE]: {
+    code: ERROR_CODES.EVIDENCE_FILE_TOO_LARGE,
+    httpStatus: 413,
+    description: 'Evidence file size exceeds allowed limit',
+  },
+  [ERROR_CODES.EVIDENCE_MISSING_FILE]: {
+    code: ERROR_CODES.EVIDENCE_MISSING_FILE,
+    httpStatus: 400,
+    description: 'Multipart request missing required file',
+  },
+  [ERROR_CODES.EVIDENCE_NOT_FOUND]: {
+    code: ERROR_CODES.EVIDENCE_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Evidence record not found',
+  },
+  [ERROR_CODES.EVIDENCE_ACCESS_DENIED]: {
+    code: ERROR_CODES.EVIDENCE_ACCESS_DENIED,
+    httpStatus: 403,
+    description: 'Access to evidence artifact is denied',
+  },
+  [ERROR_CODES.EVIDENCE_CORRUPT_FILE]: {
+    code: ERROR_CODES.EVIDENCE_CORRUPT_FILE,
+    httpStatus: 422,
+    description: 'Evidence file content does not match declared MIME header',
+  },
+  // Webhooks
+  [ERROR_CODES.WEBHOOK_DUPLICATE_EVENT]: {
+    code: ERROR_CODES.WEBHOOK_DUPLICATE_EVENT,
+    httpStatus: 409,
+    description: 'Duplicate webhook event received (idempotency key matched)',
+  },
+  [ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND]: {
+    code: ERROR_CODES.WEBHOOK_SESSION_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Session referenced in webhook was not found',
+  },
+  [ERROR_CODES.WEBHOOK_STEP_NOT_FOUND]: {
+    code: ERROR_CODES.WEBHOOK_STEP_NOT_FOUND,
+    httpStatus: 404,
+    description: 'Verification step in webhook payload was not found',
+  },
+  [ERROR_CODES.WEBHOOK_INVALID_SIGNATURE]: {
+    code: ERROR_CODES.WEBHOOK_INVALID_SIGNATURE,
+    httpStatus: 401,
+    description: 'Webhook HMAC signature verification failed',
+  },
+  [ERROR_CODES.WEBHOOK_DELIVERY_FAILED]: {
+    code: ERROR_CODES.WEBHOOK_DELIVERY_FAILED,
+    httpStatus: 502,
+    description: 'Outbound webhook delivery failed after retries exhausted',
+  },
+  [ERROR_CODES.WEBHOOK_INVALID_PAYLOAD]: {
+    code: ERROR_CODES.WEBHOOK_INVALID_PAYLOAD,
+    httpStatus: 400,
+    description: 'Webhook payload schema validation failed',
+  },
+};

--- a/app/backend/src/common/dto/error-response.dto.ts
+++ b/app/backend/src/common/dto/error-response.dto.ts
@@ -1,12 +1,40 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { INTEGRATION_ERROR_CODES } from '../constants/integration-error-codes';
-
-// Re-export integration codes so consumers only need one import path.
-export { INTEGRATION_ERROR_CODES } from '../constants/integration-error-codes';
-export {
+import {
+  ERROR_CODES,
+  API_ERROR_CODES,
+  BASE_ERROR_CODES,
+  VALIDATION_ERROR_CODES,
+  DATABASE_ERROR_CODES,
+  AUTH_ERROR_CODES,
+  DOMAIN_ERROR_CODES,
+  INTEGRATION_ERROR_CODES,
+  ApiErrorCode,
+  ErrorCode,
+  ErrorCodeDescriptor,
+  ERROR_CODE_METADATA,
+  getErrorCodeFromStatus,
   AppException,
   type IntegrationErrorCode,
-} from '../constants/integration-error-codes';
+} from '../constants/error-codes';
+
+// Re-export error codes, enums, metadata and AppException so consumers can import from DTO or constants
+export {
+  ERROR_CODES,
+  API_ERROR_CODES,
+  BASE_ERROR_CODES,
+  VALIDATION_ERROR_CODES,
+  DATABASE_ERROR_CODES,
+  AUTH_ERROR_CODES,
+  DOMAIN_ERROR_CODES,
+  INTEGRATION_ERROR_CODES,
+  ApiErrorCode,
+  ErrorCode,
+  ErrorCodeDescriptor,
+  ERROR_CODE_METADATA,
+  getErrorCodeFromStatus,
+  AppException,
+  type IntegrationErrorCode,
+};
 
 /**
  * Standardized error response format for all API endpoints
@@ -61,52 +89,4 @@ export class ErrorResponseDto {
     example: 'req_abc123',
   })
   correlationId?: string;
-}
-
-/**
- * Standard error codes for programmatic handling.
- * Integration-specific codes are merged in from INTEGRATION_ERROR_CODES so
- * both the base and domain codes are accessible from a single constant.
- */
-export const ERROR_CODES = {
-  // Base codes
-  VALIDATION_ERROR: 'VALIDATION_ERROR',
-  NOT_FOUND: 'NOT_FOUND',
-  UNAUTHORIZED: 'UNAUTHORIZED',
-  FORBIDDEN: 'FORBIDDEN',
-  CONFLICT: 'CONFLICT',
-  BAD_REQUEST: 'BAD_REQUEST',
-  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
-  RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
-  SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
-  DATABASE_ERROR: 'DATABASE_ERROR',
-  FOREIGN_KEY_VIOLATION: 'FOREIGN_KEY_VIOLATION',
-  UNIQUE_CONSTRAINT_VIOLATION: 'UNIQUE_CONSTRAINT_VIOLATION',
-  RECORD_NOT_FOUND: 'RECORD_NOT_FOUND',
-  VALUE_TOO_LONG: 'VALUE_TOO_LONG',
-  INVALID_OPERATION: 'INVALID_OPERATION',
-  DEPENDENCY_FAILURE: 'DEPENDENCY_FAILURE',
-  TIMEOUT: 'TIMEOUT',
-  // Integration codes (AI, onchain, evidence, webhook)
-  ...INTEGRATION_ERROR_CODES,
-} as const;
-
-export type ErrorCode = keyof typeof ERROR_CODES;
-
-/**
- * Map HTTP status codes to error codes
- */
-export function getErrorCodeFromStatus(status: number): ErrorCode {
-  const statusMap: Record<number, ErrorCode> = {
-    400: 'BAD_REQUEST',
-    401: 'UNAUTHORIZED',
-    403: 'FORBIDDEN',
-    404: 'NOT_FOUND',
-    409: 'CONFLICT',
-    422: 'VALIDATION_ERROR',
-    429: 'RATE_LIMIT_EXCEEDED',
-    500: 'INTERNAL_SERVER_ERROR',
-    503: 'SERVICE_UNAVAILABLE',
-  };
-  return statusMap[status] || 'INTERNAL_SERVER_ERROR';
 }

--- a/app/backend/src/common/filters/all-exceptions.filter.spec.ts
+++ b/app/backend/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,6 +1,8 @@
 import { ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import { ValidationError } from 'class-validator';
 import { AllExceptionsFilter, ErrorResponse } from './http-exception.filter';
 import { LoggerService } from '../../logger/logger.service';
+import { AppException, ERROR_CODES } from '../constants/error-codes';
 
 describe('AllExceptionsFilter', () => {
   let filter: AllExceptionsFilter;
@@ -45,7 +47,7 @@ describe('AllExceptionsFilter', () => {
   });
 
   describe('ErrorResponse shape', () => {
-    it('should always include code, message, timestamp, and path', () => {
+    it('should always include code, message, timestamp, path, and errorCode', () => {
       const exception = new Error('Test error');
 
       filter.catch(exception, mockHost);
@@ -55,10 +57,13 @@ describe('AllExceptionsFilter', () => {
       expect(body).toHaveProperty('message');
       expect(body).toHaveProperty('timestamp');
       expect(body).toHaveProperty('path');
+      expect(body).toHaveProperty('errorCode');
       expect(typeof body.code).toBe('number');
       expect(typeof body.message).toBe('string');
       expect(typeof body.timestamp).toBe('string');
       expect(typeof body.path).toBe('string');
+      expect(typeof body.errorCode).toBe('string');
+      expect(body.errorCode).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
     });
 
     it('should include traceId from x-request-id header', () => {
@@ -70,7 +75,7 @@ describe('AllExceptionsFilter', () => {
       expect(body.traceId).toBe('test-trace-id-123');
     });
 
-    it('should have undefined traceId when x-request-id header is absent', () => {
+    it('should have undefined traceId when headers are absent', () => {
       mockRequest.headers = {};
       const exception = new Error('Test error');
 
@@ -78,6 +83,43 @@ describe('AllExceptionsFilter', () => {
 
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.traceId).toBeUndefined();
+    });
+  });
+
+  describe('AppException handling', () => {
+    it('should emit the exact canonical errorCode and status defined on AppException', () => {
+      const exception = new AppException(
+        ERROR_CODES.AI_SERVICE_UNAVAILABLE,
+        503,
+        'AI service unavailable',
+        { retryAfter: 60 },
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(503);
+      const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
+      expect(body.code).toBe(503);
+      expect(body.errorCode).toBe(ERROR_CODES.AI_SERVICE_UNAVAILABLE);
+      expect(body.message).toBe('AI service unavailable');
+      expect(body.details).toEqual({ retryAfter: 60 });
+      expect(body.traceId).toBe('test-trace-id-123');
+    });
+
+    it('should handle domain-specific AppException like CLAIM_NOT_FOUND', () => {
+      const exception = new AppException(
+        ERROR_CODES.CLAIM_NOT_FOUND,
+        404,
+        'Claim not found',
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
+      expect(body.code).toBe(404);
+      expect(body.errorCode).toBe(ERROR_CODES.CLAIM_NOT_FOUND);
+      expect(body.message).toBe('Claim not found');
     });
   });
 
@@ -93,6 +135,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(400);
+      expect(body.errorCode).toBe(ERROR_CODES.BAD_REQUEST);
       expect(body.message).toBe('Bad request');
     });
 
@@ -104,6 +147,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(404);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(404);
+      expect(body.errorCode).toBe(ERROR_CODES.NOT_FOUND);
     });
 
     it('should handle UnauthorizedException (401)', () => {
@@ -117,6 +161,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(401);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(401);
+      expect(body.errorCode).toBe(ERROR_CODES.UNAUTHORIZED);
       expect(body.message).toBe('Unauthorized');
     });
 
@@ -128,6 +173,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(403);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(403);
+      expect(body.errorCode).toBe(ERROR_CODES.FORBIDDEN);
     });
 
     it('should handle InternalServerErrorException (500)', () => {
@@ -141,11 +187,16 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(500);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(500);
+      expect(body.errorCode).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
     });
 
-    it('should extract message from object response', () => {
+    it('should extract message and preserve custom errorCode from object response', () => {
       const exception = new HttpException(
-        { statusCode: 400, message: 'Validation failed', error: 'Bad Request' },
+        {
+          statusCode: 400,
+          message: 'Campaign funding cap exceeded',
+          errorCode: ERROR_CODES.CAMPAIGN_FUNDING_CAP_EXCEEDED,
+        },
         HttpStatus.BAD_REQUEST,
       );
 
@@ -153,13 +204,52 @@ describe('AllExceptionsFilter', () => {
 
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(400);
-      expect(body.message).toBe('Validation failed');
-      expect(body.details).toEqual(
-        expect.objectContaining({
+      expect(body.message).toBe('Campaign funding cap exceeded');
+      expect(body.errorCode).toBe(ERROR_CODES.CAMPAIGN_FUNDING_CAP_EXCEEDED);
+    });
+
+    it('should map array validation messages to VALIDATION_ERROR', () => {
+      const exception = new HttpException(
+        {
           statusCode: 400,
-          message: 'Validation failed',
-        }),
+          message: ['email must be an email', 'name should not be empty'],
+          error: 'Bad Request',
+        },
+        HttpStatus.BAD_REQUEST,
       );
+
+      filter.catch(exception, mockHost);
+
+      const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
+      expect(body.code).toBe(400);
+      expect(body.errorCode).toBe(ERROR_CODES.VALIDATION_ERROR);
+      expect(body.message).toContain('email must be an email');
+    });
+  });
+
+  describe('Validation errors handling', () => {
+    it('should handle class-validator ValidationError array as 422 VALIDATION_ERROR', () => {
+      const validationError = new ValidationError();
+      validationError.property = 'email';
+      validationError.value = 'invalid-email';
+      validationError.constraints = { isEmail: 'email must be an email' };
+
+      filter.catch([validationError], mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
+      expect(body.code).toBe(422);
+      expect(body.errorCode).toBe(ERROR_CODES.VALIDATION_ERROR);
+      expect(body.message).toBe('Validation failed');
+      expect(body.details).toEqual({
+        errors: [
+          {
+            property: 'email',
+            value: 'invalid-email',
+            constraints: { isEmail: 'email must be an email' },
+          },
+        ],
+      });
     });
   });
 
@@ -177,6 +267,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(409);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(409);
+      expect(body.errorCode).toBe(ERROR_CODES.UNIQUE_CONSTRAINT_VIOLATION);
       expect(body.message).toBe('Unique constraint violation');
       expect(body.details).toEqual({
         target: ['email'],
@@ -197,6 +288,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(404);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(404);
+      expect(body.errorCode).toBe(ERROR_CODES.RECORD_NOT_FOUND);
       expect(body.message).toBe('Record not found');
     });
 
@@ -213,6 +305,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(400);
+      expect(body.errorCode).toBe(ERROR_CODES.FOREIGN_KEY_VIOLATION);
       expect(body.message).toBe('Foreign key constraint violation');
     });
 
@@ -229,10 +322,11 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(400);
+      expect(body.errorCode).toBe(ERROR_CODES.VALUE_TOO_LONG);
       expect(body.message).toBe('Value too long for column');
     });
 
-    it('should handle unknown Prisma errors as 500', () => {
+    it('should handle unknown Prisma errors as 500 DATABASE_ERROR', () => {
       const prismaError = new Error('Unknown DB error');
       Object.assign(prismaError, {
         code: 'P9999',
@@ -245,6 +339,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(500);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(500);
+      expect(body.errorCode).toBe(ERROR_CODES.DATABASE_ERROR);
       expect(body.details).toEqual({
         code: 'P9999',
         meta: { something: 'unexpected' },
@@ -253,7 +348,7 @@ describe('AllExceptionsFilter', () => {
   });
 
   describe('Generic error handling', () => {
-    it('should handle generic Error as 500', () => {
+    it('should handle generic Error as 500 INTERNAL_SERVER_ERROR', () => {
       const exception = new Error('Something went wrong');
 
       filter.catch(exception, mockHost);
@@ -261,6 +356,7 @@ describe('AllExceptionsFilter', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(500);
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.code).toBe(500);
+      expect(body.errorCode).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
       expect(body.message).toBe('Something went wrong');
       expect(body.details).toEqual(
         expect.objectContaining({ error_type: 'Error' }),
@@ -274,6 +370,7 @@ describe('AllExceptionsFilter', () => {
 
       const body: ErrorResponse = mockResponse.json.mock.calls[0][0];
       expect(body.message).toBe('Internal server error');
+      expect(body.errorCode).toBe(ERROR_CODES.INTERNAL_SERVER_ERROR);
     });
   });
 

--- a/app/backend/src/common/filters/http-exception.filter.ts
+++ b/app/backend/src/common/filters/http-exception.filter.ts
@@ -14,7 +14,7 @@ import {
   ERROR_CODES,
   getErrorCodeFromStatus,
 } from '../dto/error-response.dto';
-import { AppException } from '../constants/integration-error-codes';
+import { AppException } from '../constants/error-codes';
 
 export interface ErrorResponse {
   code: number;
@@ -36,15 +36,19 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
-    const traceId = request.headers['x-request-id'] as string | undefined;
+    const traceId =
+      (request.headers?.['x-request-id'] as string) ||
+      (request.headers?.['x-correlation-id'] as string) ||
+      (request as any).traceId ||
+      undefined;
     const correlationId = (request as any).correlationId || traceId;
 
     // Log the error
     this.logger.error(
-      `[${traceId ?? 'N/A'}] ${exception.constructor?.name ?? 'UnknownError'} | Status: ${
-        exception.status || HttpStatus.INTERNAL_SERVER_ERROR
-      } | Message: ${exception.message} | Path: ${request.url}`,
-      exception.stack,
+      `[${traceId ?? 'N/A'}] ${exception?.constructor?.name ?? 'UnknownError'} | Status: ${
+        exception?.status || exception?.statusCode || HttpStatus.INTERNAL_SERVER_ERROR
+      } | Message: ${exception?.message || 'Unknown error'} | Path: ${request?.url || 'N/A'}`,
+      exception?.stack,
       'AllExceptionsFilter',
     );
 
@@ -96,7 +100,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       message: errorResponse.message,
       traceId: errorResponse.traceId,
       timestamp: errorResponse.timestamp || new Date().toISOString(),
-      path: errorResponse.path || request.url,
+      path: errorResponse.path || request?.url || '',
       details: errorResponse.details,
       errorCode:
         errorResponse.errorCode || getErrorCodeFromStatus(errorResponse.code),
@@ -122,7 +126,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       details: exception.details,
       traceId,
       timestamp: new Date().toISOString(),
-      path: request.url,
+      path: request?.url || '',
       errorCode: exception.errorCode,
       correlationId,
     };
@@ -136,20 +140,38 @@ export class AllExceptionsFilter implements ExceptionFilter {
   ): ErrorResponse {
     const status = exception.getStatus();
     const exceptionResponse = exception.getResponse();
-    const message =
-      typeof exceptionResponse === 'string'
-        ? exceptionResponse
-        : (exceptionResponse as any).message || exception.message;
+    let message: string;
+    let details: any = undefined;
+    let errorCode: string | undefined = undefined;
+
+    if (typeof exceptionResponse === 'string') {
+      message = exceptionResponse;
+    } else if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
+      const resp = exceptionResponse as any;
+      if (Array.isArray(resp.message)) {
+        message = resp.message.join(', ');
+        details = resp;
+        errorCode = ERROR_CODES.VALIDATION_ERROR;
+      } else {
+        message = resp.message || exception.message;
+        details = resp.details !== undefined ? resp.details : resp;
+      }
+
+      if (resp.errorCode) {
+        errorCode = resp.errorCode;
+      }
+    } else {
+      message = exception.message;
+    }
 
     return {
       code: status,
       message: typeof message === 'string' ? message : JSON.stringify(message),
-      details:
-        typeof exceptionResponse === 'object' ? exceptionResponse : undefined,
+      details,
       traceId,
       timestamp: new Date().toISOString(),
-      path: request.url,
-      errorCode: getErrorCodeFromStatus(status),
+      path: request?.url || '',
+      errorCode: errorCode || getErrorCodeFromStatus(status),
       correlationId,
     };
   }
@@ -159,7 +181,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       exception?.constructor?.name?.includes('Prisma') ||
       exception?.clientVersion ||
       exception?.meta?.target ||
-      exception?.code?.startsWith('P')
+      (typeof exception?.code === 'string' && exception.code.startsWith('P'))
     );
   }
 
@@ -223,7 +245,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       details,
       traceId,
       timestamp: new Date().toISOString(),
-      path: request.url,
+      path: request?.url || '',
       errorCode,
       correlationId,
     };
@@ -252,7 +274,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       },
       traceId,
       timestamp: new Date().toISOString(),
-      path: request.url,
+      path: request?.url || '',
       errorCode: ERROR_CODES.VALIDATION_ERROR,
       correlationId,
     };
@@ -277,17 +299,17 @@ export class AllExceptionsFilter implements ExceptionFilter {
   ): ErrorResponse {
     return {
       code: HttpStatus.INTERNAL_SERVER_ERROR,
-      message: exception.message || 'Internal server error',
+      message: exception?.message || 'Internal server error',
       details: {
-        error_type: exception.constructor?.name,
+        error_type: exception?.constructor?.name || 'Error',
         ...(typeof process !== 'undefined' &&
           process.env.NODE_ENV === 'development' && {
-            stack: exception.stack,
+            stack: exception?.stack,
           }),
       },
       traceId,
       timestamp: new Date().toISOString(),
-      path: request.url,
+      path: request?.url || '',
       errorCode: ERROR_CODES.INTERNAL_SERVER_ERROR,
       correlationId,
     };

--- a/app/backend/src/common/index.ts
+++ b/app/backend/src/common/index.ts
@@ -1,15 +1,24 @@
 /**
  * Common Module
  *
- * Shared utilities, constants, decorators, and helpers used across the application.
+ * Shared utilities, constants, decorators, filters, DTOs, and helpers used across the application.
  */
 
-// Constants
+// Constants & Error Catalog
 export * from './constants/api-version.constants';
+export * from './constants/error-codes';
 export * from './constants/integration-error-codes';
+
+// DTOs
+export * from './dto/error-response.dto';
+export * from './dto/api-response.dto';
+
+// Filters
+export * from './filters/http-exception.filter';
 
 // Decorators
 export * from './decorators/deprecated.decorator';
+export * from './decorators/standard-error.decorator';
 
 // Interceptors
 export * from './interceptors/deprecation.interceptor';

--- a/app/backend/test/error-handling.e2e-spec.ts
+++ b/app/backend/test/error-handling.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
 import { RequestIdInterceptor } from '../src/common/interceptors/request-id.interceptor';
+import { ERROR_CODES } from '../src/common/constants/error-codes';
 
 describe('Error Handling (e2e)', () => {
   let app: INestApplication;
@@ -46,10 +47,12 @@ describe('Error Handling (e2e)', () => {
     expect(body).toHaveProperty('message');
     expect(body).toHaveProperty('timestamp');
     expect(body).toHaveProperty('path');
+    expect(body).toHaveProperty('errorCode');
     expect(typeof body.code).toBe('number');
     expect(typeof body.message).toBe('string');
     expect(typeof body.timestamp).toBe('string');
     expect(typeof body.path).toBe('string');
+    expect(typeof body.errorCode).toBe('string');
   };
 
   it('/test-error/generic-error (GET) - should return standardized error response', () => {
@@ -67,6 +70,8 @@ describe('Error Handling (e2e)', () => {
           traceId: expect.any(String),
           timestamp: expect.any(String),
           path: '/api/v1/test-error/generic-error',
+          errorCode: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          correlationId: expect.any(String),
         });
       });
   });
@@ -84,6 +89,8 @@ describe('Error Handling (e2e)', () => {
           traceId: expect.any(String),
           timestamp: expect.any(String),
           path: '/api/v1/test-error/bad-request',
+          errorCode: ERROR_CODES.BAD_REQUEST,
+          correlationId: expect.any(String),
         });
       });
   });
@@ -101,6 +108,8 @@ describe('Error Handling (e2e)', () => {
           traceId: expect.any(String),
           timestamp: expect.any(String),
           path: '/api/v1/test-error/internal-server-error',
+          errorCode: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          correlationId: expect.any(String),
         });
       });
   });
@@ -112,6 +121,7 @@ describe('Error Handling (e2e)', () => {
       .then(response => {
         expectErrorEnvelope(response.body);
         expect(response.body.code).toBe(401);
+        expect(response.body.errorCode).toBe(ERROR_CODES.UNAUTHORIZED);
         expect(response.body.message).toBe('Authentication required');
         expect(response.body).toHaveProperty('traceId');
       });
@@ -124,6 +134,7 @@ describe('Error Handling (e2e)', () => {
       .then(response => {
         expectErrorEnvelope(response.body);
         expect(response.body.code).toBe(403);
+        expect(response.body.errorCode).toBe(ERROR_CODES.FORBIDDEN);
         expect(response.body.message).toBe('Access denied');
         expect(response.body).toHaveProperty('traceId');
       });
@@ -136,6 +147,7 @@ describe('Error Handling (e2e)', () => {
       .then(response => {
         expectErrorEnvelope(response.body);
         expect(response.body.code).toBe(404);
+        expect(response.body.errorCode).toBe(ERROR_CODES.NOT_FOUND);
         expect(response.body.message).toBe('Resource not found');
         expect(response.body).toHaveProperty('traceId');
       });
@@ -149,6 +161,7 @@ describe('Error Handling (e2e)', () => {
       .then(response => {
         expectErrorEnvelope(response.body);
         expect(response.body.code).toBe(400);
+        expect(response.body.errorCode).toBe(ERROR_CODES.VALIDATION_ERROR);
         expect(response.body).toHaveProperty('traceId');
       });
   });
@@ -169,6 +182,8 @@ describe('Error Handling (e2e)', () => {
           traceId: expect.any(String),
           timestamp: expect.any(String),
           path: '/api/v1/test-error/prisma-error-simulation',
+          errorCode: ERROR_CODES.UNIQUE_CONSTRAINT_VIOLATION,
+          correlationId: expect.any(String),
         });
       });
   });


### PR DESCRIPTION
Closes #956 
                                                                                                                                                                                                      Description
Error responses across the backend were shaped inconsistently, causing client error handling to rely on string matching and HTTP status codes alone. This PR introduces a stable canonical machine-readable error code catalog and updates the global exception filter to emit a uniform error envelope across all backend services.

### Acceptance Criteria Satisfied
- [x] Canonical Error Catalog: Created ERROR_CODES, API_ERROR_CODES, ApiErrorCode enum, and ERROR_CODE_METADATA in app/backend/src/common/constants/error-codes.ts.
- [x] Global Exception Filter: Updated AllExceptionsFilter (app/backend/src/common/filters/http-exception.filter.ts) to format all errors (AppException, HttpException, Prisma DB errors, ValidationError[], and internal errors) into a uniform { code, errorCode, message, details?, traceId, timestamp, path, correlationId } structure.
- [x] Exported for Client Consumption: Re-exported all catalog identifiers and types in common/index.ts and error-response.dto.ts.
- [x] Test Coverage: Added unit tests in error-codes.spec.ts & all-exceptions.filter.spec.ts, and end-to-end tests in error-handling.e2e-spec.ts.
- [x] Documentation: Updated app/backend/ERROR_HANDLING.md.