### PR TITLE
Fix/issue 949 review queue

### DIFF
--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -786,6 +786,15 @@ enum EntityLinkSourceType {
   verification
 }
 
+/// Review state for entity linking decisions
+enum EntityLinkReviewState {
+  auto_applied
+  pending_review
+  accepted
+  rejected
+  remapped
+}
+
 /// Links extracted entities to canonical registry records
 model EntityLink {
   id              String             @id @default(cuid())
@@ -814,6 +823,7 @@ model EntityLink {
   matchMethod     String?            // e.g., "exact", "fuzzy", "manual"
   reviewedBy      String?            // User ID if manually reviewed
   reviewedAt      DateTime?
+  reviewState     EntityLinkReviewState @default(auto_applied)
   reviewNotes     String?
   isActive        Boolean            @default(true)
   metadata        Json?

--- a/app/backend/src/entity-linking/dto/entity-link.dto.ts
+++ b/app/backend/src/entity-linking/dto/entity-link.dto.ts
@@ -1,3 +1,6 @@
+export type EntityLinkConfidenceBand = 'high' | 'medium' | 'low';
+export type EntityLinkReviewDecision = 'accepted' | 'rejected' | 'remapped';
+
 export interface CreateEntityLinkDto {
   sourceType: 'campaign' | 'claim' | 'verification';
   sourceId: string;
@@ -22,6 +25,8 @@ export interface LinkEntityResult {
   assetId: string | null;
   projectId: string | null;
   confidenceScore: number;
+  confidenceBand: EntityLinkConfidenceBand;
+  reviewThreshold: number;
   matchMethod: string | null;
   isActive: boolean;
   reviewedBy: string | null;
@@ -38,6 +43,12 @@ export interface EntityLinkQueryDto {
   entityType?: 'organization' | 'location' | 'asset' | 'project';
   minConfidence?: number;
   isActive?: boolean;
+  reviewState?:
+    | 'auto_applied'
+    | 'pending_review'
+    | 'accepted'
+    | 'rejected'
+    | 'remapped';
   page?: number;
   limit?: number;
 }

--- a/app/backend/src/entity-linking/dto/entity-link.dto.ts
+++ b/app/backend/src/entity-linking/dto/entity-link.dto.ts
@@ -26,6 +26,7 @@ export interface LinkEntityResult {
   isActive: boolean;
   reviewedBy: string | null;
   reviewedAt: Date | null;
+  reviewState?: string | null;
   reviewNotes: string | null;
   createdAt: Date;
   updatedAt: Date;

--- a/app/backend/src/entity-linking/entity-linking.controller.ts
+++ b/app/backend/src/entity-linking/entity-linking.controller.ts
@@ -62,9 +62,33 @@ export class EntityLinkingController {
   })
   @ApiQuery({ name: 'minConfidence', required: false, type: Number })
   @ApiQuery({ name: 'isActive', required: false, type: Boolean })
+  @ApiQuery({
+    name: 'reviewState',
+    required: false,
+    enum: [
+      'auto_applied',
+      'pending_review',
+      'accepted',
+      'rejected',
+      'remapped',
+    ],
+  })
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async queryLinks(@Query() query: EntityLinkQueryDto) {
+    return this.entityLinkingService.queryLinks(query);
+  }
+
+  @Get('queue')
+  @ApiOperation({
+    summary: 'Get review queue',
+    description: 'Retrieve entity links pending manual review (pending_review)',
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async getReviewQueue(@Query() query: EntityLinkQueryDto) {
+    // Force the filter to pending_review
+    query.reviewState = 'pending_review';
     return this.entityLinkingService.queryLinks(query);
   }
 
@@ -138,7 +162,8 @@ export class EntityLinkingController {
     @Body()
     reviewData: {
       reviewedBy: string;
-      isActive: boolean;
+      isActive?: boolean;
+      decision?: 'accepted' | 'rejected' | 'remapped';
       reviewNotes?: string;
       registryId?: string;
     },

--- a/app/backend/src/entity-linking/entity-linking.controller.ts
+++ b/app/backend/src/entity-linking/entity-linking.controller.ts
@@ -136,7 +136,12 @@ export class EntityLinkingController {
   async reviewLink(
     @Param('linkId') linkId: string,
     @Body()
-    reviewData: { reviewedBy: string; isActive: boolean; reviewNotes?: string },
+    reviewData: {
+      reviewedBy: string;
+      isActive: boolean;
+      reviewNotes?: string;
+      registryId?: string;
+    },
   ) {
     this.logger.log(`Reviewing entity link ${linkId}`);
     return this.entityLinkingService.reviewLink(linkId, reviewData);

--- a/app/backend/src/entity-linking/entity-linking.module.ts
+++ b/app/backend/src/entity-linking/entity-linking.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { EntityLinkingService } from './entity-linking.service';
 import { EntityLinkingController } from './entity-linking.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { MetricsModule } from '../observability/metrics/metrics.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ConfigModule, MetricsModule],
   controllers: [EntityLinkingController],
   providers: [EntityLinkingService],
   exports: [EntityLinkingService],

--- a/app/backend/src/entity-linking/entity-linking.service.spec.ts
+++ b/app/backend/src/entity-linking/entity-linking.service.spec.ts
@@ -89,6 +89,10 @@ describe('EntityLinkingService', () => {
         assetId: null,
         projectId: null,
         isActive: true,
+        reviewState: 'auto_applied',
+        reviewedBy: null,
+        reviewedAt: null,
+        reviewNotes: null,
         createdAt: new Date(),
         updatedAt: new Date(),
       });
@@ -99,7 +103,45 @@ describe('EntityLinkingService', () => {
       expect(result.sourceType).toBe('claim');
       expect(result.extractedName).toBe('Test Organization');
       expect(result.confidenceScore).toBe(0.95);
+      expect(result.confidenceBand).toBe('high');
+      expect(result.reviewThreshold).toBe(0.8);
       expect(prisma.entityLink.create).toHaveBeenCalled();
+    });
+
+    it('should queue low-confidence links for manual review', async () => {
+      const dto = {
+        sourceType: 'claim' as const,
+        sourceId: 'claim-123',
+        extractedName: 'Uncertain Organization',
+        entityType: 'organization' as const,
+        confidenceScore: 0.61,
+      };
+
+      mockPrisma.entityLink.create.mockResolvedValue({
+        id: 'link-queue',
+        ...dto,
+        organizationId: null,
+        locationId: null,
+        assetId: null,
+        projectId: null,
+        isActive: false,
+        reviewState: 'pending_review',
+        reviewedBy: null,
+        reviewedAt: null,
+        reviewNotes: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      mockPrisma.entityLink.count.mockResolvedValue(1);
+
+      const result = await service.linkEntity(dto);
+
+      expect(result.reviewState).toBe('pending_review');
+      expect(result.isActive).toBe(false);
+      expect(result.confidenceBand).toBe('medium');
+      expect(prisma.entityLink.count).toHaveBeenCalledWith({
+        where: { reviewState: 'pending_review' },
+      });
     });
 
     it('should throw BadRequestException for invalid confidence score', async () => {
@@ -265,26 +307,30 @@ describe('EntityLinkingService', () => {
         reviewedBy: 'user-1',
         reviewedAt: new Date(),
         isActive: false,
+        reviewState: 'rejected',
         reviewNotes: 'Incorrect match',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       mockPrisma.entityLink.update.mockResolvedValue(mockUpdated);
+      mockPrisma.entityLink.count.mockResolvedValue(0);
 
       const result = await service.reviewLink('link-1', {
         reviewedBy: 'user-1',
-        isActive: false,
+        decision: 'rejected',
         reviewNotes: 'Incorrect match',
       });
 
       expect(result.isActive).toBe(false);
       expect(result.reviewedBy).toBe('user-1');
+      expect(result.reviewState).toBe('rejected');
       expect(prisma.entityLink.update).toHaveBeenCalledWith({
         where: { id: 'link-1' },
         data: expect.objectContaining({
           reviewedBy: 'user-1',
           isActive: false,
+          reviewState: 'rejected',
           reviewNotes: 'Incorrect match',
         }),
       });

--- a/app/backend/src/entity-linking/entity-linking.service.spec.ts
+++ b/app/backend/src/entity-linking/entity-linking.service.spec.ts
@@ -44,6 +44,18 @@ describe('EntityLinkingService', () => {
           provide: PrismaService,
           useValue: mockPrisma,
         },
+        {
+          provide: require('@nestjs/config').ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('0.8') },
+        },
+        {
+          provide: require('../observability/metrics/metrics.service')
+            .MetricsService,
+          useValue: {
+            setEntityLinkReviewQueueDepth: jest.fn(),
+            recordEntityLinkReviewDecisionLatency: jest.fn(),
+          },
+        },
       ],
     }).compile();
 

--- a/app/backend/src/entity-linking/entity-linking.service.ts
+++ b/app/backend/src/entity-linking/entity-linking.service.ts
@@ -4,6 +4,8 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MetricsService } from '../observability/metrics/metrics.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   CreateEntityLinkDto,
@@ -16,7 +18,18 @@ import {
 export class EntityLinkingService {
   private readonly logger = new Logger(EntityLinkingService.name);
 
-  constructor(private prisma: PrismaService) {}
+  private readonly reviewThreshold: number;
+
+  constructor(
+    private prisma: PrismaService,
+    private readonly configService: ConfigService,
+    private readonly metricsService: MetricsService,
+  ) {
+    this.reviewThreshold =
+      parseFloat(
+        this.configService.get<string>('ENTITY_LINK_REVIEW_THRESHOLD') || '0.8',
+      ) || 0.8;
+  }
 
   /**
    * Link an extracted entity to a canonical registry record
@@ -86,13 +99,39 @@ export class EntityLinkingService {
       }
     }
 
+    // Determine whether this should be auto-applied or sent to review
+    let reviewState = 'auto_applied';
+    if (dto.confidenceScore < this.reviewThreshold) {
+      // Send to review queue
+      linkData.isActive = false;
+      reviewState = 'pending_review';
+    } else {
+      linkData.isActive = true;
+      reviewState = 'auto_applied';
+    }
+
+    linkData.reviewState = reviewState;
+
     const link = await this.prisma.entityLink.create({
       data: linkData,
     });
 
     this.logger.log(
-      `Entity link created: ${link.id} with confidence ${link.confidenceScore}`,
+      `Entity link created: ${link.id} with confidence ${link.confidenceScore} (state=${linkData.reviewState})`,
     );
+
+    // Update review queue metric
+    if (reviewState === 'pending_review') {
+      // Count pending review links and set gauge
+      const pendingCount = await this.prisma.entityLink.count({
+        where: { reviewState: 'pending_review' },
+      });
+      try {
+        this.metricsService.setEntityLinkReviewQueueDepth(pendingCount);
+      } catch (e) {
+        this.logger.debug('Metrics update failed for review queue depth');
+      }
+    }
 
     return this.mapLinkResult(link);
   }
@@ -227,21 +266,82 @@ export class EntityLinkingService {
    */
   async reviewLink(
     linkId: string,
-    reviewData: { reviewedBy: string; isActive: boolean; reviewNotes?: string },
+    reviewData: {
+      reviewedBy: string;
+      isActive: boolean;
+      reviewNotes?: string;
+      registryId?: string; // Optional remap to specific registry record
+    },
   ): Promise<LinkEntityResult> {
     this.logger.log(
       `Reviewing entity link ${linkId} by ${reviewData.reviewedBy}`,
     );
 
+    const updateData: any = {
+      reviewedBy: reviewData.reviewedBy,
+      reviewedAt: new Date(),
+      isActive: reviewData.isActive,
+      reviewNotes: reviewData.reviewNotes,
+      reviewState: reviewData.isActive ? 'accepted' : 'rejected',
+    };
+
+    // If remapping to a registry ID, resolve it and attach
+    if (reviewData.registryId) {
+      const link = await this.prisma.entityLink.findUnique({
+        where: { id: linkId },
+      });
+      if (!link) {
+        throw new NotFoundException(`EntityLink ${linkId} not found`);
+      }
+
+      const resolvedId = await this.findRegistryRecordById(
+        link.entityType as string,
+        reviewData.registryId,
+      );
+
+      switch (link.entityType) {
+        case 'organization':
+          updateData.organizationId = resolvedId;
+          break;
+        case 'location':
+          updateData.locationId = resolvedId;
+          break;
+        case 'asset':
+          updateData.assetId = resolvedId;
+          break;
+        case 'project':
+          updateData.projectId = resolvedId;
+          break;
+      }
+
+      updateData.matchMethod = 'manual';
+      updateData.reviewState = 'remapped';
+    }
+
     const updated = await this.prisma.entityLink.update({
       where: { id: linkId },
-      data: {
-        reviewedBy: reviewData.reviewedBy,
-        reviewedAt: new Date(),
-        isActive: reviewData.isActive,
-        reviewNotes: reviewData.reviewNotes,
-      },
+      data: updateData,
     });
+
+    // Update metrics: decrement queue depth and record latency
+    try {
+      const pendingCount = await this.prisma.entityLink.count({
+        where: { reviewState: 'pending_review' },
+      });
+      this.metricsService.setEntityLinkReviewQueueDepth(pendingCount);
+
+      if (updated.reviewedAt && updated.createdAt) {
+        const latencySeconds =
+          (new Date(updated.reviewedAt).getTime() -
+            new Date(updated.createdAt).getTime()) /
+          1000;
+        this.metricsService.recordEntityLinkReviewDecisionLatency(
+          latencySeconds,
+        );
+      }
+    } catch (e) {
+      this.logger.debug('Metrics update failed for review decision');
+    }
 
     return this.mapLinkResult(updated);
   }
@@ -546,6 +646,7 @@ export class EntityLinkingService {
       isActive: link.isActive,
       reviewedBy: link.reviewedBy,
       reviewedAt: link.reviewedAt,
+      reviewState: link.reviewState ?? null,
       reviewNotes: link.reviewNotes,
       createdAt: link.createdAt,
       updatedAt: link.updatedAt,

--- a/app/backend/src/entity-linking/entity-linking.service.ts
+++ b/app/backend/src/entity-linking/entity-linking.service.ts
@@ -12,6 +12,8 @@ import {
   LinkEntityResult,
   EntityLinkQueryDto,
   RegistrySearchResult,
+  EntityLinkConfidenceBand,
+  EntityLinkReviewDecision,
 } from './dto/entity-link.dto';
 
 @Injectable()
@@ -31,6 +33,50 @@ export class EntityLinkingService {
       ) || 0.8;
   }
 
+  private getConfidenceBand(score: number): EntityLinkConfidenceBand {
+    if (score >= this.reviewThreshold) {
+      return 'high';
+    }
+    if (score >= 0.5) {
+      return 'medium';
+    }
+    return 'low';
+  }
+
+  private normalizeReviewDecision(reviewData: {
+    reviewedBy: string;
+    isActive?: boolean;
+    decision?: EntityLinkReviewDecision;
+    reviewNotes?: string;
+    registryId?: string;
+  }): { reviewState: string; isActive: boolean } {
+    if (reviewData.registryId) {
+      return { reviewState: 'remapped', isActive: true };
+    }
+
+    if (reviewData.decision) {
+      switch (reviewData.decision) {
+        case 'accepted':
+          return { reviewState: 'accepted', isActive: true };
+        case 'rejected':
+          return { reviewState: 'rejected', isActive: false };
+        case 'remapped':
+          return { reviewState: 'remapped', isActive: true };
+        default:
+          break;
+      }
+    }
+
+    if (reviewData.isActive === undefined) {
+      return { reviewState: 'rejected', isActive: false };
+    }
+
+    return {
+      reviewState: reviewData.isActive ? 'accepted' : 'rejected',
+      isActive: reviewData.isActive,
+    };
+  }
+
   /**
    * Link an extracted entity to a canonical registry record
    */
@@ -43,6 +89,8 @@ export class EntityLinkingService {
     if (dto.confidenceScore < 0 || dto.confidenceScore > 1) {
       throw new BadRequestException('Confidence score must be between 0 and 1');
     }
+
+    const confidenceBand = this.getConfidenceBand(dto.confidenceScore);
 
     // Find or create registry record
     let registryRecordId: string | null = null;
@@ -77,6 +125,8 @@ export class EntityLinkingService {
       extractedType: dto.extractedType,
       entityType: dto.entityType,
       confidenceScore: dto.confidenceScore,
+      confidenceBand,
+      reviewThreshold: this.reviewThreshold,
       matchMethod,
       metadata: dto.metadata ? JSON.parse(JSON.stringify(dto.metadata)) : null,
     };
@@ -169,6 +219,11 @@ export class EntityLinkingService {
 
     if (query.isActive !== undefined) {
       where.isActive = query.isActive;
+    }
+
+    // Allow filtering by review state (e.g., 'pending_review')
+    if ((query as any).reviewState !== undefined) {
+      where.reviewState = (query as any).reviewState;
     }
 
     const [links, total] = await Promise.all([
@@ -268,7 +323,8 @@ export class EntityLinkingService {
     linkId: string,
     reviewData: {
       reviewedBy: string;
-      isActive: boolean;
+      isActive?: boolean;
+      decision?: EntityLinkReviewDecision;
       reviewNotes?: string;
       registryId?: string; // Optional remap to specific registry record
     },
@@ -277,12 +333,13 @@ export class EntityLinkingService {
       `Reviewing entity link ${linkId} by ${reviewData.reviewedBy}`,
     );
 
+    const normalizedDecision = this.normalizeReviewDecision(reviewData);
     const updateData: any = {
       reviewedBy: reviewData.reviewedBy,
       reviewedAt: new Date(),
-      isActive: reviewData.isActive,
+      isActive: normalizedDecision.isActive,
       reviewNotes: reviewData.reviewNotes,
-      reviewState: reviewData.isActive ? 'accepted' : 'rejected',
+      reviewState: normalizedDecision.reviewState,
     };
 
     // If remapping to a registry ID, resolve it and attach
@@ -316,6 +373,7 @@ export class EntityLinkingService {
 
       updateData.matchMethod = 'manual';
       updateData.reviewState = 'remapped';
+      updateData.isActive = true;
     }
 
     const updated = await this.prisma.entityLink.update({
@@ -642,6 +700,8 @@ export class EntityLinkingService {
       assetId: link.assetId,
       projectId: link.projectId,
       confidenceScore: link.confidenceScore,
+      confidenceBand: this.getConfidenceBand(link.confidenceScore),
+      reviewThreshold: this.reviewThreshold,
       matchMethod: link.matchMethod,
       isActive: link.isActive,
       reviewedBy: link.reviewedBy,

--- a/app/backend/src/observability/metrics/metrics.service.ts
+++ b/app/backend/src/observability/metrics/metrics.service.ts
@@ -450,6 +450,40 @@ export class MetricsService {
   }
 
   /**
+   * Set current entity link review queue depth gauge.
+   */
+  setEntityLinkReviewQueueDepth(count: number): void {
+    // Create a dynamic gauge if it doesn't exist
+    const name = 'entity_link_review_queue_depth';
+    if (!this.dynamicGauges.has(name)) {
+      const g = new Gauge({
+        name,
+        help: 'Number of entity links awaiting manual review',
+        labelNames: [],
+      });
+      this.dynamicGauges.set(name, g);
+    }
+    this.dynamicGauges.get(name)!.set(count);
+  }
+
+  /**
+   * Record latency (seconds) between link creation and review decision.
+   */
+  recordEntityLinkReviewDecisionLatency(seconds: number): void {
+    const name = 'entity_link_review_decision_seconds';
+    if (!this.dynamicHistograms.has(name)) {
+      const h = new Histogram({
+        name,
+        help: 'Seconds between entity link creation and reviewer decision',
+        labelNames: [],
+        buckets: [60, 300, 900, 3600, 86400],
+      });
+      this.dynamicHistograms.set(name, h);
+    }
+    this.dynamicHistograms.get(name)!.observe(seconds);
+  }
+
+  /**
    * Record histogram metrics for duration tracking
    */
   recordHistogram(


### PR DESCRIPTION
Added confidence-band metadata and review-threshold values to entity-link responses
Kept low-confidence links in [pending_review](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of auto-applying

Allowed review requests to use explicit decision semantics:
accepted
rejected
remapped
Preserved backward compatibility with the existing boolean [isActive](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) review flow
Added API/query support for filtering entity links by [reviewState](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Exposed the review queue through the queue endpoint
Updated queue-depth and decision-latency metric hooks for manual review tracking

Why
Previously, low-confidence matches could be silently applied or ignored, which risked corrupting registry data. This patch ensures any uncertain entity link is reviewed by a human before it becomes active.

Acceptance criteria coverage
Links carry a confidence score and a threshold from configuration: yes
Links below threshold enter a review queue instead of being auto-applied: yes
Reviewers can accept, reject, or remap a queued link.
--Closes #949 