### PR TITLE
feat(mobile): bounded local caches with eviction preserving unsynced …

### DIFF
--- a/app/mobile/src/__tests__/SettingsScreen.test.tsx
+++ b/app/mobile/src/__tests__/SettingsScreen.test.tsx
@@ -4,6 +4,13 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { SettingsScreen } from '../screens/SettingsScreen';
 import { config } from '../config';
 
+let mockWalletState = {
+  disconnectWallet: jest.fn(),
+  publicKey: null as string | null,
+  isOnCorrectNetwork: false,
+  status: 'idle',
+};
+
 jest.mock('../theme/ThemeContext', () => ({
   useTheme: () => {
     const { Colors, SoterLightTheme } = require('../theme/theme');
@@ -38,6 +45,41 @@ jest.mock('../contexts/SaverModeContext', () => ({
     autoDetectEnabled: true,
     toggleManual: jest.fn(),
     toggleAutoDetect: jest.fn(),
+  }),
+}));
+
+jest.mock('../contexts/CrashReportingContext', () => ({
+  useCrashReporting: () => ({
+    enabled: true,
+    toggle: jest.fn(),
+  }),
+}));
+
+jest.mock('../contexts/WalletContext', () => ({
+  useWallet: () => mockWalletState,
+}));
+
+jest.mock('../services/aidCache', () => ({
+  clearAidCache: jest.fn().mockResolvedValue({ items: [] }),
+  getAidCacheSummary: jest.fn().mockResolvedValue({
+    sizeBytes: 1024,
+    maxBytes: 4096,
+    itemCount: 2,
+    isNearLimit: false,
+    isOverLimit: false,
+    warningRatio: 0.8,
+  }),
+}));
+
+jest.mock('../services/taskCache', () => ({
+  clearTaskCache: jest.fn().mockResolvedValue({ items: [] }),
+  getTaskCacheSummary: jest.fn().mockResolvedValue({
+    sizeBytes: 512,
+    maxBytes: 2048,
+    itemCount: 1,
+    isNearLimit: false,
+    isOverLimit: false,
+    warningRatio: 0.8,
   }),
 }));
 
@@ -82,6 +124,15 @@ describe('SettingsScreen', () => {
 
     expect(queryByText('Get Testnet XLM')).toBeNull();
     expect(queryByText('Stellar Lab faucet')).toBeNull();
+  });
+
+  it('shows offline cache usage and clear action', async () => {
+    const { findByText, getByText } = render(<SettingsScreen />);
+
+    expect(await findByText('Offline Storage')).toBeTruthy();
+    expect(getByText('Aid cache')).toBeTruthy();
+    expect(getByText('Task cache')).toBeTruthy();
+    expect(getByText('Clear synced cache')).toBeTruthy();
   });
 
   describe('when wallet is connected on testnet', () => {

--- a/app/mobile/src/__tests__/localCache.test.ts
+++ b/app/mobile/src/__tests__/localCache.test.ts
@@ -1,0 +1,110 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { AidPackage } from '../services/api';
+import type { TaskItem } from '../services/taskApi';
+import { cacheAidList, clearAidCache, loadCachedAidList } from '../services/aidCache';
+import { cacheTaskList, loadCachedTaskList } from '../services/taskCache';
+import { AID_CACHE_KEY, getSerializedSizeBytes } from '../services/localCache';
+import type { QueuedSyncAction } from '../services/syncQueue';
+
+const QUEUE_KEY = '@soter/sync-queue';
+
+const makeAid = (id: string, date: string, padding = 'x'.repeat(80)): AidPackage => ({
+  id,
+  title: `Aid ${id} ${padding}`,
+  amount: 10,
+  status: 'active',
+  date,
+});
+
+const makeTask = (id: string, assignedPackageId: string, dueDate: string): TaskItem => ({
+  id,
+  title: `Task ${id} ${'x'.repeat(80)}`,
+  assignedPackageId,
+  dueDate,
+  dueState: 'upcoming',
+  status: 'pending',
+});
+
+const queuedActionForAid = (aidId: string): QueuedSyncAction => ({
+  id: `queue-${aidId}`,
+  type: 'evidence-upload',
+  payload: { aidId, url: 'https://example.test/upload', body: '{}' },
+  state: 'pending',
+  retryCount: 0,
+  maxRetries: 5,
+  nextRetryAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  lastError: null,
+});
+
+describe('bounded local caches', () => {
+  beforeEach(async () => {
+    await (AsyncStorage as typeof AsyncStorage & { clear: () => Promise<void> }).clear();
+  });
+
+  it('evicts the oldest aid records first until the cache fits', async () => {
+    const aid = [
+      makeAid('oldest', '2026-01-01T00:00:00.000Z'),
+      makeAid('middle', '2026-02-01T00:00:00.000Z'),
+      makeAid('newest', '2026-03-01T00:00:00.000Z'),
+    ];
+    const maxBytes = getSerializedSizeBytes([aid[1], aid[2]]) + 2;
+
+    const result = await cacheAidList(aid, maxBytes);
+    const cached = await loadCachedAidList();
+
+    expect(result.evictedCount).toBe(1);
+    expect(result.sizeBytes).toBeLessThanOrEqual(maxBytes);
+    expect(cached?.map((item) => item.id)).toEqual(['middle', 'newest']);
+  });
+
+  it('preserves aid records with unsynced local queue actions even when over limit', async () => {
+    const aid = [
+      makeAid('oldest', '2026-01-01T00:00:00.000Z'),
+      makeAid('protected', '2026-01-02T00:00:00.000Z', 'x'.repeat(220)),
+      makeAid('newest', '2026-01-03T00:00:00.000Z'),
+    ];
+    await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify([queuedActionForAid('protected')]));
+    const maxBytes = getSerializedSizeBytes([aid[1]]) - 10;
+
+    const result = await cacheAidList(aid, maxBytes);
+    const cached = await loadCachedAidList();
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.isOverLimit).toBe(true);
+    expect(cached?.map((item) => item.id)).toEqual(['protected']);
+  });
+
+  it('preserves tasks assigned to aid with unsynced local queue actions', async () => {
+    const tasks = [
+      makeTask('old-task', 'old-aid', '2026-01-01T00:00:00.000Z'),
+      makeTask('protected-task', 'protected-aid', '2026-01-02T00:00:00.000Z'),
+      makeTask('new-task', 'new-aid', '2026-01-03T00:00:00.000Z'),
+    ];
+    await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify([queuedActionForAid('protected-aid')]));
+    const maxBytes = getSerializedSizeBytes([tasks[1]]) - 10;
+
+    const result = await cacheTaskList(tasks, maxBytes);
+    const cached = await loadCachedTaskList();
+
+    expect(result.protectedCount).toBe(1);
+    expect(result.isOverLimit).toBe(true);
+    expect(cached?.map((item) => item.id)).toEqual(['protected-task']);
+  });
+
+  it('manual clear removes synced cache records but retains unsynced records', async () => {
+    const aid = [
+      makeAid('synced', '2026-01-01T00:00:00.000Z'),
+      makeAid('protected', '2026-01-02T00:00:00.000Z'),
+    ];
+    await AsyncStorage.setItem(AID_CACHE_KEY, JSON.stringify(aid));
+    await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify([queuedActionForAid('protected')]));
+
+    const result = await clearAidCache();
+    const cached = await loadCachedAidList();
+
+    expect(result.evictedCount).toBe(1);
+    expect(cached?.map((item) => item.id)).toEqual(['protected']);
+  });
+});

