### PR TITLE
Add redaction preview diff endpoint (#775)

### DIFF
--- a/app/ai-service/api/v1/redaction_preview.py
+++ b/app/ai-service/api/v1/redaction_preview.py
@@ -1,0 +1,63 @@
+"""
+v1 redaction preview-diff endpoint.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from schemas.anonymization import AnonymizeRequest, RedactionPreviewResult
+from schemas.common import ResultEnvelope
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["anonymization"])
+
+
+@router.post("/ai/redaction/preview", response_model=ResultEnvelope[RedactionPreviewResult])
+async def preview_redaction(request: AnonymizeRequest) -> ResultEnvelope[RedactionPreviewResult]:
+    """Return a redaction diff (kept vs. redacted segments) without masking the text."""
+    import main as _main
+    from main import correlation_id_var
+
+    logger.info("Processing redaction preview request")
+
+    try:
+        text = request.text
+        service = _main.pii_scrubber_service
+
+        spans = service.detect_spans(text)
+        segments = service.build_preview_segments(text, spans)
+
+        names = sum(1 for s in spans if s.label == "PERSON")
+        locations = sum(1 for s in spans if s.label == "LOCATION")
+        dates = sum(1 for s in spans if s.label == "DATE")
+        emails = sum(1 for s in spans if s.label == "EMAIL")
+        phones = sum(1 for s in spans if s.label == "PHONE")
+        ids = sum(1 for s in spans if s.label == "ID")
+
+        result = RedactionPreviewResult(
+            original_length=len(text),
+            segments=segments,
+            pii_summary={
+                "names": names, "locations": locations, "dates": dates,
+                "emails": emails, "phones": phones, "ids": ids,
+                "total": len(spans),
+            },
+        )
+
+        reasons = (
+            [f"Found {len(spans)} item(s) that would be redacted."]
+            if spans else ["No PII detected in input text."]
+        )
+
+        return ResultEnvelope[RedactionPreviewResult](
+            result=result,
+            confidence=None,
+            reasons=reasons,
+            anchor_metadata=request.anchor_metadata,
+            trace_id=correlation_id_var.get() or None,
+        )
+    except Exception as e:
+        logger.error(f"Redaction preview failed: {str(e)}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to generate redaction preview")

--- a/app/ai-service/api/v1/redaction_preview.py
+++ b/app/ai-service/api/v1/redaction_preview.py
@@ -14,8 +14,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["anonymization"])
 
 
-@router.post("/ai/redaction/preview", response_model=ResultEnvelope[RedactionPreviewResult])
-async def preview_redaction(request: AnonymizeRequest) -> ResultEnvelope[RedactionPreviewResult]:
+@router.post(
+    "/ai/redaction/preview", response_model=ResultEnvelope[RedactionPreviewResult]
+)
+async def preview_redaction(
+    request: AnonymizeRequest,
+) -> ResultEnvelope[RedactionPreviewResult]:
     """Return a redaction diff (kept vs. redacted segments) without masking the text."""
     import main as _main
     from main import correlation_id_var
@@ -40,15 +44,20 @@ async def preview_redaction(request: AnonymizeRequest) -> ResultEnvelope[Redacti
             original_length=len(text),
             segments=segments,
             pii_summary={
-                "names": names, "locations": locations, "dates": dates,
-                "emails": emails, "phones": phones, "ids": ids,
+                "names": names,
+                "locations": locations,
+                "dates": dates,
+                "emails": emails,
+                "phones": phones,
+                "ids": ids,
                 "total": len(spans),
             },
         )
 
         reasons = (
             [f"Found {len(spans)} item(s) that would be redacted."]
-            if spans else ["No PII detected in input text."]
+            if spans
+            else ["No PII detected in input text."]
         )
 
         return ResultEnvelope[RedactionPreviewResult](
@@ -60,4 +69,6 @@ async def preview_redaction(request: AnonymizeRequest) -> ResultEnvelope[Redacti
         )
     except Exception as e:
         logger.error(f"Redaction preview failed: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to generate redaction preview")
+        raise HTTPException(
+            status_code=500, detail="Failed to generate redaction preview"
+        )

--- a/app/ai-service/api/v1/router.py
+++ b/app/ai-service/api/v1/router.py
@@ -9,15 +9,8 @@ surface grows.
 from fastapi import APIRouter
 
 from api.v1 import (
-    ocr,
-    inference,
-    proof_of_life,
-    anonymize,
-    humanitarian,
-    fraud,
-    artifacts,
-    uploads,
-    dead_letter,
+    ocr, inference, proof_of_life, anonymize, humanitarian,
+    fraud, artifacts, uploads, dead_letter,redaction_preview,
 )
 
 v1_router = APIRouter(prefix="/v1")
@@ -31,3 +24,5 @@ v1_router.include_router(fraud.router)
 v1_router.include_router(artifacts.router)
 v1_router.include_router(uploads.router)
 v1_router.include_router(dead_letter.router)
+v1_router.include_router(redaction_preview.router)
+

--- a/app/ai-service/api/v1/router.py
+++ b/app/ai-service/api/v1/router.py
@@ -9,8 +9,16 @@ surface grows.
 from fastapi import APIRouter
 
 from api.v1 import (
-    ocr, inference, proof_of_life, anonymize, humanitarian,
-    fraud, artifacts, uploads, dead_letter,redaction_preview,
+    ocr,
+    inference,
+    proof_of_life,
+    anonymize,
+    humanitarian,
+    fraud,
+    artifacts,
+    uploads,
+    dead_letter,
+    redaction_preview,
 )
 
 v1_router = APIRouter(prefix="/v1")
@@ -25,4 +33,3 @@ v1_router.include_router(artifacts.router)
 v1_router.include_router(uploads.router)
 v1_router.include_router(dead_letter.router)
 v1_router.include_router(redaction_preview.router)
-

--- a/app/ai-service/schemas/anonymization.py
+++ b/app/ai-service/schemas/anonymization.py
@@ -14,10 +14,15 @@ class AnonymizeRequest(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [{
-                "text": "John Doe from New York on 2024-01-01 requested aid",
-                "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"},
-            }]
+            "examples": [
+                {
+                    "text": "John Doe from New York on 2024-01-01 requested aid",
+                    "anchor_metadata": {
+                        "campaign_ref": "campaign-2024-001",
+                        "claim_id": "claim-abc123",
+                    },
+                }
+            ]
         }
     }
 
@@ -29,17 +34,22 @@ class PIISummary(BaseModel):
     total: int = Field(examples=[3])
 
     model_config = {
-        "json_schema_extra": {"examples": [{"names": 1, "locations": 1, "dates": 1, "total": 3}]}
+        "json_schema_extra": {
+            "examples": [{"names": 1, "locations": 1, "dates": 1, "total": 3}]
+        }
     }
 
 
 class AnonymizeResult(BaseModel):
     """Payload nested inside the ResultEnvelope for anonymization responses."""
 
-    anonymized_text: str = Field(examples=["[NAME] from [LOCATION] on [DATE] requested aid"])
+    anonymized_text: str = Field(
+        examples=["[NAME] from [LOCATION] on [DATE] requested aid"]
+    )
     original_length: int = Field(examples=[50])
     pii_summary: Dict[str, Any] = Field(
-        default_factory=dict, examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}]
+        default_factory=dict,
+        examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}],
     )
     token_counts: Dict[str, int] = Field(
         default_factory=dict, examples=[{"original": 10, "anonymized": 10}]
@@ -47,12 +57,18 @@ class AnonymizeResult(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [{
-                "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
-                "original_length": 50,
-                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
-                "token_counts": {"[RECIPIENT_NAME]": 1, "[LOCATION]": 1, "[EVENT_DATE]": 1},
-            }]
+            "examples": [
+                {
+                    "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
+                    "original_length": 50,
+                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                    "token_counts": {
+                        "[RECIPIENT_NAME]": 1,
+                        "[LOCATION]": 1,
+                        "[EVENT_DATE]": 1,
+                    },
+                }
+            ]
         }
     }
 
@@ -65,7 +81,9 @@ class AnonymizeResponse(BaseModel):
     """
 
     success: bool = Field(examples=[True])
-    anonymized_text: str = Field(examples=["[NAME] from [LOCATION] on [DATE] requested aid"])
+    anonymized_text: str = Field(
+        examples=["[NAME] from [LOCATION] on [DATE] requested aid"]
+    )
     original_length: int = Field(examples=[50])
     pii_summary: PIISummary
     token_counts: Dict[str, int] = Field(
@@ -75,16 +93,22 @@ class AnonymizeResponse(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [{
-                "success": True,
-                "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
-                "original_length": 50,
-                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
-                "token_counts": {"original": 10, "anonymized": 10},
-                "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"},
-            }]
+            "examples": [
+                {
+                    "success": True,
+                    "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
+                    "original_length": 50,
+                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                    "token_counts": {"original": 10, "anonymized": 10},
+                    "anchor_metadata": {
+                        "campaign_ref": "campaign-2024-001",
+                        "claim_id": "claim-abc123",
+                    },
+                }
+            ]
         }
     }
