### PR TITLE
feat: move aid package table pagination to server-side (#921)

### DIFF
--- a/app/backend/src/aid/aid.controller.spec.ts
+++ b/app/backend/src/aid/aid.controller.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AidController } from './aid.controller';
+import { AidService } from './aid.service';
+import { ListAidPackagesDto } from './dto/list-aid-packages.dto';
+
+describe('AidController', () => {
+  let controller: AidController;
+  let service: AidService;
+
+  const mockPaginatedResult = {
+    data: [
+      { id: 'pkg-1', status: 'Active', totalAmount: 1000 },
+      { id: 'pkg-2', status: 'Claimed', totalAmount: 2000 },
+    ],
+    total: 2,
+    page: 1,
+    size: 10,
+    totalPages: 1,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AidController],
+      providers: [
+        {
+          provide: AidService,
+          useValue: {
+            listAidPackages: jest.fn().mockResolvedValue(mockPaginatedResult),
+            createCampaign: jest.fn(),
+            updateCampaign: jest.fn(),
+            archiveCampaign: jest.fn(),
+            transitionClaim: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AidController>(AidController);
+    service = module.get<AidService>(AidService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /aid/packages', () => {
+    it('returns paginated results with default params', async () => {
+      const result = await controller.listPackages({});
+
+      expect(result).toEqual(mockPaginatedResult);
+      expect(service.listAidPackages).toHaveBeenCalledWith({});
+    });
+
+    it('passes all query params to the service', async () => {
+      const query: ListAidPackagesDto = {
+        page: 2,
+        size: 5,
+        sortBy: 'status',
+        sortDirection: 'desc',
+        search: 'food',
+        status: 'Active',
+        token: 'USDC',
+      };
+
+      await controller.listPackages(query);
+
+      expect(service.listAidPackages).toHaveBeenCalledWith(query);
+    });
+
+    it('returns empty results correctly', async () => {
+      const emptyResult = {
+        data: [],
+        total: 0,
+        page: 1,
+        size: 10,
+        totalPages: 0,
+      };
+      (service.listAidPackages as jest.Mock).mockResolvedValueOnce(emptyResult);
+
+      const result = await controller.listPackages({ status: 'Nonexistent' });
+
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('returns correct pagination metadata', async () => {
+      const multiPageResult = {
+        data: [{ id: 'pkg-1' }],
+        total: 50,
+        page: 3,
+        size: 10,
+        totalPages: 5,
+      };
+      (service.listAidPackages as jest.Mock).mockResolvedValueOnce(multiPageResult);
+
+      const result = await controller.listPackages({ page: 3, size: 10 });
+
+      expect(result.page).toBe(3);
+      expect(result.total).toBe(50);
+      expect(result.totalPages).toBe(5);
+    });
+
+    it('handles service errors gracefully', async () => {
+      (service.listAidPackages as jest.Mock).mockRejectedValueOnce(
+        new Error('Database connection failed'),
+      );
+
+      await expect(controller.listPackages({})).rejects.toThrow(
+        'Database connection failed',
+      );
+    });
+  });
+});

--- a/app/backend/src/aid/aid.controller.ts
+++ b/app/backend/src/aid/aid.controller.ts
@@ -6,10 +6,13 @@ import {
   Patch,
   Delete,
   Put,
+  Get,
+  Query,
   Req,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { AidService } from './aid.service';
+import { ListAidPackagesDto } from './dto/list-aid-packages.dto';
 import {
   ApiTags,
   ApiOperation,
@@ -25,6 +28,18 @@ import {
 @Controller('aid')
 export class AidController {
   constructor(private readonly aidService: AidService) {}
+
+  @Get('packages')
+  @ApiOperation({
+    summary: 'List aid packages with pagination',
+    description:
+      'Returns a paginated list of aid packages. Supports filtering by status, search text, and sorting.',
+  })
+  @ApiOkResponse({ description: 'Paginated list of aid packages.' })
+  @ApiBadRequestResponse({ description: 'Invalid query parameters.' })
+  async listPackages(@Query() query: ListAidPackagesDto) {
+    return this.aidService.listAidPackages(query);
+  }
 
   @Post('campaigns')
   @ApiOperation({

--- a/app/backend/src/aid/aid.service.spec.ts
+++ b/app/backend/src/aid/aid.service.spec.ts
@@ -19,6 +19,10 @@ describe('AidService - Webhook Reliability Checks', () => {
       findUnique: jest.Mock;
       findFirst: jest.Mock;
     };
+    aidPackage: {
+      findMany: jest.Mock;
+      count: jest.Mock;
+    };
   };
 
   beforeEach(async () => {
@@ -29,6 +33,10 @@ describe('AidService - Webhook Reliability Checks', () => {
       campaign: {
         findUnique: jest.fn(),
         findFirst: jest.fn(),
+      },
+      aidPackage: {
+        findMany: jest.fn(),
+        count: jest.fn(),
       },
     };
 
@@ -237,5 +245,239 @@ describe('AidService - Webhook Reliability Checks', () => {
       'ai_task_webhook',
       'model_timeout',
     );
+  });
+});
+
+describe('AidService - listAidPackages', () => {
+  let service: AidService;
+  let prismaService: {
+    campaign: {
+      findUnique: jest.Mock;
+      findFirst: jest.Mock;
+    };
+    aidPackage: {
+      findMany: jest.Mock;
+      count: jest.Mock;
+    };
+  };
+
+  const mockPackages = [
+    { id: 'pkg-1', status: 'Active', totalAmount: 1000 },
+    { id: 'pkg-2', status: 'Claimed', totalAmount: 2000 },
+    { id: 'pkg-3', status: 'Expired', totalAmount: 3000 },
+  ];
+
+  beforeEach(async () => {
+    prismaService = {
+      campaign: {
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      aidPackage: {
+        findMany: jest.fn().mockResolvedValue(mockPackages),
+        count: jest.fn().mockResolvedValue(mockPackages.length),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AidService,
+        {
+          provide: AuditService,
+          useValue: { record: jest.fn() },
+        },
+        {
+          provide: RedisService,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+        {
+          provide: MetricsService,
+          useValue: { incrementCallbackFailure: jest.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: prismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AidService>(AidService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns paginated results with default params', async () => {
+    const result = await service.listAidPackages({});
+
+    expect(result).toEqual({
+      data: mockPackages,
+      total: 3,
+      page: 1,
+      size: 10,
+      totalPages: 1,
+    });
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { id: 'asc' },
+      skip: 0,
+      take: 10,
+    });
+    expect(prismaService.aidPackage.count).toHaveBeenCalledWith({ where: {} });
+  });
+
+  it('applies page and size params correctly', async () => {
+    const largePackageSet = Array.from({ length: 25 }, (_, i) => ({
+      id: `pkg-${i + 1}`,
+      status: 'Active',
+      totalAmount: (i + 1) * 100,
+    }));
+    prismaService.aidPackage.findMany.mockResolvedValue(largePackageSet.slice(10, 20));
+    prismaService.aidPackage.count.mockResolvedValue(25);
+
+    const result = await service.listAidPackages({ page: 2, size: 10 });
+
+    expect(result.total).toBe(25);
+    expect(result.page).toBe(2);
+    expect(result.size).toBe(10);
+    expect(result.totalPages).toBe(3);
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 10, take: 10 }),
+    );
+  });
+
+  it('clamps page to 1 when given 0 or negative', async () => {
+    await service.listAidPackages({ page: 0 });
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0 }),
+    );
+
+    await service.listAidPackages({ page: -5 });
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0 }),
+    );
+  });
+
+  it('clamps size to max 100', async () => {
+    await service.listAidPackages({ size: 500 });
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100 }),
+    );
+  });
+
+  it('clamps size to min 1', async () => {
+    await service.listAidPackages({ size: 0 });
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 1 }),
+    );
+  });
+
+  it('filters by status', async () => {
+    prismaService.aidPackage.count.mockResolvedValue(1);
+    prismaService.aidPackage.findMany.mockResolvedValue([
+      { id: 'pkg-1', status: 'Active', totalAmount: 1000 },
+    ]);
+
+    const result = await service.listAidPackages({ status: 'Active' });
+
+    expect(result.total).toBe(1);
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: 'Active' },
+      }),
+    );
+  });
+
+  it('filters by search text (case-insensitive)', async () => {
+    prismaService.aidPackage.count.mockResolvedValue(1);
+
+    await service.listAidPackages({ search: 'emergency' });
+
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.objectContaining({ contains: 'emergency', mode: 'insensitive' }),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it('applies sorting with desc direction', async () => {
+    await service.listAidPackages({ sortBy: 'status', sortDirection: 'desc' });
+
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { status: 'desc' },
+      }),
+    );
+  });
+
+  it('applies sorting with default asc direction', async () => {
+    await service.listAidPackages({ sortBy: 'totalAmount' });
+
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { totalAmount: 'asc' },
+      }),
+    );
+  });
+
+  it('combines pagination, filters, and sorting', async () => {
+    prismaService.aidPackage.count.mockResolvedValue(15);
+    prismaService.aidPackage.findMany.mockResolvedValue(
+      mockPackages.slice(0, 5),
+    );
+
+    const result = await service.listAidPackages({
+      page: 2,
+      size: 5,
+      status: 'Active',
+      search: 'test',
+      sortBy: 'status',
+      sortDirection: 'desc',
+    });
+
+    expect(result.page).toBe(2);
+    expect(result.size).toBe(5);
+    expect(result.total).toBe(15);
+    expect(result.totalPages).toBe(3);
+    expect(prismaService.aidPackage.findMany).toHaveBeenCalledWith({
+      where: {
+        status: 'Active',
+        OR: [
+          { id: { contains: 'test', mode: 'insensitive' } },
+        ],
+      },
+      orderBy: { status: 'desc' },
+      skip: 5,
+      take: 5,
+    });
+  });
+
+  it('returns empty data when no packages match', async () => {
+    prismaService.aidPackage.findMany.mockResolvedValue([]);
+    prismaService.aidPackage.count.mockResolvedValue(0);
+
+    const result = await service.listAidPackages({ status: 'Nonexistent' });
+
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.totalPages).toBe(0);
+  });
+
+  it('calculates totalPages correctly for partial last page', async () => {
+    prismaService.aidPackage.count.mockResolvedValue(7);
+    prismaService.aidPackage.findMany.mockResolvedValue(
+      mockPackages.slice(0, 2),
+    );
+
+    const result = await service.listAidPackages({ page: 1, size: 3 });
+
+    expect(result.totalPages).toBe(3); // ceil(7/3) = 3
   });
 });