--- a/app/mobile/src/config/index.ts
+++ b/app/mobile/src/config/index.ts
@@ -29,6 +29,12 @@ export interface AppConfig {
   largeUploadThreshold?: number;
   /** Whether to allow sync on metered connections without user opt-in */
   allowMeteredSync?: boolean;
+  /** Maximum serialized AsyncStorage bytes for cached aid packages */
+  aidCacheMaxBytes: number;
+  /** Maximum serialized AsyncStorage bytes for cached tasks */
+  taskCacheMaxBytes: number;
+  /** Ratio of cache usage at which the app warns operators */
+  localCacheWarningRatio: number;
 }
 
 /**
@@ -82,6 +88,15 @@ const buildConfig = (): AppConfig => {
       ? parseInt(process.env.EXPO_PUBLIC_LARGE_UPLOAD_THRESHOLD, 10) 
       : 5 * 1024 * 1024, // Default: 5MB
     allowMeteredSync: process.env.EXPO_PUBLIC_ALLOW_METERED_SYNC === 'true',
+    aidCacheMaxBytes: process.env.EXPO_PUBLIC_AID_CACHE_MAX_BYTES
+      ? parseInt(process.env.EXPO_PUBLIC_AID_CACHE_MAX_BYTES, 10)
+      : 512 * 1024,
+    taskCacheMaxBytes: process.env.EXPO_PUBLIC_TASK_CACHE_MAX_BYTES
+      ? parseInt(process.env.EXPO_PUBLIC_TASK_CACHE_MAX_BYTES, 10)
+      : 256 * 1024,
+    localCacheWarningRatio: process.env.EXPO_PUBLIC_LOCAL_CACHE_WARNING_RATIO
+      ? parseFloat(process.env.EXPO_PUBLIC_LOCAL_CACHE_WARNING_RATIO)
+      : 0.8,
     isValid: errors.length === 0,
     errors,
   };

--- a/app/mobile/src/screens/SettingsScreen.tsx
+++ b/app/mobile/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -18,9 +18,42 @@ import { useNotification } from '../contexts/NotificationContext';
 import { useSaverMode } from '../contexts/SaverModeContext';
 import { useCrashReporting } from '../contexts/CrashReportingContext';
 import { config } from '../config';
+import { useWallet } from '../contexts/WalletContext';
+import { getAccountExplorerUrl } from '../explorerUtils';
+import type { CacheSummary } from '../services/localCache';
+import { clearAidCache, getAidCacheSummary } from '../services/aidCache';
+import { clearTaskCache, getTaskCacheSummary } from '../services/taskCache';
 
 const STELLAR_LAB_FAUCET_URL = 'https://lab.stellar.org/account/fund';
 const STELLAR_FRIENDBOT_URL = 'https://friendbot-testnet.stellar.org';
+
+interface CacheUsageState {
+  aid: CacheSummary;
+  task: CacheSummary;
+  totalSizeBytes: number;
+  totalMaxBytes: number;
+  isNearLimit: boolean;
+  isOverLimit: boolean;
+}
+
+const emptyCacheSummary = (maxBytes: number): CacheSummary => ({
+  sizeBytes: 0,
+  maxBytes,
+  itemCount: 0,
+  isNearLimit: false,
+  isOverLimit: false,
+  warningRatio: config.localCacheWarningRatio,
+});
+
+const formatBytes = (bytes: number) => {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+};
 
 export const SettingsScreen: React.FC = () => {
   const { colors } = useTheme();
@@ -38,6 +71,39 @@ export const SettingsScreen: React.FC = () => {
     enabled: crashReportingEnabled,
     toggle: toggleCrashReporting,
   } = useCrashReporting();
+  const { publicKey, status: walletStatus } = useWallet();
+  const isWalletConnected = walletStatus === 'connected';
+  const [copiedKey, setCopiedKey] = useState(false);
+  const [cacheUsage, setCacheUsage] = useState<CacheUsageState>({
+    aid: emptyCacheSummary(config.aidCacheMaxBytes),
+    task: emptyCacheSummary(config.taskCacheMaxBytes),
+    totalSizeBytes: 0,
+    totalMaxBytes: config.aidCacheMaxBytes + config.taskCacheMaxBytes,
+    isNearLimit: false,
+    isOverLimit: false,
+  });
+
+  const refreshCacheUsage = useCallback(async () => {
+    const [aid, task] = await Promise.all([
+      getAidCacheSummary(),
+      getTaskCacheSummary(),
+    ]);
+    const totalSizeBytes = aid.sizeBytes + task.sizeBytes;
+    const totalMaxBytes = aid.maxBytes + task.maxBytes;
+
+    setCacheUsage({
+      aid,
+      task,
+      totalSizeBytes,
+      totalMaxBytes,
+      isNearLimit: aid.isNearLimit || task.isNearLimit,
+      isOverLimit: aid.isOverLimit || task.isOverLimit,
+    });
+  }, []);
+
+  useEffect(() => {
+    void refreshCacheUsage();
+  }, [refreshCacheUsage]);
 
   const handleNotificationToggle = async (value: boolean) => {
     if (value) {
@@ -99,6 +165,25 @@ export const SettingsScreen: React.FC = () => {
         'Unable to Open Link',
         'Could not open the Stellar Expert explorer.',
       );
+    }
+  };
+
+  const clearLocalCaches = async () => {
+    try {
+      const [aidResult, taskResult] = await Promise.all([
+        clearAidCache(),
+        clearTaskCache(),
+      ]);
+      await refreshCacheUsage();
+      const retainedCount = aidResult.items.length + taskResult.items.length;
+      Alert.alert(
+        'Offline Cache Cleared',
+        retainedCount > 0
+          ? `${retainedCount} unsynced item${retainedCount === 1 ? '' : 's'} retained for safety.`
+          : 'Cached aid and task data was cleared.',
+      );
+    } catch {
+      Alert.alert('Unable to Clear Cache', 'Please try again from Settings.');
     }
   };
 
@@ -306,6 +391,62 @@ export const SettingsScreen: React.FC = () => {
           />
         </View>
 
+        <Text
+          style={styles.sectionHeader}
+          accessibilityRole="header"
+        >
+          Offline Storage
+        </Text>
+
+        <View style={styles.cachePanel}>
+          {(cacheUsage.isNearLimit || cacheUsage.isOverLimit) && (
+            <Text style={styles.cacheWarning} accessibilityRole="alert">
+              Offline cache is nearing its storage limit. Clear synced cache
+              data to keep room for evidence capture.
+            </Text>
+          )}
+
+          <View style={styles.cacheMetricRow}>
+            <Text style={styles.cacheMetricLabel}>Aid cache</Text>
+            <Text style={styles.cacheMetricValue}>
+              {formatBytes(cacheUsage.aid.sizeBytes)} / {formatBytes(cacheUsage.aid.maxBytes)}
+            </Text>
+          </View>
+          <Text style={styles.cacheMetricHint}>
+            {cacheUsage.aid.itemCount} package{cacheUsage.aid.itemCount === 1 ? '' : 's'} cached
+          </Text>
+
+          <View style={styles.cacheMetricRow}>
+            <Text style={styles.cacheMetricLabel}>Task cache</Text>
+            <Text style={styles.cacheMetricValue}>
+              {formatBytes(cacheUsage.task.sizeBytes)} / {formatBytes(cacheUsage.task.maxBytes)}
+            </Text>
+          </View>
+          <Text style={styles.cacheMetricHint}>
+            {cacheUsage.task.itemCount} task{cacheUsage.task.itemCount === 1 ? '' : 's'} cached
+          </Text>
+
+          <View style={styles.cacheMetricRow}>
+            <Text style={styles.cacheMetricLabel}>Total</Text>
+            <Text style={styles.cacheMetricValue}>
+              {formatBytes(cacheUsage.totalSizeBytes)} / {formatBytes(cacheUsage.totalMaxBytes)}
+            </Text>
+          </View>
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.secondaryLinkButton,
+              pressed && styles.linkButtonPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Clear synced offline cache"
+            accessibilityHint="Removes cached aid and task data while keeping unsynced local changes"
+            onPress={() => void clearLocalCaches()}
+          >
+            <Text style={styles.secondaryLinkButtonText}>Clear synced cache</Text>
+          </Pressable>
+        </View>
+
         {config.network === 'testnet' && (
           <>
             <Text
@@ -478,6 +619,44 @@ const makeStyles = (colors: AppColors) =>
       borderWidth: 1,
       borderColor: colors.border,
       gap: 14,
+    },
+    cachePanel: {
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: colors.border,
+      gap: 10,
+    },
+    cacheWarning: {
+      backgroundColor: colors.warningBg,
+      borderRadius: 8,
+      color: colors.warning,
+      fontSize: 13,
+      fontWeight: '600',
+      lineHeight: 18,
+      padding: 10,
+    },
+    cacheMetricRow: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      gap: 12,
+    },
+    cacheMetricLabel: {
+      color: colors.textPrimary,
+      fontSize: 14,
+      fontWeight: '600',
+    },
+    cacheMetricValue: {
+      color: colors.textPrimary,
+      fontSize: 14,
+      fontWeight: '700',
+    },
+    cacheMetricHint: {
+      color: colors.textSecondary,
+      fontSize: 12,
+      marginTop: -6,
     },
     faucetCopy: {
       fontSize: 14,

--- a/app/mobile/src/services/aidCache.ts
+++ b/app/mobile/src/services/aidCache.ts
@@ -1,30 +1,47 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { AidPackage } from './api';
+import type { AidPackage } from './api';
+import { config } from '../config';
+import {
+  AID_CACHE_KEY,
+  AID_CACHE_TIMESTAMP_KEY,
+  clearBoundedCache,
+  getCacheSummary,
+  loadCachedItems,
+  persistBoundedCache,
+} from './localCache';
+import type { CacheWriteResult } from './localCache';
 
-const CACHE_KEY = '@soter/aid_overview';
-const CACHE_TIMESTAMP_KEY = '@soter/aid_overview_timestamp';
+const aidCacheOptions = {
+  cacheKey: AID_CACHE_KEY,
+  timestampKey: AID_CACHE_TIMESTAMP_KEY,
+  maxBytes: config.aidCacheMaxBytes,
+  warningRatio: config.localCacheWarningRatio,
+  getIdentity: (item: AidPackage) => ({ id: item.id }),
+  getEvictionTimestamp: (item: AidPackage) => {
+    const timestamp = new Date(item.date).getTime();
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  },
+};
 
 /** Persist aid list to AsyncStorage */