+
 
 class RedactionSegment(BaseModel):
     """One contiguous span of the original text, marked kept or redacted."""
@@ -100,7 +124,9 @@ class RedactionSegment(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [{"type": "redacted", "start": 0, "end": 8, "category": "RECIPIENT_NAME"}]
+            "examples": [
+                {"type": "redacted", "start": 0, "end": 8, "category": "RECIPIENT_NAME"}
+            ]
         }
     }
 
@@ -117,13 +143,20 @@ class RedactionPreviewResult(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [{
-                "original_length": 60,
-                "segments": [
-                    {"type": "kept", "start": 0, "end": 3, "category": None},
-                    {"type": "redacted", "start": 3, "end": 15, "category": "RECIPIENT_NAME"},
-                ],
-                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
-            }]
+            "examples": [
+                {
+                    "original_length": 60,
+                    "segments": [
+                        {"type": "kept", "start": 0, "end": 3, "category": None},
+                        {
+                            "type": "redacted",
+                            "start": 3,
+                            "end": 15,
+                            "category": "RECIPIENT_NAME",
+                        },
+                    ],
+                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                }
+            ]
         }
     }

--- a/app/ai-service/schemas/anonymization.py
+++ b/app/ai-service/schemas/anonymization.py
@@ -14,15 +14,10 @@ class AnonymizeRequest(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [
-                {
-                    "text": "John Doe from New York on 2024-01-01 requested aid",
-                    "anchor_metadata": {
-                        "campaign_ref": "campaign-2024-001",
-                        "claim_id": "claim-abc123",
-                    },
-                }
-            ]
+            "examples": [{
+                "text": "John Doe from New York on 2024-01-01 requested aid",
+                "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"},
+            }]
         }
     }
 
@@ -34,22 +29,17 @@ class PIISummary(BaseModel):
     total: int = Field(examples=[3])
 
     model_config = {
-        "json_schema_extra": {
-            "examples": [{"names": 1, "locations": 1, "dates": 1, "total": 3}]
-        }
+        "json_schema_extra": {"examples": [{"names": 1, "locations": 1, "dates": 1, "total": 3}]}
     }
 
 
 class AnonymizeResult(BaseModel):
     """Payload nested inside the ResultEnvelope for anonymization responses."""
 