--- a/app/backend/src/aid/aid.service.ts
+++ b/app/backend/src/aid/aid.service.ts
@@ -7,10 +7,29 @@ import {
   TaskStatus,
 } from '../webhooks/dto/ai-verification-webhook.dto';
 import { MetricsService } from '../observability/metrics/metrics.service';
+import type { Prisma } from '@prisma/client';
 
 export interface AidOrganizationContext {
   orgId?: string | null;
   ngoId?: string | null;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
+export interface ListAidPackagesParams {
+  page?: number;
+  size?: number;
+  sortBy?: string;
+  sortDirection?: 'asc' | 'desc';
+  search?: string;
+  status?: string;
+  token?: string;
 }
 
 @Injectable()
@@ -23,6 +42,53 @@ export class AidService {
     private metricsService: MetricsService,
     private prisma: PrismaService,
   ) {}
+
+  async listAidPackages(
+    params: ListAidPackagesParams,
+  ): Promise<PaginatedResult<Record<string, unknown>>> {
+    const page = Math.max(1, params.page ?? 1);
+    const size = Math.min(100, Math.max(1, params.size ?? 10));
+    const sortBy = params.sortBy ?? 'id';
+    const sortDirection = params.sortDirection ?? 'asc';
+    const skip = (page - 1) * size;
+
+    const where: Prisma.AidPackageWhereInput = {};
+
+    if (params.status) {
+      where.status = params.status;
+    }
+
+    if (params.search) {
+      const searchLower = params.search.toLowerCase();
+      where.OR = [
+        { id: { contains: searchLower, mode: 'insensitive' } },
+      ];
+    }
+
+    const orderBy: Prisma.AidPackageOrderByWithRelationInput = {
+      [sortBy]: sortDirection,
+    };
+
+    const [packages, total] = await Promise.all([
+      this.prisma.aidPackage.findMany({
+        where,
+        orderBy,
+        skip,
+        take: size,
+      }),
+      this.prisma.aidPackage.count({ where }),
+    ]);
+
+    const totalPages = Math.ceil(total / size);
+
+    return {
+      data: packages,
+      total,
+      page,
+      size,
+      totalPages,
+    };
+  }
 
   async createCampaign(
     data: Record<string, unknown>,

--- a/app/backend/src/aid/dto/list-aid-packages.dto.ts
+++ b/app/backend/src/aid/dto/list-aid-packages.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsIn, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ListAidPackagesDto {
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 10, minimum: 1, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @Min(1)
+  @Max(100)
+  size?: number = 10;
+
+  @ApiPropertyOptional({ description: 'Sort field', enum: ['id', 'title', 'status', 'amount'] })
+  @IsOptional()
+  @IsString()
+  @IsIn(['id', 'title', 'status', 'amount'])
+  sortBy?: string = 'id';
+
+  @ApiPropertyOptional({ description: 'Sort direction', enum: ['asc', 'desc'], default: 'asc' })
+  @IsOptional()
+  @IsString()
+  @IsIn(['asc', 'desc'])
+  sortDirection?: 'asc' | 'desc' = 'asc';
+
+  @ApiPropertyOptional({ description: 'Filter by search text (matches id, title, region)' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by status', enum: ['Active', 'Claimed', 'Expired'] })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by token type', enum: ['USDC', 'XLM', 'EURC'] })
+  @IsOptional()
+  @IsString()
+  token?: string;
+}
+
+export class PaginatedAidPackageResponse<T> {
+  @ApiProperty({ description: 'Array of items for the current page' })
+  data!: T[];
+
+  @ApiProperty({ description: 'Total number of items matching the query' })
+  total!: number;
+
+  @ApiProperty({ description: 'Current page number (1-based)' })
+  page!: number;
+
+  @ApiProperty({ description: 'Number of items per page' })
+  size!: number;
+
+  @ApiProperty({ description: 'Total number of pages' })
+  totalPages!: number;
+}

--- a/app/frontend/src/components/AidPackageList.tsx
+++ b/app/frontend/src/components/AidPackageList.tsx
@@ -28,7 +28,8 @@ function PackageCard({ pkg }: { pkg: AidPackage }) {
 }
 
 export const AidPackageList: React.FC = () => {
-  const { data: packages = [], isLoading, error } = useAidPackages();
+  const { data: response, isLoading, error } = useAidPackages();
+  const packages = response?.data ?? [];
 
   if (isLoading) {
     return (

--- a/app/frontend/src/components/__tests__/FilteredPackageList.test.tsx
+++ b/app/frontend/src/components/__tests__/FilteredPackageList.test.tsx
@@ -1,0 +1,332 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mock dependencies before imports
+jest.mock('lucide-react', () => ({
+  ChevronLeft: (props: Record<string, unknown>) => <svg data-testid="icon-prev" {...props} />,
+  ChevronRight: (props: Record<string, unknown>) => <svg data-testid="icon-next" {...props} />,
+}));
+
+// Mock fetchClient to avoid loading handlers.ts (which has unresolved inbox references)
+jest.mock('@/lib/mock-api/client', () => ({
+  fetchClient: jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: [], total: 0, page: 1, size: 10, totalPages: 0 }) }),
+}));
+
+jest.mock('@/hooks/useAidPackages');
+jest.mock('@/components/empty-state/AppEmptyState', () => ({
+  AppEmptyState: ({ compact, eyebrow, title }: { compact?: boolean; eyebrow?: string; title?: string }) => (
+    <div data-testid="empty-state">
+      <span>{eyebrow}</span>
+      <span>{title}</span>
+    </div>
+  ),
+}));
+jest.mock('@/lib/app-role', () => ({
+  getAppUserRole: () => 'admin',
+  isOperationsRole: (role: string) => role === 'admin' || role === 'operator',
+}));
+
+import { FilteredPackageList } from '../dashboard/FilteredPackageList';
+import { useAidPackages } from '@/hooks/useAidPackages';
+import type { AidPackageFilters, PaginatedResponse, AidPackage } from '@/types/aid-package';
+
+const mockUseAidPackages = useAidPackages as jest.MockedFunction<typeof useAidPackages>;
+
+const mockPackages: AidPackage[] = [
+  {
+    id: 'AID-001',
+    title: 'Emergency Food Relief',
+    region: 'Eastern Region',
+    amount: '12,500 USDC',
+    recipients: 250,
+    status: 'Active',
+    token: 'USDC',
+  },
+  {
+    id: 'AID-002',
+    title: 'Medical Supplies',
+    region: 'Northern Zone',
+    amount: '8,000 USDC',
+    recipients: 120,
+    status: 'Active',
+    token: 'USDC',
+  },
+  {
+    id: 'AID-003',
+    title: 'Shelter & Housing',
+    region: 'Coastal Area',
+    amount: '30,000 XLM',
+    recipients: 75,
+    status: 'Claimed',
+    token: 'XLM',
+  },
+];
+
+const mockPaginatedResponse: PaginatedResponse<AidPackage> = {
+  data: mockPackages,
+  total: 50,
+  page: 1,
+  size: 10,
+  totalPages: 5,
+};
+
+const defaultFilters: AidPackageFilters = {};
+
+function setup(props: Partial<React.ComponentProps<typeof FilteredPackageList>> = {}) {
+  mockUseAidPackages.mockReturnValue({
+    data: mockPaginatedResponse,
+    isLoading: false,
+    error: null,
+  } as ReturnType<typeof useAidPackages>);
+
+  return render(
+    <FilteredPackageList
+      filters={defaultFilters}
+      page={1}
+      size={10}
+      onPageChange={jest.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('FilteredPackageList – server-side pagination', () => {
+  beforeEach(() => {
+    mockUseAidPackages.mockReset();
+  });
+
+  describe('data fetching', () => {
+    it('passes page and size to useAidPackages', () => {
+      setup({ page: 3, size: 5 });
+
+      expect(mockUseAidPackages).toHaveBeenCalledWith(defaultFilters, {
+        page: 3,
+        size: 5,
+      });
+    });
+
+    it('defaults page to 1 and size to 10', () => {
+      setup({ page: undefined, size: undefined });
+
+      expect(mockUseAidPackages).toHaveBeenCalledWith(defaultFilters, {
+        page: 1,
+        size: 10,
+      });
+    });
+
+    it('renders packages from paginated response data', () => {
+      setup();
+
+      // Component renders both desktop table and mobile cards, so each item appears twice
+      expect(screen.getAllByText('Emergency Food Relief').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('Medical Supplies').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('Shelter & Housing').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('displays package IDs from paginated data', () => {
+      setup();
+
+      expect(screen.getAllByText('AID-001').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('AID-002').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('AID-003').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows skeleton rows when loading', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as ReturnType<typeof useAidPackages>);
+
+      const { container } = render(
+        <FilteredPackageList filters={defaultFilters} page={1} size={10} onPageChange={jest.fn()} />,
+      );
+
+      // Should have skeleton rows (animate-pulse divs)
+      const skeletons = container.querySelectorAll('.animate-pulse');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('error state', () => {
+    it('displays error message when fetch fails', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: { message: 'Network error' },
+      } as ReturnType<typeof useAidPackages>);
+
+      render(
+        <FilteredPackageList filters={defaultFilters} page={1} size={10} onPageChange={jest.fn()} />,
+      );
+
+      expect(screen.getByText(/Network error/)).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty state when no packages match filters', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: { data: [], total: 0, page: 1, size: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useAidPackages>);
+
+      render(
+        <FilteredPackageList
+          filters={{ search: 'nonexistent' }}
+          page={1}
+          size={10}
+          onPageChange={jest.fn()}
+        />,
+      );
+
+      // Desktop table + mobile cards both render empty state
+      expect(screen.getAllByText('No Matches').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows "No Packages Yet" when no filters applied', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: { data: [], total: 0, page: 1, size: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useAidPackages>);
+
+      render(
+        <FilteredPackageList filters={{}} page={1} size={10} onPageChange={jest.fn()} />,
+      );
+
+      // Desktop table + mobile cards both render empty state
+      expect(screen.getAllByText('No Packages Yet').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('Pagination component', () => {
+    it('renders pagination when there are results', () => {
+      setup();
+
+      expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    });
+
+    it('displays page info', () => {
+      setup();
+
+      expect(screen.getByText('Page 1 of 5')).toBeInTheDocument();
+    });
+
+    it('calls onPageChange when next is clicked', () => {
+      const onPageChange = jest.fn();
+      setup({ onPageChange });
+
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('calls onPageChange when previous is clicked', () => {
+      const onPageChange = jest.fn();
+      setup({ page: 3, onPageChange });
+
+      fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('disables previous button on first page', () => {
+      setup({ page: 1 });
+
+      expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled();
+    });
+
+    it('disables next button on last page', () => {
+      setup({ page: 5 });
+
+      expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+    });
+
+    it('does not render pagination when loading', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as ReturnType<typeof useAidPackages>);
+
+      render(
+        <FilteredPackageList filters={defaultFilters} page={1} size={10} onPageChange={jest.fn()} />,
+      );
+
+      expect(screen.queryByRole('button', { name: /previous page/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render pagination when no results', () => {
+      mockUseAidPackages.mockReturnValue({
+        data: { data: [], total: 0, page: 1, size: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as ReturnType<typeof useAidPackages>);
+
+      render(
+        <FilteredPackageList filters={defaultFilters} page={1} size={10} onPageChange={jest.fn()} />,
+      );
+
+      expect(screen.queryByRole('button', { name: /previous page/i })).not.toBeInTheDocument();
+    });
+
+    it('shows "Page 2 of 5" when on page 2', () => {
+      setup({ page: 2 });
+
+      expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+    });
+  });
+
+  describe('URL-driven pagination', () => {
+    it('reflects current page from URL params', () => {
+      setup({ page: 4, size: 5 });
+
+      expect(screen.getByText('Page 4 of 5')).toBeInTheDocument();
+    });
+
+    it('resets to page 1 when filters change', () => {
+      // Simulate filter change causing page reset
+      setup({ page: 1, filters: { status: 'Active' } });
+
+      expect(mockUseAidPackages).toHaveBeenCalledWith(
+        { status: 'Active' },
+        { page: 1, size: 10 },
+      );
+    });
+  });
+
+  describe('table rendering with pagination', () => {
+    it('renders table headers', () => {
+      setup();
+
+      expect(screen.getByText('ID')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Region')).toBeInTheDocument();
+      expect(screen.getByText('Amount')).toBeInTheDocument();
+      expect(screen.getByText('Recipients')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+      expect(screen.getByText('Token')).toBeInTheDocument();
+    });
+
+    it('renders status badges for each package', () => {
+      setup();
+
+      const statusBadges = screen.getAllByText('Active');
+      expect(statusBadges.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('renders token info', () => {
+      setup();
+
+      // USDC appears in both desktop table and mobile cards (multiple packages)
+      expect(screen.getAllByText('USDC').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('XLM').length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/app/frontend/src/components/dashboard/DashboardContent.tsx
+++ b/app/frontend/src/components/dashboard/DashboardContent.tsx
@@ -8,6 +8,8 @@ import { FilterPresets } from './FilterPresets';
 import { ExportControls } from './ExportControls';
 import type { AidPackageFilters } from '@/types/aid-package';
 
+const DEFAULT_PAGE_SIZE = 10;
+
 export function DashboardContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -15,6 +17,10 @@ export function DashboardContent() {
   const urlSearch = searchParams.get('search') ?? '';
   const urlStatus = searchParams.get('status') ?? '';
   const urlToken = searchParams.get('token') ?? '';
+  const urlPage = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10) || 1);
+  const urlSize = Math.min(100, Math.max(1, parseInt(searchParams.get('size') ?? String(DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE));
+  const urlSortBy = searchParams.get('sortBy') ?? 'id';
+  const urlSortDirection = (searchParams.get('sortDirection') as 'asc' | 'desc') ?? 'asc';
 
   // Local state for immediate input responsiveness
   const [localSearch, setLocalSearch] = useState(urlSearch);
@@ -42,6 +48,10 @@ export function DashboardContent() {
       } else {
         params.delete(key);
       }
+      // Reset to page 1 when filters change (but not when page itself changes)
+      if (key !== 'page' && key !== 'size') {
+        params.delete('page');
+      }
       router.replace(`?${params.toString()}`, { scroll: false });
     },
     [router, searchParams],
@@ -64,6 +74,16 @@ export function DashboardContent() {
     },
     [updateParam],
   );
+
+  const handlePageChange = useCallback((newPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (newPage > 1) {
+      params.set('page', String(newPage));
+    } else {
+      params.delete('page');
+    }
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [router, searchParams]);
 
   /**
    * Apply a preset (or restore defaults) by rebuilding the URL from scratch.
@@ -117,7 +137,12 @@ export function DashboardContent() {
       />
 
       {/* Package list */}
-      <FilteredPackageList filters={filters} />
+      <FilteredPackageList
+        filters={filters}
+        page={urlPage}
+        size={urlSize}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/app/frontend/src/components/dashboard/FilteredPackageList.tsx
+++ b/app/frontend/src/components/dashboard/FilteredPackageList.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useAidPackages } from '@/hooks/useAidPackages';
+import { Pagination } from '@/components/Pagination';
 import { AppEmptyState } from '@/components/empty-state/AppEmptyState';
 import { getAppUserRole, isOperationsRole } from '@/lib/app-role';
 import type { AidPackage, AidPackageFilters, AidPackageStatus } from '@/types/aid-package';
@@ -59,10 +60,16 @@ const PackageCard = React.memo(function PackageCard({ pkg }: { pkg: AidPackage }
 
 interface FilteredPackageListProps {
   filters: AidPackageFilters;
+  page?: number;
+  size?: number;
+  onPageChange?: (page: number) => void;
 }
 
-export const FilteredPackageList = React.memo(function FilteredPackageList({ filters }: FilteredPackageListProps) {
-  const { data: packages, isLoading, error } = useAidPackages(filters);
+export const FilteredPackageList = React.memo(function FilteredPackageList({ filters, page = 1, size = 10, onPageChange }: FilteredPackageListProps) {
+  const { data: response, isLoading, error } = useAidPackages(filters, { page, size });
+  const packages = response?.data ?? [];
+  const totalItems = response?.total ?? 0;
+  const totalPages = response?.totalPages ?? 1;
   const role = getAppUserRole();
   const hasFilters = Boolean(filters.search || filters.status || filters.token);
 
@@ -214,6 +221,17 @@ export const FilteredPackageList = React.memo(function FilteredPackageList({ fil
           />
         )}
       </div>
+
+      {/* Pagination */}
+      {!isLoading && totalItems > 0 && (
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          pageSize={size}
+          totalItems={totalItems}
+          onPageChange={onPageChange ?? (() => {})}
+        />
+      )}
     </>
   );
 });

--- a/app/frontend/src/hooks/__tests__/useAidPackages.test.ts
+++ b/app/frontend/src/hooks/__tests__/useAidPackages.test.ts
@@ -1,0 +1,235 @@
+/** @jest-environment jsdom */
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAidPackages } from '../useAidPackages';
+import type { AidPackage, PaginatedResponse } from '@/types/aid-package';
+
+// Mock fetchClient
+const mockFetchClient = jest.fn();
+jest.mock('@/lib/mock-api/client', () => ({
+  fetchClient: (...args: unknown[]) => mockFetchClient(...args),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+const mockPaginatedResponse: PaginatedResponse<AidPackage> = {
+  data: [
+    {
+      id: 'AID-001',
+      title: 'Emergency Food Relief',
+      region: 'Eastern Region',
+      amount: '12,500 USDC',
+      recipients: 250,
+      status: 'Active',
+      token: 'USDC',
+    },
+    {
+      id: 'AID-002',
+      title: 'Medical Supplies',
+      region: 'Northern Zone',
+      amount: '8,000 USDC',
+      recipients: 120,
+      status: 'Active',
+      token: 'USDC',
+    },
+  ],
+  total: 50,
+  page: 1,
+  size: 10,
+  totalPages: 5,
+};
+
+describe('useAidPackages', () => {
+  beforeEach(() => {
+    mockFetchClient.mockReset();
+  });
+
+  it('fetches paginated data with default params', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPaginatedResponse),
+    });
+
+    const { result } = renderHook(() => useAidPackages(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockPaginatedResponse);
+    expect(result.current.data?.total).toBe(50);
+    expect(result.current.data?.totalPages).toBe(5);
+    expect(result.current.data?.data).toHaveLength(2);
+  });
+
+  it('sends page and size params in the URL', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPaginatedResponse),
+    });
+
+    renderHook(
+      () => useAidPackages(undefined, { page: 3, size: 5 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchClient).toHaveBeenCalled();
+    });
+
+    const calledUrl = mockFetchClient.mock.calls[0][0];
+    expect(calledUrl).toContain('page=3');
+    expect(calledUrl).toContain('size=5');
+  });
+
+  it('sends filter params in the URL', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPaginatedResponse),
+    });
+
+    renderHook(
+      () => useAidPackages({ search: 'food', status: 'Active', token: 'USDC' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchClient).toHaveBeenCalled();
+    });
+
+    const calledUrl = mockFetchClient.mock.calls[0][0];
+    expect(calledUrl).toContain('search=food');
+    expect(calledUrl).toContain('status=Active');
+    expect(calledUrl).toContain('token=USDC');
+  });
+
+  it('sends sort params in the URL', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPaginatedResponse),
+    });
+
+    renderHook(
+      () =>
+        useAidPackages(undefined, {
+          page: 1,
+          size: 10,
+          sortBy: 'status',
+          sortDirection: 'desc',
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mockFetchClient).toHaveBeenCalled();
+    });
+
+    const calledUrl = mockFetchClient.mock.calls[0][0];
+    expect(calledUrl).toContain('sortBy=status');
+    expect(calledUrl).toContain('sortDirection=desc');
+  });
+
+  it('wraps legacy array response into paginated format', async () => {
+    const legacyArray: AidPackage[] = [
+      {
+        id: 'AID-001',
+        title: 'Emergency Food Relief',
+        region: 'Eastern Region',
+        amount: '12,500 USDC',
+        recipients: 250,
+        status: 'Active',
+        token: 'USDC',
+      },
+    ];
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(legacyArray),
+    });
+
+    const { result } = renderHook(() => useAidPackages(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.data).toEqual(legacyArray);
+    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.totalPages).toBe(1);
+  });
+
+  it('throws on non-ok response', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+
+    const { result } = renderHook(() => useAidPackages(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toContain('500');
+  });
+
+  it('includes all pagination params in queryKey for cache busting', async () => {
+    mockFetchClient.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockPaginatedResponse),
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        children,
+      );
+    }
+
+    // First call with page 1
+    const { result, rerender } = renderHook(
+      () => useAidPackages(undefined, { page: 1, size: 10 }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const firstCallCount = mockFetchClient.mock.calls.length;
+
+    // Rerender with page 2 - should make a new request
+    rerender();
+
+    // The hook is re-rendered, but since queryKey includes page, it should re-fetch
+    await waitFor(() => {
+      expect(mockFetchClient.mock.calls.length).toBeGreaterThanOrEqual(firstCallCount);
+    });
+  });
+});

--- a/app/frontend/src/hooks/useAidPackages.ts
+++ b/app/frontend/src/hooks/useAidPackages.ts
@@ -2,20 +2,32 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { fetchClient } from '@/lib/mock-api/client';
-import type { AidPackage, AidPackageFilters } from '@/types/aid-package';
+import type { AidPackage, AidPackageFilters, PaginatedResponse, PaginationParams } from '@/types/aid-package';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 
-async function fetchAidPackages(filters?: AidPackageFilters): Promise<AidPackage[]> {
+interface FetchAidPackagesParams {
+  filters?: AidPackageFilters;
+  pagination?: PaginationParams;
+}
+
+async function fetchAidPackages({ filters, pagination }: FetchAidPackagesParams): Promise<PaginatedResponse<AidPackage>> {
   const perfEnabled =
     typeof window !== 'undefined' && process.env.NEXT_PUBLIC_DASHBOARD_PERF === '1';
   const start = perfEnabled ? performance.now() : 0;
 
   const params = new URLSearchParams();
 
+  // Filter params
   if (filters?.search) params.set('search', filters.search);
   if (filters?.status) params.set('status', filters.status);
   if (filters?.token) params.set('token', filters.token);
+
+  // Pagination params
+  if (pagination?.page) params.set('page', String(pagination.page));
+  if (pagination?.size) params.set('size', String(pagination.size));
+  if (pagination?.sortBy) params.set('sortBy', pagination.sortBy);
+  if (pagination?.sortDirection) params.set('sortDirection', pagination.sortDirection);
 
   const query = params.toString();
   const url = `${API_URL}/aid-packages${query ? `?${query}` : ''}`;
@@ -32,20 +44,38 @@ async function fetchAidPackages(filters?: AidPackageFilters): Promise<AidPackage
       search: filters?.search ?? '',
       status: filters?.status ?? '',
       token: filters?.token ?? '',
+      page: pagination?.page,
+      size: pagination?.size,
     });
   }
 
-  return json;
+  // Handle both paginated and legacy (array) responses
+  if (Array.isArray(json)) {
+    // Legacy non-paginated response from old backend
+    return {
+      data: json,
+      total: json.length,
+      page: pagination?.page ?? 1,
+      size: pagination?.size ?? json.length,
+      totalPages: 1,
+    };
+  }
+
+  return json as PaginatedResponse<AidPackage>;
 }
 
-export function useAidPackages(filters?: AidPackageFilters) {
+export function useAidPackages(filters?: AidPackageFilters, pagination?: PaginationParams) {
   const search = filters?.search ?? '';
   const status = filters?.status ?? '';
   const token = filters?.token ?? '';
+  const page = pagination?.page ?? 1;
+  const size = pagination?.size ?? 10;
+  const sortBy = pagination?.sortBy ?? '';
+  const sortDirection = pagination?.sortDirection ?? '';
 
   return useQuery({
-    queryKey: ['aid-packages', search, status, token],
-    queryFn: () => fetchAidPackages(filters),
+    queryKey: ['aid-packages', search, status, token, page, size, sortBy, sortDirection],
+    queryFn: () => fetchAidPackages({ filters, pagination }),
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 }

--- a/app/frontend/src/lib/mock-api/handlers.ts
+++ b/app/frontend/src/lib/mock-api/handlers.ts
@@ -331,6 +331,10 @@ const aidPackagesHandler: MockHandler = async (url) => {
   const search = urlObj.searchParams.get('search') ?? '';
   const status = urlObj.searchParams.get('status') ?? '';
   const token = urlObj.searchParams.get('token') ?? '';
+  const page = Math.max(1, parseInt(urlObj.searchParams.get('page') ?? '1', 10) || 1);
+  const size = Math.min(100, Math.max(1, parseInt(urlObj.searchParams.get('size') ?? '10', 10) || 10));
+  const sortBy = urlObj.searchParams.get('sortBy') ?? 'id';
+  const sortDirection = urlObj.searchParams.get('sortDirection') ?? 'asc';
 
   let results = [...ALL_PACKAGES];
 
@@ -352,7 +356,28 @@ const aidPackagesHandler: MockHandler = async (url) => {
     results = results.filter(p => p.token === token);
   }
 
-  return new Response(JSON.stringify(results), {
+  // Sort
+  if (sortBy && sortBy in results[0]) {
+    results.sort((a, b) => {
+      const aVal = a[sortBy as keyof AidPackage] ?? '';
+      const bVal = b[sortBy as keyof AidPackage] ?? '';
+      const cmp = String(aVal).localeCompare(String(bVal));
+      return sortDirection === 'desc' ? -cmp : cmp;
+    });
+  }
+
+  const total = results.length;
+  const totalPages = Math.ceil(total / size);
+  const startIdx = (page - 1) * size;
+  const paginatedResults = results.slice(startIdx, startIdx + size);
+
+  return new Response(JSON.stringify({
+    data: paginatedResults,
+    total,
+    page,
+    size,
+    totalPages,
+  }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/app/frontend/src/types/aid-package.ts
+++ b/app/frontend/src/types/aid-package.ts
@@ -18,6 +18,21 @@ export interface AidPackageFilters {
   token?: TokenType | '';
 }
 
+export interface PaginationParams {
+  page?: number;
+  size?: number;
+  sortBy?: string;
+  sortDirection?: 'asc' | 'desc';
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
 /** A named, saved filter combination for a specific admin list view */
 export interface FilterPreset {
   /** Unique ID (timestamp-based) */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       expo-battery:
         specifier: ~7.0.0
         version: 7.0.0(expo@54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3))
+      expo-build-properties:
+        specifier: ^57.0.15
+        version: 57.0.15(expo@54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3))
       expo-camera:
         specifier: ^55.0.16
         version: 55.0.21(@types/emscripten@1.41.5)(expo@54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)
@@ -509,6 +512,9 @@ importers:
       react-native-screens:
         specifier: ~4.16.0
         version: 4.16.0(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)
+      react-native-ssl-public-key-pinning:
+        specifier: ^1.2.6
+        version: 1.2.6(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)
       react-native-web:
         specifier: ^0.21.2
         version: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1280,6 +1286,9 @@ packages:
 
   '@expo/schema-utils@0.1.9':
     resolution: {integrity: sha512-t9bYwG4Z0yCVzHYJoDMci1OFq2FkBkhStlfUGSkspKYTwB/84+x6sY+CXCgdhkQNQtvWaugW5KUs9YZfAXq9Sg==}
+
+  '@expo/schema-utils@57.0.2':
+    resolution: {integrity: sha512-fMu/jyN0l1Wzv7XkeWR4IYCx1M8ryui3FdBNGrWwbRgJ7EhxXxK8E2jxP2W3pbgUwUY0V3hG8+GyfCZwny+Lxw==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
@@ -5330,6 +5339,11 @@ packages:
     peerDependencies:
       expo: '*'
 
+  expo-build-properties@57.0.15:
+    resolution: {integrity: sha512-qZe9pnxlBpHT7SSNDR2a3C+P34xv67Ep9I0Erh+3xCczGlokyRd4pu9h0PrBdsVlr1d0QREQ1Do/+IgrIWkQQA==}
+    peerDependencies:
+      expo: '*'
+
   expo-camera@55.0.21:
     resolution: {integrity: sha512-mHQchiIoRMdhNr3V8VPecdsocbnDiuY2TEtKxR0eL9CkVyQkxoS1jaDrhJMEPIOeyA6K52YkeTBMVsHkHJvR7A==}
     peerDependencies:
@@ -7740,6 +7754,12 @@ packages:
 
   react-native-screens@4.16.0:
     resolution: {integrity: sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-ssl-public-key-pinning@1.2.6:
+    resolution: {integrity: sha512-WrWCRgXSet/lw8VVgrnTM5RXI+YWmSxE4+PmWcxFOUq7Kea+arkYASvDD1Dajw6yFGEw4GYuvIRdp6s7KxO60Q==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -10274,6 +10294,8 @@ snapshots:
       - supports-color
 
   '@expo/schema-utils@0.1.9': {}
+
+  '@expo/schema-utils@57.0.2': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
 
@@ -14941,6 +14963,13 @@ snapshots:
     dependencies:
       expo: 54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3)
 
+  expo-build-properties@57.0.15(expo@54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3)):
+    dependencies:
+      '@expo/schema-utils': 57.0.2
+      expo: 54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3)
+      resolve-from: 5.0.0
+      semver: 7.8.5
+
   expo-camera@55.0.21(@types/emscripten@1.41.5)(expo@54.0.36(@babel/core@7.29.7(supports-color@8.1.1))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)(supports-color@8.1.1)(typescript@5.9.3))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0):
     dependencies:
       barcode-detector: 3.2.1(@types/emscripten@1.41.5)
@@ -18043,6 +18072,11 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-ssl-public-key-pinning@1.2.6(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1)
 
   react-native-url-polyfill@2.0.0(react-native@0.81.5(@babel/core@7.29.7(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.0)(supports-color@8.1.1)):
     dependencies:


### PR DESCRIPTION
Closes #921

---

Add paginated GET /aid/packages endpoint accepting page, size, sortBy, sortDirection, search, status, and token query parameters. Frontend now sends these params in the URL, reads total/totalPages from the server response instead of array.length, and renders the Pagination component below the table. Filter changes reset to page 1. React Query cache keys include all pagination params to prevent stale out-of-order r