-export const cacheAidList = async (data: AidPackage[]): Promise<void> => {
-  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
-  await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
-};
+export const cacheAidList = async (
+  data: AidPackage[],
+  maxBytes = config.aidCacheMaxBytes,
+): Promise<CacheWriteResult<AidPackage>> =>
+  persistBoundedCache(data, { ...aidCacheOptions, maxBytes });
 
 /** Load cached aid list from AsyncStorage */
-export const loadCachedAidList = async (): Promise<AidPackage[] | null> => {
-  const raw = await AsyncStorage.getItem(CACHE_KEY);
-  if (!raw) return null;
-  return JSON.parse(raw) as AidPackage[];
-};
+export const loadCachedAidList = async (): Promise<AidPackage[] | null> =>
+  loadCachedItems<AidPackage>(AID_CACHE_KEY);
 
 /** Returns the ISO timestamp of the last successful cache write, or null */
 export const getCacheTimestamp = async (): Promise<string | null> => {
-  const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
+  const ts = await AsyncStorage.getItem(AID_CACHE_TIMESTAMP_KEY);
   if (!ts) return null;
   return new Date(parseInt(ts, 10)).toLocaleString();
 };
 
-/** Clear the cached aid list */
-export const clearAidCache = async (): Promise<void> => {
-  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
-};
+/** Clear synced cached aid records while preserving unsynced local changes. */
+export const clearAidCache = async () => clearBoundedCache<AidPackage>(aidCacheOptions);
+
+export const getAidCacheSummary = async () => getCacheSummary<AidPackage>(aidCacheOptions);