-    anonymized_text: str = Field(
-        examples=["[NAME] from [LOCATION] on [DATE] requested aid"]
-    )
+    anonymized_text: str = Field(examples=["[NAME] from [LOCATION] on [DATE] requested aid"])
     original_length: int = Field(examples=[50])
     pii_summary: Dict[str, Any] = Field(
-        default_factory=dict,
-        examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}],
+        default_factory=dict, examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}]
     )
     token_counts: Dict[str, int] = Field(
         default_factory=dict, examples=[{"original": 10, "anonymized": 10}]
@@ -57,18 +47,12 @@ class AnonymizeResult(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [
-                {
-                    "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
-                    "original_length": 50,
-                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
-                    "token_counts": {
-                        "[RECIPIENT_NAME]": 1,
-                        "[LOCATION]": 1,
-                        "[EVENT_DATE]": 1,
-                    },
-                }
-            ]
+            "examples": [{
+                "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
+                "original_length": 50,
+                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                "token_counts": {"[RECIPIENT_NAME]": 1, "[LOCATION]": 1, "[EVENT_DATE]": 1},
+            }]
         }
     }
 
@@ -76,15 +60,12 @@ class AnonymizeResult(BaseModel):
 class AnonymizeResponse(BaseModel):
     """
     Legacy response model — kept for backward compatibility.
-
     New consumers should use the ``ResultEnvelope[AnonymizeResult]`` shape
     returned by the v1 endpoint.
     """
 
     success: bool = Field(examples=[True])
-    anonymized_text: str = Field(
-        examples=["[NAME] from [LOCATION] on [DATE] requested aid"]
-    )
+    anonymized_text: str = Field(examples=["[NAME] from [LOCATION] on [DATE] requested aid"])
     original_length: int = Field(examples=[50])
     pii_summary: PIISummary
     token_counts: Dict[str, int] = Field(
@@ -94,18 +75,55 @@ class AnonymizeResponse(BaseModel):
 
     model_config = {
         "json_schema_extra": {
-            "examples": [
-                {
-                    "success": True,
-                    "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
-                    "original_length": 50,
-                    "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
-                    "token_counts": {"original": 10, "anonymized": 10},
-                    "anchor_metadata": {
-                        "campaign_ref": "campaign-2024-001",
-                        "claim_id": "claim-abc123",
-                    },
-                }
-            ]
+            "examples": [{
+                "success": True,
+                "anonymized_text": "[NAME] from [LOCATION] on [DATE] requested aid",
+                "original_length": 50,
+                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+                "token_counts": {"original": 10, "anonymized": 10},
+                "anchor_metadata": {"campaign_ref": "campaign-2024-001", "claim_id": "claim-abc123"},
+            }]
+        }
+    }
+
+class RedactionSegment(BaseModel):
+    """One contiguous span of the original text, marked kept or redacted."""
+
+    type: str = Field(examples=["kept", "redacted"])
+    start: int = Field(examples=[0])
+    end: int = Field(examples=[8])
+    category: Optional[str] = Field(
+        None,
+        description="PII category label, present only when type == 'redacted'",
+        examples=["RECIPIENT_NAME"],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{"type": "redacted", "start": 0, "end": 8, "category": "RECIPIENT_NAME"}]
+        }
+    }
+
+
+class RedactionPreviewResult(BaseModel):
+    """Payload nested inside the ResultEnvelope for the redaction preview diff."""
+
+    original_length: int = Field(examples=[60])
+    segments: list[RedactionSegment] = Field(default_factory=list)
+    pii_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        examples=[{"names": 1, "locations": 1, "dates": 1, "total": 3}],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "original_length": 60,
+                "segments": [
+                    {"type": "kept", "start": 0, "end": 3, "category": None},
+                    {"type": "redacted", "start": 3, "end": 15, "category": "RECIPIENT_NAME"},
+                ],
+                "pii_summary": {"names": 1, "locations": 1, "dates": 1, "total": 3},
+            }]
         }
     }

--- a/app/ai-service/services/pii_scrubber.py
+++ b/app/ai-service/services/pii_scrubber.py
@@ -34,8 +34,16 @@ class PIIScrubberService:
     }
 
     ALLOWLIST = {
-        "Soter", "Pulsefy", "Stellar", "Humanitarian", "Coordinator",
-        "Manager", "Project", "Water", "Clear", "Crystal",
+        "Soter",
+        "Pulsefy",
+        "Stellar",
+        "Humanitarian",
+        "Coordinator",
+        "Manager",
+        "Project",
+        "Water",
+        "Clear",
+        "Crystal",
         "HTTP",  # HTTP error codes like 404-123-4567 should not match
     }
 
@@ -67,8 +75,8 @@ class PIIScrubberService:
     ]
 
     ID_REGEXES = [
-        r"\b\d{11}\b",           # NIN (Nigeria)
-        r"\b[A-Z]{2}\d{8}\b",    # Voter ID
+        r"\b\d{11}\b",  # NIN (Nigeria)
+        r"\b[A-Z]{2}\d{8}\b",  # Voter ID
     ]
 
     def __init__(self):
@@ -104,8 +112,12 @@ class PIIScrubberService:
                 "original_length": len(text),
                 "anonymized_text": anonymized_text,
                 "pii_summary": {
-                    "names": names, "locations": locations, "dates": dates,
-                    "emails": emails, "phones": phones, "ids": ids,
+                    "names": names,
+                    "locations": locations,
+                    "dates": dates,
+                    "emails": emails,
+                    "phones": phones,
+                    "ids": ids,
                     "total": len(spans),
                 },
                 "token_counts": token_counts,
@@ -124,54 +136,112 @@ class PIIScrubberService:
             return []
         return self._detect_spans(text)
 