--- a/app/mobile/src/services/localCache.ts
+++ b/app/mobile/src/services/localCache.ts
@@ -1,0 +1,241 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { config } from '../config';
+import type { QueuedSyncAction } from './syncQueue';
+
+export interface CacheEntryIdentity {
+  id: string;
+  relatedAidId?: string;
+}
+
+export interface CacheBoundsOptions<TItem> {
+  cacheKey: string;
+  timestampKey: string;
+  maxBytes: number;
+  warningRatio?: number;
+  getIdentity: (item: TItem) => CacheEntryIdentity;
+  getEvictionTimestamp: (item: TItem) => number;
+}
+
+export interface CacheWriteResult<TItem> {
+  items: TItem[];
+  sizeBytes: number;
+  maxBytes: number;
+  evictedCount: number;
+  protectedCount: number;
+  isOverLimit: boolean;
+  isNearLimit: boolean;
+}
+
+export interface CacheSummary {
+  sizeBytes: number;
+  maxBytes: number;
+  itemCount: number;
+  isOverLimit: boolean;
+  isNearLimit: boolean;
+  warningRatio: number;
+}
+
+export interface LocalCacheSummary {
+  aid: CacheSummary;
+  task: CacheSummary;
+  totalSizeBytes: number;
+  totalMaxBytes: number;
+  isNearLimit: boolean;
+  isOverLimit: boolean;
+}
+
+const DEFAULT_WARNING_RATIO = 0.8;
+const SYNC_QUEUE_STORAGE_KEY = '@soter/sync-queue';
+
+export const AID_CACHE_KEY = '@soter/aid_overview';
+export const AID_CACHE_TIMESTAMP_KEY = '@soter/aid_overview_timestamp';
+export const TASK_CACHE_KEY = '@soter/task_list';
+export const TASK_CACHE_TIMESTAMP_KEY = '@soter/task_list_timestamp';
+
+const getWarningRatio = (warningRatio?: number) => {
+  const ratio = warningRatio ?? config.localCacheWarningRatio ?? DEFAULT_WARNING_RATIO;
+  if (!Number.isFinite(ratio) || ratio <= 0 || ratio > 1) {
+    return DEFAULT_WARNING_RATIO;
+  }
+  return ratio;
+};
+
+export const getSerializedSizeBytes = (value: unknown): number => {
+  const serialized = JSON.stringify(value);
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(serialized).length;
+  }
+  return serialized.length;
+};
+
+const getActionAidId = (action: QueuedSyncAction): string | null => {
+  const payload = action.payload as { aidId?: unknown };
+  return typeof payload.aidId === 'string' ? payload.aidId : null;
+};
+
+const isUnsyncedAction = (action: QueuedSyncAction) =>
+  action.state !== 'submitted';
+
+export const getUnsyncedAidIds = async (): Promise<Set<string>> => {
+  const raw = await AsyncStorage.getItem(SYNC_QUEUE_STORAGE_KEY);
+  const items = raw ? (JSON.parse(raw) as QueuedSyncAction[]) : [];
+  return new Set(
+    items
+      .filter(isUnsyncedAction)
+      .map(getActionAidId)
+      .filter((aidId): aidId is string => Boolean(aidId)),
+  );
+};
+
+const hasLocalChangeFlag = (item: unknown): boolean => {
+  if (!item || typeof item !== 'object') {
+    return false;
+  }
+
+  const record = item as Record<string, unknown>;
+  return (
+    record.hasLocalChanges === true ||
+    record.localOnly === true ||
+    record.dirty === true ||
+    record.isDirty === true ||
+    record.isSynced === false ||
+    record.synced === false ||
+    record.syncStatus === 'pending' ||
+    record.syncStatus === 'retrying' ||
+    record.syncStatus === 'failed' ||
+    record.syncStatus === 'conflict'
+  );
+};
+
+const getProtectedIds = async <TItem>(
+  items: TItem[],
+  getIdentity: (item: TItem) => CacheEntryIdentity,
+): Promise<Set<string>> => {
+  const unsyncedAidIds = await getUnsyncedAidIds();
+  const protectedIds = new Set<string>();
+
+  items.forEach((item) => {
+    const identity = getIdentity(item);
+    if (
+      hasLocalChangeFlag(item) ||
+      unsyncedAidIds.has(identity.id) ||
+      (identity.relatedAidId && unsyncedAidIds.has(identity.relatedAidId))
+    ) {
+      protectedIds.add(identity.id);
+    }
+  });
+
+  return protectedIds;
+};
+
+const buildWriteResult = <TItem>(
+  items: TItem[],
+  maxBytes: number,
+  warningRatio: number,
+  evictedCount: number,
+  protectedCount: number,
+): CacheWriteResult<TItem> => {
+  const sizeBytes = getSerializedSizeBytes(items);
+  return {
+    items,
+    sizeBytes,
+    maxBytes,
+    evictedCount,
+    protectedCount,
+    isOverLimit: sizeBytes > maxBytes,
+    isNearLimit: sizeBytes >= maxBytes * warningRatio,
+  };
+};
+
+/**
+ * Eviction policy: preserve unsynced local changes first, then evict the oldest
+ * server-synced records until the serialized cache fits the configured limit.
+ * If protected records alone exceed the limit, they are kept and reported over-limit.
+ */
+export const boundCacheItems = async <TItem>(
+  items: TItem[],
+  options: Pick<CacheBoundsOptions<TItem>, 'maxBytes' | 'warningRatio' | 'getIdentity' | 'getEvictionTimestamp'>,
+): Promise<CacheWriteResult<TItem>> => {
+  const warningRatio = getWarningRatio(options.warningRatio);
+  const protectedIds = await getProtectedIds(items, options.getIdentity);
+  let boundedItems = [...items];
+  let evictedCount = 0;
+
+  const evictable = items
+    .filter((item) => !protectedIds.has(options.getIdentity(item).id))
+    .map((item, index) => ({ item, index, timestamp: options.getEvictionTimestamp(item) }))
+    .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index);
+
+  for (const candidate of evictable) {
+    if (getSerializedSizeBytes(boundedItems) <= options.maxBytes) {
+      break;
+    }
+    const candidateId = options.getIdentity(candidate.item).id;
+    boundedItems = boundedItems.filter((item) => options.getIdentity(item).id !== candidateId);
+    evictedCount += 1;
+  }
+
+  return buildWriteResult(
+    boundedItems,
+    options.maxBytes,
+    warningRatio,
+    evictedCount,
+    protectedIds.size,
+  );
+};
+
+export const persistBoundedCache = async <TItem>(
+  items: TItem[],
+  options: CacheBoundsOptions<TItem>,
+): Promise<CacheWriteResult<TItem>> => {
+  const result = await boundCacheItems(items, options);
+  await AsyncStorage.setItem(options.cacheKey, JSON.stringify(result.items));
+  await AsyncStorage.setItem(options.timestampKey, Date.now().toString());
+  return result;
+};
+
+export const loadCachedItems = async <TItem>(cacheKey: string): Promise<TItem[] | null> => {
+  const raw = await AsyncStorage.getItem(cacheKey);
+  if (!raw) return null;
+  return JSON.parse(raw) as TItem[];
+};
+
+export const clearBoundedCache = async <TItem>(
+  options: CacheBoundsOptions<TItem>,
+): Promise<CacheWriteResult<TItem>> => {
+  const current = (await loadCachedItems<TItem>(options.cacheKey)) ?? [];
+  const protectedIds = await getProtectedIds(current, options.getIdentity);
+  const retained = current.filter((item) => protectedIds.has(options.getIdentity(item).id));
+
+  if (retained.length === 0) {
+    await AsyncStorage.multiRemove([options.cacheKey, options.timestampKey]);
+  } else {
+    await AsyncStorage.setItem(options.cacheKey, JSON.stringify(retained));
+    await AsyncStorage.setItem(options.timestampKey, Date.now().toString());
+  }
+
+  return buildWriteResult(
+    retained,
+    options.maxBytes,
+    getWarningRatio(options.warningRatio),
+    current.length - retained.length,
+    protectedIds.size,
+  );
+};
+
+export const getCacheSummary = async <TItem>(
+  options: CacheBoundsOptions<TItem>,
+): Promise<CacheSummary> => {
+  const items = (await loadCachedItems<TItem>(options.cacheKey)) ?? [];
+  const sizeBytes = getSerializedSizeBytes(items);
+  const warningRatio = getWarningRatio(options.warningRatio);
+
+  return {
+    sizeBytes,
+    maxBytes: options.maxBytes,
+    itemCount: items.length,
+    isOverLimit: sizeBytes > options.maxBytes,
+    isNearLimit: sizeBytes >= options.maxBytes * warningRatio,
+    warningRatio,
+  };
+};

--- a/app/mobile/src/services/taskCache.ts
+++ b/app/mobile/src/services/taskCache.ts
@@ -1,30 +1,47 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { TaskItem } from './taskApi';
+import type { TaskItem } from './taskApi';
+import { config } from '../config';
+import {
+  TASK_CACHE_KEY,
+  TASK_CACHE_TIMESTAMP_KEY,
+  clearBoundedCache,
+  getCacheSummary,
+  loadCachedItems,
+  persistBoundedCache,
+} from './localCache';
+import type { CacheWriteResult } from './localCache';
 
-const CACHE_KEY = '@soter/task_list';
-const CACHE_TIMESTAMP_KEY = '@soter/task_list_timestamp';
+const taskCacheOptions = {
+  cacheKey: TASK_CACHE_KEY,
+  timestampKey: TASK_CACHE_TIMESTAMP_KEY,
+  maxBytes: config.taskCacheMaxBytes,
+  warningRatio: config.localCacheWarningRatio,
+  getIdentity: (item: TaskItem) => ({ id: item.id, relatedAidId: item.assignedPackageId }),
+  getEvictionTimestamp: (item: TaskItem) => {
+    const timestamp = new Date(item.dueDate).getTime();
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  },
+};
 
 /** Persist task list to AsyncStorage */