-    def build_preview_segments(self, text: str, spans: List[PIISpan]) -> List[Dict[str, object]]:
+    def build_preview_segments(
+        self, text: str, spans: List[PIISpan]
+    ) -> List[Dict[str, object]]:
         """Turn detected spans into kept/redacted segments covering the full text."""
         segments: List[Dict[str, object]] = []
         cursor = 0
 
         for span in spans:
             if span.start > cursor:
-                segments.append({"type": "kept", "start": cursor, "end": span.start, "category": None})
-            segments.append({
-                "type": "redacted",
-                "start": span.start,
-                "end": span.end,
-                "category": self.TOKEN_BASE_BY_LABEL[span.label],
-            })
+                segments.append(
+                    {
+                        "type": "kept",
+                        "start": cursor,
+                        "end": span.start,
+                        "category": None,
+                    }
+                )
+            segments.append(
+                {
+                    "type": "redacted",
+                    "start": span.start,
+                    "end": span.end,
+                    "category": self.TOKEN_BASE_BY_LABEL[span.label],
+                }
+            )
             cursor = span.end
 
         if cursor < len(text):
-            segments.append({"type": "kept", "start": cursor, "end": len(text), "category": None})
+            segments.append(
+                {"type": "kept", "start": cursor, "end": len(text), "category": None}
+            )
 
         return segments
 
     def _build_nlp(self) -> Language:
         nlp = spacy.blank("en")
         ruler = nlp.add_pipe("entity_ruler")
-        ruler.add_patterns([
-            {"label": "PERSON", "pattern": [
-                {"LOWER": {"IN": ["mr", "mrs", "ms", "miss", "dr", "prof"]}},
-                {"IS_TITLE": True},
-                {"IS_TITLE": True, "OP": "?"},
-            ]},
-            {"label": "PERSON", "pattern": [
-                {"IS_TITLE": True}, {"IS_TITLE": True},
-            ]},
-            {"label": "LOCATION", "pattern": [
-                {"LOWER": {"IN": ["in", "at", "from", "near"]}},
-                {"IS_TITLE": True},
-                {"IS_TITLE": True, "OP": "?"},
-                {"IS_TITLE": True, "OP": "?"},
-                {"LOWER": {"IN": ["camp", "state", "region", "district", "city", "village"]}, "OP": "?"},
-            ]},
-            {"label": "DATE", "pattern": [{"SHAPE": "dd/dd/dddd"}]},
-            {"label": "DATE", "pattern": [{"SHAPE": "dd-dd-dddd"}]},
-            {"label": "DATE", "pattern": [
-                {"IS_DIGIT": True},
-                {"LOWER": {"IN": ["jan","feb","mar","apr","may","jun","jul","aug","sep","sept","oct","nov","dec"]}},
-                {"IS_DIGIT": True},
-            ]},
-        ])
+        ruler.add_patterns(
+            [
+                {
+                    "label": "PERSON",
+                    "pattern": [
+                        {"LOWER": {"IN": ["mr", "mrs", "ms", "miss", "dr", "prof"]}},
+                        {"IS_TITLE": True},
+                        {"IS_TITLE": True, "OP": "?"},
+                    ],
+                },
+                {
+                    "label": "PERSON",
+                    "pattern": [
+                        {"IS_TITLE": True},
+                        {"IS_TITLE": True},
+                    ],
+                },
+                {
+                    "label": "LOCATION",
+                    "pattern": [
+                        {"LOWER": {"IN": ["in", "at", "from", "near"]}},
+                        {"IS_TITLE": True},
+                        {"IS_TITLE": True, "OP": "?"},
+                        {"IS_TITLE": True, "OP": "?"},
+                        {
+                            "LOWER": {
+                                "IN": [
+                                    "camp",
+                                    "state",
+                                    "region",
+                                    "district",
+                                    "city",
+                                    "village",
+                                ]
+                            },
+                            "OP": "?",
+                        },
+                    ],
+                },
+                {"label": "DATE", "pattern": [{"SHAPE": "dd/dd/dddd"}]},
+                {"label": "DATE", "pattern": [{"SHAPE": "dd-dd-dddd"}]},
+                {
+                    "label": "DATE",
+                    "pattern": [
+                        {"IS_DIGIT": True},
+                        {
+                            "LOWER": {
+                                "IN": [
+                                    "jan",
+                                    "feb",
+                                    "mar",
+                                    "apr",
+                                    "may",
+                                    "jun",
+                                    "jul",
+                                    "aug",
+                                    "sep",
+                                    "sept",
+                                    "oct",
+                                    "nov",
+                                    "dec",
+                                ]
+                            }
+                        },
+                        {"IS_DIGIT": True},
+                    ],
+                },
+            ]
+        )
         return nlp
 
     def _detect_spans(self, text: str) -> List[PIISpan]:
@@ -196,7 +266,14 @@ class PIIScrubberService:
 
             mapped = self._normalize_label(ent.label_)
             if mapped:
-                spans.append(PIISpan(start=ent.start_char, end=ent.end_char, label=mapped, text=ent.text))
+                spans.append(
+                    PIISpan(
+                        start=ent.start_char,
+                        end=ent.end_char,
+                        label=mapped,
+                        text=ent.text,
+                    )
+                )
 
         for pattern in self.DATE_REGEXES:
             spans.extend(self._spans_from_regex(text, pattern, "DATE"))
@@ -220,7 +297,9 @@ class PIIScrubberService:
             return "DATE"
         return ""
 
-    def _spans_from_regex(self, text: str, pattern: str, label: str, capture_group: int = 0) -> List[PIISpan]:
+    def _spans_from_regex(
+        self, text: str, pattern: str, label: str, capture_group: int = 0
+    ) -> List[PIISpan]:
         spans: List[PIISpan] = []
         for match in re.finditer(pattern, text):
             if capture_group:
@@ -244,7 +323,8 @@ class PIIScrubberService:
             return []
 
         filtered_by_allowlist = [
-            span for span in spans
+            span
+            for span in spans
             if not any(word in self.ALLOWLIST for word in span.text.split())
         ]
 
@@ -267,7 +347,9 @@ class PIIScrubberService:
 
         return filtered
 
-    def _mask_spans(self, text: str, spans: List[PIISpan]) -> Tuple[str, Dict[str, int]]:
+    def _mask_spans(
+        self, text: str, spans: List[PIISpan]
+    ) -> Tuple[str, Dict[str, int]]:
         if not spans:
             return text, {}
 
@@ -277,7 +359,7 @@ class PIIScrubberService:
         cursor = 0
 
         for span in spans:
-            chunks.append(text[cursor:span.start])
+            chunks.append(text[cursor : span.start])
             counters[span.label] += 1
             token_base = self.TOKEN_BASE_BY_LABEL[span.label]
             token = f"[{token_base}]"

--- a/app/ai-service/services/pii_scrubber.py
+++ b/app/ai-service/services/pii_scrubber.py
@@ -34,16 +34,8 @@ class PIIScrubberService:
     }
 
     ALLOWLIST = {
-        "Soter",
-        "Pulsefy",
-        "Stellar",
-        "Humanitarian",
-        "Coordinator",
-        "Manager",
-        "Project",
-        "Water",
-        "Clear",
-        "Crystal",
+        "Soter", "Pulsefy", "Stellar", "Humanitarian", "Coordinator",
+        "Manager", "Project", "Water", "Clear", "Crystal",
         "HTTP",  # HTTP error codes like 404-123-4567 should not match
     }
 
@@ -75,8 +67,8 @@ class PIIScrubberService:
     ]
 
     ID_REGEXES = [
-        r"\b\d{11}\b",  # NIN (Nigeria)
-        r"\b[A-Z]{2}\d{8}\b",  # Voter ID
+        r"\b\d{11}\b",           # NIN (Nigeria)
+        r"\b[A-Z]{2}\d{8}\b",    # Voter ID
     ]
 
     def __init__(self):
@@ -98,7 +90,7 @@ class PIIScrubberService:
                     "token_counts": {},
                 }
 
-            spans = self._detect_spans(text)
+            spans = self.detect_spans(text)
             anonymized_text, token_counts = self._mask_spans(text, spans)
 
             names = sum(1 for span in spans if span.label == "PERSON")
@@ -112,12 +104,8 @@ class PIIScrubberService:
                 "original_length": len(text),
                 "anonymized_text": anonymized_text,
                 "pii_summary": {
-                    "names": names,
-                    "locations": locations,
-                    "dates": dates,
-                    "emails": emails,
-                    "phones": phones,
-                    "ids": ids,
+                    "names": names, "locations": locations, "dates": dates,
+                    "emails": emails, "phones": phones, "ids": ids,
                     "total": len(spans),
                 },
                 "token_counts": token_counts,
@@ -126,103 +114,80 @@ class PIIScrubberService:
             latency = time.time() - start_time
             metrics.PIPELINE_STEP_LATENCY.labels(step_name="scrub").observe(latency)
 
+    def detect_spans(self, text: str) -> List[PIISpan]:
+        """Public accessor for detected PII spans.
+
+        Used by both `anonymize()` (which masks them) and the redaction
+        preview-diff endpoint (which needs the spans without masking).
+        """
+        if not text:
+            return []
+        return self._detect_spans(text)
+
+    def build_preview_segments(self, text: str, spans: List[PIISpan]) -> List[Dict[str, object]]:
+        """Turn detected spans into kept/redacted segments covering the full text."""
+        segments: List[Dict[str, object]] = []
+        cursor = 0
+
+        for span in spans:
+            if span.start > cursor:
+                segments.append({"type": "kept", "start": cursor, "end": span.start, "category": None})
+            segments.append({
+                "type": "redacted",
+                "start": span.start,
+                "end": span.end,
+                "category": self.TOKEN_BASE_BY_LABEL[span.label],
+            })
+            cursor = span.end
+
+        if cursor < len(text):
+            segments.append({"type": "kept", "start": cursor, "end": len(text), "category": None})
+
+        return segments
+
     def _build_nlp(self) -> Language:
         nlp = spacy.blank("en")
         ruler = nlp.add_pipe("entity_ruler")