-export const cacheTaskList = async (data: TaskItem[]): Promise<void> => {
-  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
-  await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
-};
+export const cacheTaskList = async (
+  data: TaskItem[],
+  maxBytes = config.taskCacheMaxBytes,
+): Promise<CacheWriteResult<TaskItem>> =>
+  persistBoundedCache(data, { ...taskCacheOptions, maxBytes });
 
 /** Load cached task list from AsyncStorage */
-export const loadCachedTaskList = async (): Promise<TaskItem[] | null> => {
-  const raw = await AsyncStorage.getItem(CACHE_KEY);
-  if (!raw) return null;
-  return JSON.parse(raw) as TaskItem[];
-};
+export const loadCachedTaskList = async (): Promise<TaskItem[] | null> =>
+  loadCachedItems<TaskItem>(TASK_CACHE_KEY);
 
 /** Returns the ISO timestamp of the last successful cache write, or null */
 export const getTaskCacheTimestamp = async (): Promise<string | null> => {
-  const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
+  const ts = await AsyncStorage.getItem(TASK_CACHE_TIMESTAMP_KEY);
   if (!ts) return null;
   return new Date(parseInt(ts, 10)).toLocaleString();
 };
 
-/** Clear the cached task list */
-export const clearTaskCache = async (): Promise<void> => {
-  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
-};
+/** Clear synced cached tasks while preserving unsynced local changes. */
+export const clearTaskCache = async () => clearBoundedCache<TaskItem>(taskCacheOptions);
+
+export const getTaskCacheSummary = async () => getCacheSummary<TaskItem>(taskCacheOptions);


### PR DESCRIPTION
Fixes issue #928 by bounding the mobile offline cache for aid and task data and evicting stale entries before the cache grows without limit.

Previously, the app stored cached aid and task records for offline use without enforcing a size ceiling or removal policy. Over long field deployments, that could cause storage exhaustion and eventually interfere with evidence capture. This patch enforces a configurable maximum size per cache and applies a documented eviction strategy that preserves user-local unsynced changes.

What changed

Added a shared bounded-cache mechanism for mobile local storage
Enforced maximum byte limits for both aid and task caches
Evicted oldest synced records first while keeping protected local records intact
Preserved items associated with unsynced local actions from the sync queue
Exposed current cache size and limits in Settings
Added a manual clear action for synced cache entries
Added warnings when usage is approaching the configured limit
Added regression tests for eviction ordering and protection of unsynced data

Eviction policy
The cache follows a safety-first policy:

Protect any item with local unsynced state or related unsynced queue activity.
Remove only server-synced, evictable records.
Evict the oldest records first, using the record timestamp as the ordering key.
Stop once the serialized payload fits within the configured maximum.
If protected records alone exceed the limit, keep them and report the cache as over limit rather than deleting local unsynced work.
This ensures storage remains bounded without sacrificing user data that has not been synced yet.

Settings and UX updates
Current cache usage is visible per cache and in total
Settings now renders size and limits in human-readable units
Users can manually clear synced cache data while preserving unsynced local changes
Near-limit usage surfaces a warning to prompt cache cleanup before storage pressure affects evidence capture
Acceptance criteria
 Each cache enforces a configurable maximum size
 Eviction follows a documented policy and never discards unsynced local changes
 Current cache size is visible in Settings with a manual clear action
 Approaching the storage limit surfaces a warning
 Tests cover eviction ordering and preservation of unsynced data
Testing
Verified the bounded local cache test suite passes:
local cache regression tests for oldest-first eviction
preservation of unsynced records
manual clear behavior