-        ruler.add_patterns(
-            [
-                {
-                    "label": "PERSON",
-                    "pattern": [
-                        {"LOWER": {"IN": ["mr", "mrs", "ms", "miss", "dr", "prof"]}},
-                        {"IS_TITLE": True},
-                        {"IS_TITLE": True, "OP": "?"},
-                    ],
-                },
-                {
-                    "label": "PERSON",
-                    "pattern": [
-                        {"IS_TITLE": True},
-                        {"IS_TITLE": True},
-                    ],
-                },
-                {
-                    "label": "LOCATION",
-                    "pattern": [
-                        {"LOWER": {"IN": ["in", "at", "from", "near"]}},
-                        {"IS_TITLE": True},
-                        {"IS_TITLE": True, "OP": "?"},
-                        {"IS_TITLE": True, "OP": "?"},
-                        {
-                            "LOWER": {
-                                "IN": [
-                                    "camp",
-                                    "state",
-                                    "region",
-                                    "district",
-                                    "city",
-                                    "village",
-                                ]
-                            },
-                            "OP": "?",
-                        },
-                    ],
-                },
-                {
-                    "label": "DATE",
-                    "pattern": [{"SHAPE": "dd/dd/dddd"}],
-                },
-                {
-                    "label": "DATE",
-                    "pattern": [{"SHAPE": "dd-dd-dddd"}],
-                },
-                {
-                    "label": "DATE",
-                    "pattern": [
-                        {"IS_DIGIT": True},
-                        {
-                            "LOWER": {
-                                "IN": [
-                                    "jan",
-                                    "feb",
-                                    "mar",
-                                    "apr",
-                                    "may",
-                                    "jun",
-                                    "jul",
-                                    "aug",
-                                    "sep",
-                                    "sept",
-                                    "oct",
-                                    "nov",
-                                    "dec",
-                                ]
-                            }
-                        },
-                        {"IS_DIGIT": True},
-                    ],
-                },
-            ]
-        )
+        ruler.add_patterns([
+            {"label": "PERSON", "pattern": [
+                {"LOWER": {"IN": ["mr", "mrs", "ms", "miss", "dr", "prof"]}},
+                {"IS_TITLE": True},
+                {"IS_TITLE": True, "OP": "?"},
+            ]},
+            {"label": "PERSON", "pattern": [
+                {"IS_TITLE": True}, {"IS_TITLE": True},
+            ]},
+            {"label": "LOCATION", "pattern": [
+                {"LOWER": {"IN": ["in", "at", "from", "near"]}},
+                {"IS_TITLE": True},
+                {"IS_TITLE": True, "OP": "?"},
+                {"IS_TITLE": True, "OP": "?"},
+                {"LOWER": {"IN": ["camp", "state", "region", "district", "city", "village"]}, "OP": "?"},
+            ]},
+            {"label": "DATE", "pattern": [{"SHAPE": "dd/dd/dddd"}]},
+            {"label": "DATE", "pattern": [{"SHAPE": "dd-dd-dddd"}]},
+            {"label": "DATE", "pattern": [
+                {"IS_DIGIT": True},
+                {"LOWER": {"IN": ["jan","feb","mar","apr","may","jun","jul","aug","sep","sept","oct","nov","dec"]}},
+                {"IS_DIGIT": True},
+            ]},
+        ])
         return nlp
 
     def _detect_spans(self, text: str) -> List[PIISpan]:
         spans: List[PIISpan] = []
 
         # Check for emails FIRST to prioritize them over names
-        # This prevents "John@Example.Com" from being split into "John" + email
         email_spans = []
         for pattern in self.EMAIL_REGEXES:
             email_spans.extend(self._spans_from_regex(text, pattern, "EMAIL"))
         spans.extend(email_spans)
 
-        # Build set of email character ranges to exclude from spacy processing
         email_ranges = {(span.start, span.end) for span in email_spans}
 
         doc = self.nlp(text)
 
         for ent in doc.ents:
-            # Skip if this entity overlaps with an email
             if any(
                 not (ent.end_char <= start or ent.start_char >= end)
                 for start, end in email_ranges
@@ -231,29 +196,16 @@ class PIIScrubberService:
 
             mapped = self._normalize_label(ent.label_)
             if mapped:
-                spans.append(
-                    PIISpan(
-                        start=ent.start_char,
-                        end=ent.end_char,
-                        label=mapped,
-                        text=ent.text,
-                    )
-                )
+                spans.append(PIISpan(start=ent.start_char, end=ent.end_char, label=mapped, text=ent.text))
 
         for pattern in self.DATE_REGEXES:
             spans.extend(self._spans_from_regex(text, pattern, "DATE"))
-
         for pattern in self.NAME_REGEXES:
             spans.extend(self._spans_from_regex(text, pattern, "PERSON"))
-
         for pattern in self.LOCATION_REGEXES:
-            spans.extend(
-                self._spans_from_regex(text, pattern, "LOCATION")
-            )  # Removed capture group 1 to get full address if regex 2 matches
-
+            spans.extend(self._spans_from_regex(text, pattern, "LOCATION"))
         for pattern in self.PHONE_REGEXES:
             spans.extend(self._spans_from_regex(text, pattern, "PHONE"))
-
         for pattern in self.ID_REGEXES:
             spans.extend(self._spans_from_regex(text, pattern, "ID"))
 
@@ -268,9 +220,7 @@ class PIIScrubberService:
             return "DATE"
         return ""
 
-    def _spans_from_regex(
-        self, text: str, pattern: str, label: str, capture_group: int = 0
-    ) -> List[PIISpan]:
+    def _spans_from_regex(self, text: str, pattern: str, label: str, capture_group: int = 0) -> List[PIISpan]:
         spans: List[PIISpan] = []
         for match in re.finditer(pattern, text):
             if capture_group:
@@ -280,9 +230,7 @@ class PIIScrubberService:
                 start, end = match.start(), match.end()
                 value = match.group(0)
 
-            # Skip phone numbers that are HTTP/error codes (preceded by "error" or "code")
             if label == "PHONE":
-                # Check if preceded by "error code", "HTTP error", etc.
                 context_start = max(0, start - 20)
                 context = text[context_start:start].lower()
                 if "error" in context or "http" in context:
@@ -295,10 +243,8 @@ class PIIScrubberService:
         if not spans:
             return []
 
-        # Filter out spans that are in the allowlist
         filtered_by_allowlist = [
-            span
-            for span in spans
+            span for span in spans
             if not any(word in self.ALLOWLIST for word in span.text.split())
         ]
 
@@ -307,7 +253,7 @@ class PIIScrubberService:
             key=lambda span: (
                 span.start,
                 -(span.end - span.start),
-                0 if span.label == "EMAIL" else 1,  # Prioritize EMAIL
+                0 if span.label == "EMAIL" else 1,
             ),
         )
         filtered: List[PIISpan] = []
@@ -321,9 +267,7 @@ class PIIScrubberService:
 
         return filtered
 
-    def _mask_spans(
-        self, text: str, spans: List[PIISpan]
-    ) -> Tuple[str, Dict[str, int]]:
+    def _mask_spans(self, text: str, spans: List[PIISpan]) -> Tuple[str, Dict[str, int]]:
         if not spans:
             return text, {}
 
@@ -333,7 +277,7 @@ class PIIScrubberService:
         cursor = 0
 
         for span in spans:
-            chunks.append(text[cursor : span.start])
+            chunks.append(text[cursor:span.start])
             counters[span.label] += 1
             token_base = self.TOKEN_BASE_BY_LABEL[span.label]
             token = f"[{token_base}]"

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -23,7 +23,9 @@ class TestBuildPreviewSegments:
         for a, b in zip(segments, segments[1:]):
             assert a["end"] == b["start"]
 
-        redacted_categories = {s["category"] for s in segments if s["type"] == "redacted"}
+        redacted_categories = {
+            s["category"] for s in segments if s["type"] == "redacted"
+        }
         assert "RECIPIENT_NAME" in redacted_categories
         assert "LOCATION" in redacted_categories
         assert "EVENT_DATE" in redacted_categories
@@ -75,7 +77,9 @@ class TestRedactionPreviewRoute:
         body = response.json()
 
         result = body["result"]
-        assert result["original_length"] == len("Mary Johnson received aid in Maiduguri Camp.")
+        assert result["original_length"] == len(
+            "Mary Johnson received aid in Maiduguri Camp."
+        )
         assert len(result["segments"]) > 0
         assert any(seg["type"] == "redacted" for seg in result["segments"])
 

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch, MagicMock
+
+from services.pii_scrubber import PIIScrubberService
+
+
+class TestBuildPreviewSegments:
+    """Unit tests on the segment-builder — no HTTP layer involved."""
+
+    def setup_method(self):
+        self.service = PIIScrubberService()
+
+    @patch("metrics.PIPELINE_STEP_LATENCY.labels")
+    def test_segments_cover_full_text_with_kept_and_redacted(self, mock_labels):
+        mock_labels.return_value.observe = MagicMock()
+
+        text = "On 15 Jan 2025, Mary Johnson received aid in Maiduguri Camp."
+        spans = self.service.detect_spans(text)
+        segments = self.service.build_preview_segments(text, spans)
+
+        # Segments should reconstruct the full text length with no gaps/overlaps
+        assert segments[0]["start"] == 0
+        assert segments[-1]["end"] == len(text)
+        for a, b in zip(segments, segments[1:]):
+            assert a["end"] == b["start"]
+
+        redacted_categories = {s["category"] for s in segments if s["type"] == "redacted"}
+        assert "RECIPIENT_NAME" in redacted_categories
+        assert "LOCATION" in redacted_categories
+        assert "EVENT_DATE" in redacted_categories
+
+    def test_kept_segments_have_no_category(self):
+        text = "John Doe reported delays in Kano State on 2024-07-12."
+        spans = self.service.detect_spans(text)
+        segments = self.service.build_preview_segments(text, spans)
+
+        for seg in segments:
+            if seg["type"] == "kept":
+                assert seg["category"] is None
+
+    def test_no_pii_returns_single_kept_segment(self):
+        text = "The weather today is sunny with clear skies."
+        spans = self.service.detect_spans(text)
+        segments = self.service.build_preview_segments(text, spans)
+
+        assert len(segments) == 1
+        assert segments[0]["type"] == "kept"
+        assert segments[0]["start"] == 0
+        assert segments[0]["end"] == len(text)
+
+    def test_empty_text_returns_no_segments(self):
+        spans = self.service.detect_spans("")
+        segments = self.service.build_preview_segments("", spans)
+        assert segments == []
+
+    def test_entirely_sensitive_text_single_redacted_segment(self):
+        text = "Mary Johnson"
+        spans = self.service.detect_spans(text)
+        segments = self.service.build_preview_segments(text, spans)
+
+        assert len(segments) == 1
+        assert segments[0]["type"] == "redacted"
+        assert segments[0]["start"] == 0
+        assert segments[0]["end"] == len(text)
+
+
+class TestRedactionPreviewRoute:
+    """Integration tests against the FastAPI app."""
+
+    def test_preview_endpoint_returns_segments(self, client):
+        response = client.post(
+            "/v1/ai/redaction/preview",
+            json={"text": "Mary Johnson received aid in Maiduguri Camp."},
+        )
+        assert response.status_code == 200
+        body = response.json()
+
+        result = body["result"]
+        assert result["original_length"] == len("Mary Johnson received aid in Maiduguri Camp.")
+        assert len(result["segments"]) > 0
+        assert any(seg["type"] == "redacted" for seg in result["segments"])
+
+        # The response must never contain the raw PII substring as a bare field —
+        # only positions and categories.
+        assert "Mary Johnson" not in str(result["segments"])
+
+    def test_preview_endpoint_no_pii(self, client):
+        response = client.post(
+            "/v1/ai/redaction/preview",
+            json={"text": "The sky is clear today."},
+        )
+        assert response.status_code == 200
+        result = response.json()["result"]
+        assert result["pii_summary"]["total"] == 0
+        assert all(seg["type"] == "kept" for seg in result["segments"])
+
+    def test_preview_endpoint_does_not_log_raw_text(self, client, caplog):
+        sensitive_text = "Mary Johnson's ID is AB12345678"
+        client.post("/v1/ai/redaction/preview", json={"text": sensitive_text})
+
+        for record in caplog.records:
+            assert sensitive_text not in record.getMessage()
+            assert "Mary Johnson" not in record.getMessage()

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -1,6 +1,10 @@
+from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 
+from main import app
 from services.pii_scrubber import PIIScrubberService
+
+client = TestClient(app)
 
 
 class TestBuildPreviewSegments:
@@ -17,15 +21,12 @@ class TestBuildPreviewSegments:
         spans = self.service.detect_spans(text)
         segments = self.service.build_preview_segments(text, spans)
 
-        # Segments should reconstruct the full text length with no gaps/overlaps
         assert segments[0]["start"] == 0
         assert segments[-1]["end"] == len(text)
         for a, b in zip(segments, segments[1:]):
             assert a["end"] == b["start"]
 
-        redacted_categories = {
-            s["category"] for s in segments if s["type"] == "redacted"
-        }
+        redacted_categories = {s["category"] for s in segments if s["type"] == "redacted"}
         assert "RECIPIENT_NAME" in redacted_categories
         assert "LOCATION" in redacted_categories
         assert "EVENT_DATE" in redacted_categories
@@ -68,26 +69,20 @@ class TestBuildPreviewSegments:
 class TestRedactionPreviewRoute:
     """Integration tests against the FastAPI app."""
 
-    def test_preview_endpoint_returns_segments(self, client):
+    def test_preview_endpoint_returns_segments(self):
         response = client.post(
             "/v1/ai/redaction/preview",
             json={"text": "Mary Johnson received aid in Maiduguri Camp."},
         )
         assert response.status_code == 200
-        body = response.json()
+        result = response.json()["result"]
 
-        result = body["result"]
-        assert result["original_length"] == len(
-            "Mary Johnson received aid in Maiduguri Camp."
-        )
+        assert result["original_length"] == len("Mary Johnson received aid in Maiduguri Camp.")
         assert len(result["segments"]) > 0
         assert any(seg["type"] == "redacted" for seg in result["segments"])
-
-        # The response must never contain the raw PII substring as a bare field —
-        # only positions and categories.
         assert "Mary Johnson" not in str(result["segments"])
 
-    def test_preview_endpoint_no_pii(self, client):
+    def test_preview_endpoint_no_pii(self):
         response = client.post(
             "/v1/ai/redaction/preview",
             json={"text": "The sky is clear today."},
@@ -97,7 +92,7 @@ class TestRedactionPreviewRoute:
         assert result["pii_summary"]["total"] == 0
         assert all(seg["type"] == "kept" for seg in result["segments"])
 
-    def test_preview_endpoint_does_not_log_raw_text(self, client, caplog):
+    def test_preview_endpoint_does_not_log_raw_text(self, caplog):
         sensitive_text = "Mary Johnson's ID is AB12345678"
         client.post("/v1/ai/redaction/preview", json={"text": sensitive_text})
 

--- a/app/ai-service/tests/test_redaction_preview.py
+++ b/app/ai-service/tests/test_redaction_preview.py
@@ -26,7 +26,9 @@ class TestBuildPreviewSegments:
         for a, b in zip(segments, segments[1:]):
             assert a["end"] == b["start"]
 
-        redacted_categories = {s["category"] for s in segments if s["type"] == "redacted"}
+        redacted_categories = {
+            s["category"] for s in segments if s["type"] == "redacted"
+        }
         assert "RECIPIENT_NAME" in redacted_categories
         assert "LOCATION" in redacted_categories
         assert "EVENT_DATE" in redacted_categories
@@ -77,7 +79,9 @@ class TestRedactionPreviewRoute:
         assert response.status_code == 200
         result = response.json()["result"]
 
-        assert result["original_length"] == len("Mary Johnson received aid in Maiduguri Camp.")
+        assert result["original_length"] == len(
+            "Mary Johnson received aid in Maiduguri Camp."
+        )
         assert len(result["segments"]) > 0
         assert any(seg["type"] == "redacted" for seg in result["segments"])
         assert "Mary Johnson" not in str(result["segments"])


### PR DESCRIPTION
## Problem

Closes #775

Clients need to preview what content would be scrubbed from a piece of
text *before* committing to a final anonymization action, so they can
show the user what's about to be redacted. Currently `/ai/anonymize`
only returns the final masked text — there's no way to see the diff
between original and scrubbed content ahead of time.

## Solution

Adds `POST /v1/ai/redaction/preview`, which reuses the existing
`PIIScrubberService` detection pipeline (same regex/spaCy rules used by
`/ai/anonymize`) but returns a segment-level diff instead of masking
the text outright.

- `PIIScrubberService.detect_spans()` — new public wrapper around the
  existing private `_detect_spans()`, so both `anonymize()` and the new
  preview endpoint share one detector (no duplicated/drifting logic).
- `PIIScrubberService.build_preview_segments()` — turns detected spans
  into an ordered list of `{type: "kept" | "redacted", start, end,
  category}` segments covering the full input text.
- `RedactionSegment` / `RedactionPreviewResult` — new Pydantic schemas
  following the existing `ResultEnvelope[T]` convention used across v1
  endpoints.
- New route registered in `api/v1/router.py`.

## Acceptance criteria

- [x] **Response distinguishes original segments from scrubbed segments
      safely** — each segment is tagged `kept` or `redacted`;
      `category` is only populated on redacted segments. The response
      never echoes back the raw redacted substrings, only positions —
      clients already hold the original text and can slice it
      themselves.
- [x] **Preview does not leak raw sensitive content into logs** — the
      route only logs static messages and counts, never the input text
      or detected spans. This is backed by the existing global
      `RedactionFilter` in `logging_redaction.py` as a fallback.
- [x] **Tests cover preview generation and edge cases** — see below.

## Testing

`tests/test_redaction_preview.py`:
- Unit tests on `build_preview_segments`: full-text coverage with no
  gaps/overlaps, kept segments never carry a category, no-PII input,
  empty input, and fully-sensitive input.
- Integration tests on the route: happy path, no-PII input, and an
  explicit `caplog`-based assertion that raw sensitive input text never
  appears in emitted log records.

Manual test plan:
```bash
curl -X POST http://localhost:8000/v1/ai/redaction/preview \
  -H "Content-Type: application/json" \
  -d '{"text": "Mary Johnson received aid in Maiduguri Camp on 15 Jan 2025."}'
```

No secrets committed.