### PR TITLE
fix(mobile): retire mock data fallbacks from field screens (#923)

### DIFF
--- a/app/mobile/src/__tests__/AidDetailsScreen.test.tsx
+++ b/app/mobile/src/__tests__/AidDetailsScreen.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react-native';
+import { AidDetailsScreen } from '../screens/AidDetailsScreen';
+import { fetchAidDetails, AidDetails } from '../services/aidApi';
+import {
+  cacheAidDetails,
+  loadCachedAidDetails,
+  getAidDetailsCacheTimestamp,
+} from '../services/aidCache';
+import { ThemeProvider } from '../theme/ThemeContext';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+// Mock dependencies
+jest.mock('../services/aidApi');
+jest.mock('../services/aidCache');
+
+jest.mock('../contexts/BiometricContext', () => ({
+  useBiometric: () => ({
+    biometricEnabled: false,
+    authenticate: jest.fn().mockResolvedValue(true),
+    confirmValueAction: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
+jest.mock('../contexts/SaverModeContext', () => ({
+  useSaverMode: () => ({
+    active: false,
+    source: null,
+  }),
+}));
+
+jest.mock('../contexts/SyncContext', () => ({
+  useSync: () => ({
+    getActionsForAid: jest.fn().mockReturnValue([]),
+    isConnected: true,
+    isSyncing: false,
+    lastCompletedAction: null,
+    queueClaimConfirmation: jest.fn(),
+    queueStatusRefresh: jest.fn(),
+  }),
+}));
+
+const mockFetchAidDetails = fetchAidDetails as jest.MockedFunction<typeof fetchAidDetails>;
+const mockCacheAidDetails = cacheAidDetails as jest.MockedFunction<typeof cacheAidDetails>;
+const mockLoadCachedAidDetails = loadCachedAidDetails as jest.MockedFunction<typeof loadCachedAidDetails>;
+const mockGetAidDetailsCacheTimestamp = getAidDetailsCacheTimestamp as jest.MockedFunction<typeof getAidDetailsCacheTimestamp>;
+
+const sampleAidDetails: AidDetails = {
+  id: 'aid-101',
+  title: 'Clean Water Initiative',
+  description: 'Water filtration kits for families.',
+  recipient: {
+    name: 'Fatima Zahra',
+    id: 'REC-9081',
+    wallet: 'GBXY...9911',
+  },
+  tokenType: 'USDC',
+  amount: '300',
+  expiryDate: '2026-12-31T00:00:00Z',
+  status: 'verified',
+  claimId: 'claim-aid-101',
+  createdAt: '2026-08-01T00:00:00Z',
+  verifiedAt: '2026-08-02T00:00:00Z',
+  approvalTransactionHash: 'c'.repeat(64),
+};
+
+const Stack = createNativeStackNavigator();
+
+const renderScreen = (aidId = 'aid-101') => {
+  return render(
+    <ThemeProvider>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="AidDetails"
+            component={AidDetailsScreen}
+            initialParams={{ aidId }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ThemeProvider>,
+  );
+};
+
+describe('AidDetailsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadCachedAidDetails.mockResolvedValue(null);
+    mockGetAidDetailsCacheTimestamp.mockResolvedValue(null);
+  });
+
+  it('renders fresh aid details and writes to cache when backend is reachable', async () => {
+    mockFetchAidDetails.mockResolvedValueOnce(sampleAidDetails);
+
+    renderScreen('aid-101');
+
+    await waitFor(() => {
+      expect(screen.getByText('Clean Water Initiative')).toBeTruthy();
+      expect(screen.getByText('Package ID: aid-101')).toBeTruthy();
+      expect(screen.getByText('Fatima Zahra', { includeHiddenElements: true })).toBeTruthy();
+      expect(screen.getByText('300 USDC', { includeHiddenElements: true })).toBeTruthy();
+      expect(mockCacheAidDetails).toHaveBeenCalledWith('aid-101', sampleAidDetails);
+    });
+  });
+
+  it('displays cached aid data with age label when backend fails and cached data exists', async () => {
+    mockFetchAidDetails.mockRejectedValueOnce(new Error('Network offline'));
+    mockLoadCachedAidDetails.mockResolvedValueOnce(sampleAidDetails);
+    mockGetAidDetailsCacheTimestamp.mockResolvedValueOnce('2026-08-28T09:00:00Z');
+
+    renderScreen('aid-101');
+
+    await waitFor(() => {
+      expect(screen.getByText('Clean Water Initiative')).toBeTruthy();
+      expect(
+        screen.getByText('Unable to reach the server. Showing last known cached data.'),
+      ).toBeTruthy();
+      expect(screen.getByText('Fatima Zahra', { includeHiddenElements: true })).toBeTruthy();
+    });
+  });
+
+  it('displays honest unavailable state when backend fails and no cache exists', async () => {
+    mockFetchAidDetails.mockRejectedValueOnce(new Error('Network offline'));
+    mockLoadCachedAidDetails.mockResolvedValueOnce(null);
+
+    renderScreen('aid-101');
+
+    await waitFor(() => {
+      expect(screen.getByText('Aid Details Unavailable')).toBeTruthy();
+      expect(
+        screen.getByText('Unable to reach the server. Aid details are unavailable offline.'),
+      ).toBeTruthy();
+      expect(screen.getByText('🔄 Retry Connection')).toBeTruthy();
+      expect(screen.getByText('Back to Aid Overview')).toBeTruthy();
+      // Ensure mock fake recipient Amina Yusuf is NOT rendered
+      expect(screen.queryByText('Amina Yusuf', { includeHiddenElements: true })).toBeNull();
+      expect(screen.queryByText('Emergency Food Supply')).toBeNull();
+    });
+  });
+
+  it('retries fetching aid details when retry button is pressed on unavailable screen', async () => {
+    mockFetchAidDetails.mockRejectedValueOnce(new Error('Network offline'));
+    mockLoadCachedAidDetails.mockResolvedValueOnce(null);
+
+    renderScreen('aid-101');
+
+    await waitFor(() => {
+      expect(screen.getByText('Aid Details Unavailable')).toBeTruthy();
+    });
+
+    mockFetchAidDetails.mockResolvedValueOnce(sampleAidDetails);
+
+    const retryButton = screen.getByText('🔄 Retry Connection');
+    fireEvent.press(retryButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Clean Water Initiative')).toBeTruthy();
+      expect(screen.getByText('Fatima Zahra', { includeHiddenElements: true })).toBeTruthy();
+    });
+  });
+});

--- a/app/mobile/src/__tests__/HealthScreen.test.tsx
+++ b/app/mobile/src/__tests__/HealthScreen.test.tsx
@@ -4,6 +4,11 @@ import { Clipboard } from 'react-native';
 import { HealthScreen } from '../screens/HealthScreen';
 import { fetchHealthStatus } from '../services/api';
 import { config } from '../config';
+import {
+  cacheHealthStatus,
+  loadCachedHealthStatus,
+  getHealthCacheTimestamp,
+} from '../services/healthCache';
 
 // Mock expo-constants
 jest.mock('expo-constants', () => ({
@@ -40,6 +45,15 @@ jest.mock('../theme/ThemeContext', () => ({
 
 // Mock the API module
 jest.mock('../services/api');
+
+// Mock healthCache
+jest.mock('../services/healthCache', () => ({
+  cacheHealthStatus: jest.fn().mockResolvedValue(undefined),
+  loadCachedHealthStatus: jest.fn().mockResolvedValue(null),
+  getHealthCacheTimestamp: jest.fn().mockResolvedValue(null),
+  clearHealthCache: jest.fn().mockResolvedValue(undefined),
+}));
+
 // Mock the config module
 jest.mock('../config', () => ({
   config: {
@@ -54,23 +68,27 @@ jest.mock('../config', () => ({
 }));
 
 const mockFetchHealthStatus = fetchHealthStatus as jest.MockedFunction<typeof fetchHealthStatus>;
-const mockConfig = config as jest.Mocked<typeof config>;
+const mockCacheHealthStatus = cacheHealthStatus as jest.MockedFunction<typeof cacheHealthStatus>;
+const mockLoadCachedHealthStatus = loadCachedHealthStatus as jest.MockedFunction<typeof loadCachedHealthStatus>;
+const mockGetHealthCacheTimestamp = getHealthCacheTimestamp as jest.MockedFunction<typeof getHealthCacheTimestamp>;
 
 describe('HealthScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLoadCachedHealthStatus.mockResolvedValue(null);
+    mockGetHealthCacheTimestamp.mockResolvedValue(null);
   });
 
   it('shows loading state initially', () => {
     mockFetchHealthStatus.mockImplementationOnce(() => new Promise(() => {}));
-    
+
     render(<HealthScreen />);
-    
+
     expect(screen.getByText('Checking system health...')).toBeTruthy();
   });
 
-  it('renders live backend data correctly', async () => {
-    const mockData = {
+  it('renders live backend data correctly and caches it', async () => {
+    const liveData = {
       status: 'ok',
       service: 'backend',
       version: '1.0.0',
@@ -78,7 +96,7 @@ describe('HealthScreen', () => {
       timestamp: new Date().toISOString(),
     };
 
-    mockFetchHealthStatus.mockResolvedValueOnce(mockData);
+    mockFetchHealthStatus.mockResolvedValueOnce(liveData);
 
     render(<HealthScreen />);
 
@@ -87,24 +105,58 @@ describe('HealthScreen', () => {
       expect(screen.getByText('🌐 Live backend data')).toBeTruthy();
       expect(screen.getByText('backend', { includeHiddenElements: true })).toBeTruthy();
       expect(screen.getByText('1.0.0', { includeHiddenElements: true })).toBeTruthy();
+      expect(mockCacheHealthStatus).toHaveBeenCalledWith(liveData);
     });
   });
 
-  it('shows mock data label when backend fails', async () => {
+  it('shows explicit unavailable state when backend fails and no cache exists', async () => {
     mockFetchHealthStatus.mockRejectedValueOnce(new Error('Network error'));
+    mockLoadCachedHealthStatus.mockResolvedValueOnce(null);
 
     render(<HealthScreen />);
 
     await waitFor(() => {
-      expect(screen.getByText('🔧 MOCK', { includeHiddenElements: true })).toBeTruthy();
-      expect(screen.getByText('📊 Using simulated data')).toBeTruthy();
-      expect(screen.getByText('Backend unreachable - showing mock data')).toBeTruthy();
-      expect(screen.getByText('⚠️ This is simulated data - backend connection failed', { includeHiddenElements: true })).toBeTruthy();
+      expect(screen.getByText('UNAVAILABLE')).toBeTruthy();
+      expect(
+        screen.getByText(
+          'Unable to connect to the backend server and no cached health data is available.',
+        ),
+      ).toBeTruthy();
+      expect(screen.getByText('⚠️ Backend unavailable')).toBeTruthy();
+      expect(screen.queryByText('🔧 MOCK')).toBeNull();
+      expect(screen.queryByText('📊 Using simulated data')).toBeNull();
+      expect(screen.getByText('🔄 Retry Connection')).toBeTruthy();
     });
   });
 
-  it('shows troubleshooting tips when using mock data', async () => {
+  it('shows cached real data with age label when backend fails but cached data exists', async () => {
+    const cachedData = {
+      status: 'ok',
+      service: 'backend-production',
+      version: '2.1.0',
+      environment: 'production',
+      timestamp: '2026-08-28T10:00:00Z',
+    };
+
     mockFetchHealthStatus.mockRejectedValueOnce(new Error('Network error'));
+    mockLoadCachedHealthStatus.mockResolvedValueOnce(cachedData);
+    mockGetHealthCacheTimestamp.mockResolvedValueOnce('2026-08-28T10:00:00Z');
+
+    render(<HealthScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('📦 CACHED', { includeHiddenElements: true })).toBeTruthy();
+      expect(screen.getByText('backend-production', { includeHiddenElements: true })).toBeTruthy();
+      expect(screen.getByText('2.1.0', { includeHiddenElements: true })).toBeTruthy();
+      expect(screen.getByText('📦 Using cached data')).toBeTruthy();
+      expect(screen.getByText('Backend unreachable - showing cached health data')).toBeTruthy();
+      expect(screen.queryByText('🔧 MOCK')).toBeNull();
+    });
+  });
+
+  it('shows troubleshooting tips when backend is unreachable', async () => {
+    mockFetchHealthStatus.mockRejectedValueOnce(new Error('Network error'));
+    mockLoadCachedHealthStatus.mockResolvedValueOnce(null);
 
     render(<HealthScreen />);
 
@@ -113,27 +165,30 @@ describe('HealthScreen', () => {
     });
   });
 
-  it('displays the correct mock data structure', async () => {
+  it('retries fetching health status when retry button is pressed', async () => {
     mockFetchHealthStatus.mockRejectedValueOnce(new Error('Network error'));
-
-    render(<HealthScreen />);
-
-    await waitFor(() => {
-      expect(screen.getByText('backend', { includeHiddenElements: true })).toBeTruthy();
-      expect(screen.getByText('0.0.0', { includeHiddenElements: true })).toBeTruthy();
-      expect(screen.getByText('development', { includeHiddenElements: true })).toBeTruthy();
-      expect(screen.getByText('✅', { includeHiddenElements: true })).toBeTruthy();
-      expect(screen.getByText('OK')).toBeTruthy();
-    });
-  });
-
-  it('shows retry button when error occurs', async () => {
-    mockFetchHealthStatus.mockRejectedValueOnce(new Error('Network error'));
+    mockLoadCachedHealthStatus.mockResolvedValueOnce(null);
 
     render(<HealthScreen />);
 
     await waitFor(() => {
       expect(screen.getByText('🔄 Retry Connection')).toBeTruthy();
+    });
+
+    const liveData = {
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
+    };
+    mockFetchHealthStatus.mockResolvedValueOnce(liveData);
+
+    const retryButton = screen.getByText('🔄 Retry Connection');
+    fireEvent.press(retryButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('🌐 Live backend data')).toBeTruthy();
     });
   });
 
@@ -141,31 +196,32 @@ describe('HealthScreen', () => {
 
   it('shows environment badge in the header', async () => {
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
 
     await waitFor(() => {
-      // The env badge element is always rendered
       expect(screen.getByTestId('env-badge')).toBeTruthy();
     });
   });
 
   it('displays environment label from config', async () => {
-    // Note: Since config is mocked as a constant above, we'd need to change the mock 
-    // implementation if we wanted to test different values in the same file, 
-    // or just verify it shows what's in our default mock.
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
 
     await waitFor(() => {
-      // Default mocked envName is 'dev'
       expect(screen.getByTestId('env-badge')).toBeTruthy();
       expect(screen.getByTestId('footer-env-name')).toBeTruthy();
     });
@@ -173,8 +229,11 @@ describe('HealthScreen', () => {
 
   it('shows blockchain diagnostics section', async () => {
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
@@ -187,14 +246,16 @@ describe('HealthScreen', () => {
   });
 
   it('shows configuration errors when config is invalid', async () => {
-    // Temporarily modify the mock for this test
     const originalConfig = { ...config };
     (config as any).isValid = false;
     (config as any).errors = ['Missing API Key'];
 
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
@@ -204,7 +265,6 @@ describe('HealthScreen', () => {
       expect(screen.getByText('• Missing API Key')).toBeTruthy();
     });
 
-    // Restore
     Object.assign(config, originalConfig);
   });
 
@@ -212,8 +272,11 @@ describe('HealthScreen', () => {
 
   it('renders safe diagnostics elements (app version, api reachability, network state)', async () => {
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
@@ -235,10 +298,13 @@ describe('HealthScreen', () => {
 
   it('copies safe diagnostics to clipboard when button is pressed', async () => {
     const clipboardSpy = jest.spyOn(Clipboard, 'setString').mockImplementation(() => {});
-    
+
     mockFetchHealthStatus.mockResolvedValueOnce({
-      status: 'ok', service: 'backend', version: '1.0.0',
-      environment: 'development', timestamp: new Date().toISOString(),
+      status: 'ok',
+      service: 'backend',
+      version: '1.0.0',
+      environment: 'development',
+      timestamp: new Date().toISOString(),
     });
 
     render(<HealthScreen />);
@@ -259,8 +325,7 @@ describe('HealthScreen', () => {
     expect(copiedText).toContain('Network Type: WIFI');
     expect(copiedText).toContain('Internet Reachable: Yes');
     expect(copiedText).toContain('Contract ID: CC123...');
-    
-    // Ensure no secrets are present
+
     expect(copiedText).not.toContain('test-project-id');
 
     await waitFor(() => {

--- a/app/mobile/src/__tests__/aidCache.test.ts
+++ b/app/mobile/src/__tests__/aidCache.test.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  cacheAidList,
+  loadCachedAidList,
+  getCacheTimestamp,
+  clearAidCache,
+  cacheAidDetails,
+  loadCachedAidDetails,
+  getAidDetailsCacheTimestamp,
+  clearAidDetailsCache,
+} from '../services/aidCache';
+import { AidPackage } from '../services/api';
+import { AidDetails } from '../services/aidApi';
+
+describe('aidCache', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  const sampleAidPackages: AidPackage[] = [
+    { id: 'aid-1', title: 'Food Aid', amount: 500, status: 'active', date: '2026-01-01' },
+  ];
+
+  const sampleAidDetails: AidDetails = {
+    id: 'aid-1',
+    title: 'Food Aid',
+    description: 'Emergency food packages',
+    recipient: {
+      name: 'Amina Yusuf',
+      id: 'REC-2041',
+      wallet: 'GAKD...Q9X2',
+    },
+    tokenType: 'USDC',
+    amount: '500',
+    expiryDate: '2026-01-10T00:00:00Z',
+    status: 'verified',
+    claimId: 'claim-aid-1',
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+
+  it('persists and loads aid list and timestamp', async () => {
+    expect(await loadCachedAidList()).toBeNull();
+    await cacheAidList(sampleAidPackages);
+    expect(await loadCachedAidList()).toEqual(sampleAidPackages);
+    expect(await getCacheTimestamp()).toBeTruthy();
+    await clearAidCache();
+    expect(await loadCachedAidList()).toBeNull();
+  });
+
+  it('persists and loads aid details and timestamp', async () => {
+    expect(await loadCachedAidDetails('aid-1')).toBeNull();
+    await cacheAidDetails('aid-1', sampleAidDetails);
+    expect(await loadCachedAidDetails('aid-1')).toEqual(sampleAidDetails);
+    const ts = await getAidDetailsCacheTimestamp('aid-1');
+    expect(ts).toBeTruthy();
+    expect(Number.isNaN(new Date(ts!).getTime())).toBe(false);
+    await clearAidDetailsCache('aid-1');
+    expect(await loadCachedAidDetails('aid-1')).toBeNull();
+  });
+});

--- a/app/mobile/src/__tests__/healthCache.test.ts
+++ b/app/mobile/src/__tests__/healthCache.test.ts
@@ -1,0 +1,45 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  cacheHealthStatus,
+  loadCachedHealthStatus,
+  getHealthCacheTimestamp,
+  clearHealthCache,
+} from '../services/healthCache';
+import { HealthStatus } from '../services/api';
+
+describe('healthCache', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  const sampleHealth: HealthStatus = {
+    status: 'ok',
+    service: 'backend-test',
+    version: '1.2.0',
+    environment: 'staging',
+    timestamp: '2026-08-28T12:00:00Z',
+  };
+
+  it('persists and loads health status', async () => {
+    expect(await loadCachedHealthStatus()).toBeNull();
+    await cacheHealthStatus(sampleHealth);
+    const loaded = await loadCachedHealthStatus();
+    expect(loaded).toEqual(sampleHealth);
+  });
+
+  it('retrieves valid timestamp after cache write', async () => {
+    expect(await getHealthCacheTimestamp()).toBeNull();
+    await cacheHealthStatus(sampleHealth);
+    const ts = await getHealthCacheTimestamp();
+    expect(ts).toBeTruthy();
+    expect(Number.isNaN(new Date(ts!).getTime())).toBe(false);
+  });
+
+  it('clears health cache', async () => {
+    await cacheHealthStatus(sampleHealth);
+    expect(await loadCachedHealthStatus()).toEqual(sampleHealth);
+    await clearHealthCache();
+    expect(await loadCachedHealthStatus()).toBeNull();
+    expect(await getHealthCacheTimestamp()).toBeNull();
+  });
+});

--- a/app/mobile/src/__tests__/mockData.test.ts
+++ b/app/mobile/src/__tests__/mockData.test.ts
@@ -1,0 +1,26 @@
+import { getMockHealthData } from '../services/mockData';
+
+describe('mockData', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('returns mock health data in non-production environments', () => {
+    process.env.NODE_ENV = 'development';
+    const data = getMockHealthData();
+    expect(data.status).toBe('ok');
+    expect(data.service).toBe('backend');
+    expect(data.version).toBe('0.0.0');
+    expect(data.environment).toBe('development');
+    expect(data.mocked).toBe(true);
+  });
+
+  it('throws an error when accessed in a production environment', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => getMockHealthData()).toThrow(
+      'mockData.ts cannot be used in production builds',
+    );
+  });
+});

--- a/app/mobile/src/__tests__/navigation.test.tsx
+++ b/app/mobile/src/__tests__/navigation.test.tsx
@@ -74,6 +74,10 @@ jest.mock('../services/aidCache', () => ({
   cacheAidList: jest.fn(),
   loadCachedAidList: jest.fn().mockResolvedValue([]),
   getCacheTimestamp: jest.fn().mockResolvedValue(null),
+  cacheAidDetails: jest.fn().mockResolvedValue(undefined),
+  loadCachedAidDetails: jest.fn().mockResolvedValue(null),
+  getAidDetailsCacheTimestamp: jest.fn().mockResolvedValue(null),
+  clearAidDetailsCache: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../hooks/useNetworkStatus', () => ({

--- a/app/mobile/src/screens/AidDetailsScreen.tsx
+++ b/app/mobile/src/screens/AidDetailsScreen.tsx
@@ -20,8 +20,12 @@ import {
   ClaimTimelineStatus,
   ClaimStatus,
   fetchAidDetails,
-  getMockAidDetails,
 } from '../services/aidApi';
+import {
+  cacheAidDetails,
+  loadCachedAidDetails,
+  getAidDetailsCacheTimestamp,
+} from '../services/aidCache';
 import { useSync } from '../contexts/SyncContext';
 import { useSaverMode } from '../contexts/SaverModeContext';
 import { SaverModeBanner } from '../components/SaverModeBanner';
@@ -90,15 +94,26 @@ export const AidDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         setDetails(data);
         setIsCached(false);
         setError(null);
-        if (isRefresh) setRefreshMessage('Data refreshed successfully.');
-      } catch {
-        setError('Unable to reach the server. Showing last known data.');
-        setIsCached(true);
-        if (isRefresh) setRefreshMessage('Refresh failed. Showing the last cached data.');
-        setDetails((current) => current ?? getMockAidDetails(aidId));
-      } finally {
+        await cacheAidDetails(aidId, data);
         const now = new Date().toISOString();
         setLastUpdated(now);
+        if (isRefresh) setRefreshMessage('Data refreshed successfully.');
+      } catch {
+        const cached = await loadCachedAidDetails(aidId);
+        if (cached) {
+          setDetails(cached);
+          setIsCached(true);
+          const ts = await getAidDetailsCacheTimestamp(aidId);
+          setLastUpdated(ts || new Date().toISOString());
+          setError('Unable to reach the server. Showing last known cached data.');
+          if (isRefresh) setRefreshMessage('Refresh failed. Showing the last cached data.');
+        } else {
+          setDetails(null);
+          setIsCached(false);
+          setError('Unable to reach the server. Aid details are unavailable offline.');
+          if (isRefresh) setRefreshMessage('Refresh failed. Server is unreachable.');
+        }
+      } finally {
         setLoading(false);
         setRefreshing(false);
       }
@@ -262,7 +277,7 @@ export const AidDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
   }
 
   // authState === 'granted'
-  if (loading || !details) {
+  if (loading) {
     return (
       <View
         style={styles.centered}
@@ -276,6 +291,43 @@ export const AidDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
           accessibilityElementsHidden
         />
         <Text style={styles.subtitle}>Loading aid details...</Text>
+      </View>
+    );
+  }
+
+  if (!details) {
+    return (
+      <View
+        style={styles.centered}
+        accessible
+        accessibilityLabel="Aid details unavailable. Unable to connect to the server and no cached details exist."
+        accessibilityRole="alert"
+      >
+        <Text style={styles.unavailableIcon} accessibilityElementsHidden>
+          ⚠️
+        </Text>
+        <Text style={styles.title}>Aid Details Unavailable</Text>
+        <Text style={styles.unavailableText}>
+          {error ?? 'Unable to retrieve package details from the server and no cached data is available on this device.'}
+        </Text>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading aid details"
+          style={[styles.button, { backgroundColor: colors.brand.primary }]}
+          onPress={() => loadDetails(false)}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.buttonText}>🔄 Retry Connection</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel="Back to aid operations"
+          style={[styles.button, styles.secondaryButton]}
+          onPress={() => navigation.goBack()}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.secondaryButtonText}>Back to Aid Overview</Text>
+        </TouchableOpacity>
       </View>
     );
   }
@@ -952,6 +1004,18 @@ const makeStyles = (colors: AppColors) =>
       backgroundColor: colors.background,
       padding: 32,
       gap: 16,
+    },
+    unavailableIcon: {
+      fontSize: 48,
+      marginBottom: 8,
+    },
+    unavailableText: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 20,
+      marginHorizontal: 16,
+      marginBottom: 8,
     },
     lockIcon: {
       fontSize: 48,

--- a/app/mobile/src/screens/HealthScreen.tsx
+++ b/app/mobile/src/screens/HealthScreen.tsx
@@ -15,10 +15,14 @@ import {
 import Constants from 'expo-constants';
 import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
 import { fetchHealthStatus, HealthStatus } from '../services/api';
-import { getMockHealthData } from '../services/mockData';
+import {
+  cacheHealthStatus,
+  loadCachedHealthStatus,
+  getHealthCacheTimestamp,
+} from '../services/healthCache';
+import { formatAge } from '../components/DataFreshnessIndicator';
 import { useTheme } from '../theme/ThemeContext';
 import { AppColors } from '../theme/useAppTheme';
-
 import { config } from '../config';
 
 // Derive environment label from config
@@ -41,7 +45,8 @@ export const HealthScreen = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  const [isMockData, setIsMockData] = useState(false);
+  const [isCached, setIsCached] = useState(false);
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
   const [netInfo, setNetInfo] = useState<NetInfoState | null>(null);
   const [apiReachable, setApiReachable] = useState<boolean | null>(null);
   const [copied, setCopied] = useState(false);
@@ -68,18 +73,30 @@ export const HealthScreen = () => {
       try {
         const data = await fetchHealthStatus();
         setHealthData(data);
-        setIsMockData(false);
+        setIsCached(false);
+        setCachedAt(null);
         setApiReachable(true);
+        await cacheHealthStatus(data);
       } catch (err) {
-        console.log('Using mock data fallback');
-        setHealthData(getMockHealthData());
-        setIsMockData(true);
-        setError('Backend unreachable - showing mock data');
         setApiReachable(false);
+        const cached = await loadCachedHealthStatus();
+        if (cached) {
+          setHealthData(cached);
+          setIsCached(true);
+          const ts = await getHealthCacheTimestamp();
+          setCachedAt(ts);
+          setError('Backend unreachable - showing cached health data');
+        } else {
+          setHealthData(null);
+          setIsCached(false);
+          setCachedAt(null);
+          setError('Backend unreachable - system health data unavailable');
+        }
       }
     } catch (err) {
       setError('Failed to load health data');
       setApiReachable(false);
+      setHealthData(null);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -120,15 +137,17 @@ export const HealthScreen = () => {
 
   const handleCopyDiagnostics = async () => {
     const formattedNetworkType = netInfo?.type ? netInfo.type.toUpperCase() : 'UNKNOWN';
-    const formattedInternetReachable = netInfo?.isInternetReachable === true 
-      ? 'Yes' 
-      : netInfo?.isInternetReachable === false 
-        ? 'No' 
+    const formattedInternetReachable =
+      netInfo?.isInternetReachable === true
+        ? 'Yes'
+        : netInfo?.isInternetReachable === false
+        ? 'No'
         : 'Unknown';
-    const formattedApiReachable = apiReachable === true 
-      ? 'Reachable' 
-      : apiReachable === false 
-        ? 'Unreachable' 
+    const formattedApiReachable =
+      apiReachable === true
+        ? 'Reachable'
+        : apiReachable === false
+        ? 'Unreachable'
         : 'Checking...';
 
     const diagnosticsText = `Soter App Diagnostics
@@ -187,7 +206,6 @@ Timestamp: ${new Date().toISOString()}`;
         accessibilityLabel="Loading system health data"
         accessibilityLiveRegion="polite"
       >
-        {/* Third-party: ActivityIndicator uses brand.primary for consistent branding */}
         <ActivityIndicator
           size="large"
           color={colors.brand.primary}
@@ -202,7 +220,6 @@ Timestamp: ${new Date().toISOString()}`;
     <SafeAreaView style={styles.container}>
       <ScrollView
         refreshControl={
-          // Third-party: RefreshControl tintColor / colors aligned to brand
           <RefreshControl
             refreshing={refreshing}
             onRefresh={onRefresh}
@@ -233,17 +250,17 @@ Timestamp: ${new Date().toISOString()}`;
                   {envLabel.toUpperCase()}
                 </Text>
               </View>
-              {isMockData && (
+              {isCached && (
                 <View
-                  style={styles.mockBadge}
+                  style={styles.cachedBadge}
                   accessible
-                  accessibilityLabel="Using mock data"
+                  accessibilityLabel="Showing cached health data"
                 >
                   <Text
-                    style={styles.mockBadgeText}
+                    style={styles.cachedBadgeText}
                     importantForAccessibility="no-hide-descendants"
                   >
-                    🔧 MOCK
+                    📦 CACHED
                   </Text>
                 </View>
               )}
@@ -272,7 +289,9 @@ Timestamp: ${new Date().toISOString()}`;
             >
               <Text style={styles.configErrorTitle}>⚠️ Configuration Issues</Text>
               {config.errors.map((err, index) => (
-                <Text key={index} style={styles.configErrorText}>• {err}</Text>
+                <Text key={index} style={styles.configErrorText}>
+                  • {err}
+                </Text>
               ))}
             </View>
           )}
@@ -283,28 +302,64 @@ Timestamp: ${new Date().toISOString()}`;
               Environment & Blockchain
             </Text>
             <View style={styles.card}>
-              <View style={styles.infoRow} accessible accessibilityLabel={`Network: ${config.network}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Network: ${config.network}`}
+              >
                 <Text style={styles.infoLabel}>Network:</Text>
                 <Text style={styles.infoValue}>{config.network.toUpperCase()}</Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`API URL: ${config.apiUrl}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`API URL: ${config.apiUrl}`}
+              >
                 <Text style={styles.infoLabel}>Backend URL:</Text>
-                <Text style={styles.infoValue} numberOfLines={1} ellipsizeMode="middle">
+                <Text
+                  style={styles.infoValue}
+                  numberOfLines={1}
+                  ellipsizeMode="middle"
+                >
                   {config.apiUrl}
                 </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Contract ID: ${config.sorobanContractId || 'Not Configured'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Contract ID: ${
+                  config.sorobanContractId || 'Not Configured'
+                }`}
+              >
                 <Text style={styles.infoLabel}>Contract ID:</Text>
-                <Text style={[styles.infoValue, !config.sorobanContractId && { color: colors.warning }]} numberOfLines={1} ellipsizeMode="middle">
+                <Text
+                  style={[
+                    styles.infoValue,
+                    !config.sorobanContractId && { color: colors.warning },
+                  ]}
+                  numberOfLines={1}
+                  ellipsizeMode="middle"
+                >
                   {config.sorobanContractId || 'None'}
                 </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Config Status: ${config.isValid ? 'Valid' : 'Invalid'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Config Status: ${
+                  config.isValid ? 'Valid' : 'Invalid'
+                }`}
+              >
                 <Text style={styles.infoLabel}>Config Status:</Text>
-                <Text style={[styles.infoValue, { color: config.isValid ? colors.success : colors.error }]}>
+                <Text
+                  style={[
+                    styles.infoValue,
+                    { color: config.isValid ? colors.success : colors.error },
+                  ]}
+                >
                   {config.isValid ? 'VALID ✅' : 'INVALID ❌'}
                 </Text>
               </View>
@@ -312,14 +367,16 @@ Timestamp: ${new Date().toISOString()}`;
           </View>
 
           {/* ── Health Data Card ────────────────────────────────────────── */}
-          {healthData && (
+          {healthData ? (
             <View
               style={[
                 styles.card,
                 { borderLeftColor: getStatusColor(healthData.status) },
               ]}
               accessible
-              accessibilityLabel={`Backend status: ${healthData.status.toUpperCase()}. Service: ${healthData.service}. Version: ${healthData.version}. Environment: ${healthData.environment}.`}
+              accessibilityLabel={`Backend status: ${healthData.status.toUpperCase()}. Service: ${
+                healthData.service
+              }. Version: ${healthData.version}. Environment: ${healthData.environment}.`}
             >
               <View style={styles.cardHeader}>
                 <Text style={styles.cardTitle}>Backend Status</Text>
@@ -328,10 +385,7 @@ Timestamp: ${new Date().toISOString()}`;
                   accessible
                   accessibilityLabel={`Status: ${healthData.status.toUpperCase()}`}
                 >
-                  <Text
-                    style={styles.statusIcon}
-                    accessibilityElementsHidden
-                  >
+                  <Text style={styles.statusIcon} accessibilityElementsHidden>
                     {getStatusIcon(healthData.status)}
                   </Text>
                   <Text
@@ -345,40 +399,100 @@ Timestamp: ${new Date().toISOString()}`;
                 </View>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Service: ${healthData.service}`}>
-                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">Service:</Text>
-                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">{healthData.service}</Text>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Service: ${healthData.service}`}
+              >
+                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">
+                  Service:
+                </Text>
+                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">
+                  {healthData.service}
+                </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Version: ${healthData.version}`}>
-                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">Version:</Text>
-                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">{healthData.version}</Text>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Version: ${healthData.version}`}
+              >
+                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">
+                  Version:
+                </Text>
+                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">
+                  {healthData.version}
+                </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Environment: ${healthData.environment}`}>
-                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">Environment:</Text>
-                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">{healthData.environment}</Text>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Environment: ${healthData.environment}`}
+              >
+                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">
+                  Environment:
+                </Text>
+                <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">
+                  {healthData.environment}
+                </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Last updated: ${formatTimestamp(healthData.timestamp)}`}>
-                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">Last updated:</Text>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Last updated: ${formatTimestamp(healthData.timestamp)}`}
+              >
+                <Text style={styles.infoLabel} importantForAccessibility="no-hide-descendants">
+                  Last updated:
+                </Text>
                 <Text style={styles.infoValue} importantForAccessibility="no-hide-descendants">
                   {formatTimestamp(healthData.timestamp)}
                 </Text>
               </View>
 
-              {isMockData && (
+              {isCached && (
                 <View
-                  style={styles.insideMockIndicator}
+                  style={styles.insideCachedIndicator}
                   accessible
                   accessibilityRole="alert"
-                  accessibilityLabel="Warning: This is simulated data. Backend connection failed."
+                  accessibilityLabel="Notice: Showing cached health data. Backend connection is currently unreachable."
                 >
-                  <Text style={styles.insideMockText} importantForAccessibility="no-hide-descendants">
-                    ⚠️ This is simulated data - backend connection failed
+                  <Text
+                    style={styles.insideCachedText}
+                    importantForAccessibility="no-hide-descendants"
+                  >
+                    📦 Cached data ({formatAge(cachedAt) ?? 'earlier'}) — backend unreachable
                   </Text>
                 </View>
               )}
+            </View>
+          ) : (
+            /* Explicit Unavailable State */
+            <View
+              style={[styles.card, styles.unavailableCard]}
+              accessible
+              accessibilityRole="alert"
+              accessibilityLabel="Backend status unavailable. Unable to connect to the backend server and no cached health data is available."
+            >
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>Backend Status</Text>
+                <View
+                  style={styles.statusBadge}
+                  accessible
+                  accessibilityLabel="Status: UNAVAILABLE"
+                >
+                  <Text style={styles.statusIcon} accessibilityElementsHidden>
+                    ❌
+                  </Text>
+                  <Text style={[styles.statusText, { color: colors.error }]}>
+                    UNAVAILABLE
+                  </Text>
+                </View>
+              </View>
+              <Text style={styles.unavailableMessage}>
+                Unable to connect to the backend server and no cached health data is available.
+              </Text>
             </View>
           )}
 
@@ -388,34 +502,111 @@ Timestamp: ${new Date().toISOString()}`;
               Diagnostics
             </Text>
             <View style={styles.card}>
-              <View style={styles.infoRow} accessible accessibilityLabel={`App Version: ${appVersion}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`App Version: ${appVersion}`}
+              >
                 <Text style={styles.infoLabel}>App Version:</Text>
                 <Text style={styles.infoValue}>{appVersion}</Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`API Reachability: ${apiReachable === true ? 'Reachable' : apiReachable === false ? 'Unreachable' : 'Checking...'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`API Reachability: ${
+                  apiReachable === true
+                    ? 'Reachable'
+                    : apiReachable === false
+                    ? 'Unreachable'
+                    : 'Checking...'
+                }`}
+              >
                 <Text style={styles.infoLabel}>API Reachability:</Text>
-                <Text style={[styles.infoValue, { color: apiReachable === true ? colors.success : apiReachable === false ? colors.error : colors.textSecondary }]}>
-                  {apiReachable === true ? 'REACHABLE ✅' : apiReachable === false ? 'UNREACHABLE ❌' : 'CHECKING...'}
+                <Text
+                  style={[
+                    styles.infoValue,
+                    {
+                      color:
+                        apiReachable === true
+                          ? colors.success
+                          : apiReachable === false
+                          ? colors.error
+                          : colors.textSecondary,
+                    },
+                  ]}
+                >
+                  {apiReachable === true
+                    ? 'REACHABLE ✅'
+                    : apiReachable === false
+                    ? 'UNREACHABLE ❌'
+                    : 'CHECKING...'}
                 </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Network Connection: ${netInfo?.isConnected ? 'Connected' : 'Disconnected'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Network Connection: ${
+                  netInfo?.isConnected ? 'Connected' : 'Disconnected'
+                }`}
+              >
                 <Text style={styles.infoLabel}>Network Status:</Text>
-                <Text style={[styles.infoValue, { color: netInfo?.isConnected ? colors.success : colors.error }]}>
+                <Text
+                  style={[
+                    styles.infoValue,
+                    {
+                      color: netInfo?.isConnected ? colors.success : colors.error,
+                    },
+                  ]}
+                >
                   {netInfo?.isConnected ? 'CONNECTED' : 'DISCONNECTED'}
                 </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Network Type: ${netInfo?.type ? netInfo.type.toUpperCase() : 'UNKNOWN'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Network Type: ${
+                  netInfo?.type ? netInfo.type.toUpperCase() : 'UNKNOWN'
+                }`}
+              >
                 <Text style={styles.infoLabel}>Network Type:</Text>
-                <Text style={styles.infoValue}>{netInfo?.type ? netInfo.type.toUpperCase() : 'UNKNOWN'}</Text>
+                <Text style={styles.infoValue}>
+                  {netInfo?.type ? netInfo.type.toUpperCase() : 'UNKNOWN'}
+                </Text>
               </View>
 
-              <View style={styles.infoRow} accessible accessibilityLabel={`Internet Reachable: ${netInfo?.isInternetReachable === true ? 'Yes' : netInfo?.isInternetReachable === false ? 'No' : 'Unknown'}`}>
+              <View
+                style={styles.infoRow}
+                accessible
+                accessibilityLabel={`Internet Reachable: ${
+                  netInfo?.isInternetReachable === true
+                    ? 'Yes'
+                    : netInfo?.isInternetReachable === false
+                    ? 'No'
+                    : 'Unknown'
+                }`}
+              >
                 <Text style={styles.infoLabel}>Internet Reachable:</Text>
-                <Text style={[styles.infoValue, { color: netInfo?.isInternetReachable === true ? colors.success : netInfo?.isInternetReachable === false ? colors.error : colors.textSecondary }]}>
-                  {netInfo?.isInternetReachable === true ? 'YES' : netInfo?.isInternetReachable === false ? 'NO' : 'UNKNOWN'}
+                <Text
+                  style={[
+                    styles.infoValue,
+                    {
+                      color:
+                        netInfo?.isInternetReachable === true
+                          ? colors.success
+                          : netInfo?.isInternetReachable === false
+                          ? colors.error
+                          : colors.textSecondary,
+                    },
+                  ]}
+                >
+                  {netInfo?.isInternetReachable === true
+                    ? 'YES'
+                    : netInfo?.isInternetReachable === false
+                    ? 'NO'
+                    : 'UNKNOWN'}
                 </Text>
               </View>
             </View>
@@ -428,7 +619,9 @@ Timestamp: ${new Date().toISOString()}`;
               onPress={handleCopyDiagnostics}
               activeOpacity={0.8}
             >
-              <Text style={[styles.copyButtonText, copied && { color: colors.success }]}>
+              <Text
+                style={[styles.copyButtonText, copied && { color: colors.success }]}
+              >
                 {copied ? '✅ Diagnostics Copied!' : '📋 Copy Diagnostics'}
               </Text>
             </TouchableOpacity>
@@ -444,10 +637,20 @@ Timestamp: ${new Date().toISOString()}`;
               <View
                 style={styles.statItem}
                 accessible
-                accessibilityLabel={`Platform: ${Platform.OS === 'android' ? 'Android' : 'iOS'}`}
+                accessibilityLabel={`Platform: ${
+                  Platform.OS === 'android' ? 'Android' : 'iOS'
+                }`}
               >
-                <Text style={styles.statLabel} importantForAccessibility="no-hide-descendants">Platform</Text>
-                <Text style={styles.statValue} importantForAccessibility="no-hide-descendants">
+                <Text
+                  style={styles.statLabel}
+                  importantForAccessibility="no-hide-descendants"
+                >
+                  Platform
+                </Text>
+                <Text
+                  style={styles.statValue}
+                  importantForAccessibility="no-hide-descendants"
+                >
                   {Platform.OS === 'android' ? 'Android' : 'iOS'}
                 </Text>
               </View>
@@ -455,10 +658,22 @@ Timestamp: ${new Date().toISOString()}`;
               <View
                 style={styles.statItem}
                 accessible
-                accessibilityLabel={`Last check: ${healthData ? formatTimestamp(healthData.timestamp).split(',')[0] : 'Not available'}`}
+                accessibilityLabel={`Last check: ${
+                  healthData
+                    ? formatTimestamp(healthData.timestamp).split(',')[0]
+                    : 'Not available'
+                }`}
               >
-                <Text style={styles.statLabel} importantForAccessibility="no-hide-descendants">Last Check</Text>
-                <Text style={styles.statValue} importantForAccessibility="no-hide-descendants">
+                <Text
+                  style={styles.statLabel}
+                  importantForAccessibility="no-hide-descendants"
+                >
+                  Last Check
+                </Text>
+                <Text
+                  style={styles.statValue}
+                  importantForAccessibility="no-hide-descendants"
+                >
                   {healthData
                     ? formatTimestamp(healthData.timestamp).split(',')[0]
                     : 'N/A'}
@@ -467,9 +682,13 @@ Timestamp: ${new Date().toISOString()}`;
             </View>
           </View>
 
-          {/* ── Troubleshooting Tips ────────────────────────────────────── */}
-          {isMockData && (
-            <View style={styles.tipsContainer} accessible accessibilityRole="summary">
+          {/* ── Troubleshooting Tips (shown when API is unreachable or error exists) ── */}
+          {(apiReachable === false || error) && (
+            <View
+              style={styles.tipsContainer}
+              accessible
+              accessibilityRole="summary"
+            >
               <Text style={styles.tipsTitle} accessibilityRole="header">
                 🔍 Troubleshooting Tips
               </Text>
@@ -477,20 +696,19 @@ Timestamp: ${new Date().toISOString()}`;
                 • Ensure backend server is running on port 3000
               </Text>
               <Text style={styles.tipText}>
-                • Check if API URL is correct:{' '}
-                {config.apiUrl}
+                • Check if API URL is correct: {config.apiUrl}
               </Text>
               <Text style={styles.tipText}>
                 • For Android emulator, use 10.0.2.2 instead of localhost
               </Text>
               <Text style={styles.tipText}>
-                • Try restarting the backend server
+                • Try restarting the backend server or checking network connection
               </Text>
             </View>
           )}
 
           {/* ── Retry Button ────────────────────────────────────────────── */}
-          {error && (
+          {(error || apiReachable === false) && (
             <TouchableOpacity
               style={styles.retryButton}
               accessibilityRole="button"
@@ -505,28 +723,32 @@ Timestamp: ${new Date().toISOString()}`;
           {/* ── Footer ──────────────────────────────────────────────────── */}
           <View style={styles.footer}>
             <Text style={styles.footerText}>
-              {isMockData ? '📊 Using simulated data' : '🌐 Live backend data'}
+              {isCached
+                ? '📦 Using cached data'
+                : apiReachable
+                ? '🌐 Live backend data'
+                : '⚠️ Backend unavailable'}
             </Text>
             <Text style={styles.footerSubText}>
-              {!isMockData && 'Data fetched from /health endpoint'}
+              {apiReachable && !isCached
+                ? 'Data fetched from /health endpoint'
+                : isCached
+                ? `Last cached: ${cachedAt ? formatTimestamp(cachedAt) : 'N/A'}`
+                : 'Showing offline status'}
             </Text>
             <View
               style={styles.footerEnvRow}
               testID="footer-env-row"
               accessibilityLabel={`Environment: ${envLabel} · ${shortApiUrl}`}
             >
-              <Text style={styles.footerEnvLabel}>
-                Environment:{' '}
-              </Text>
+              <Text style={styles.footerEnvLabel}>Environment: </Text>
               <Text
                 testID="footer-env-name"
                 style={[styles.footerEnvValue, { color: envBadgeColor }]}
               >
                 {envLabel}
               </Text>
-              <Text style={styles.footerEnvSeparator}>
-                {' '}·{' '}
-              </Text>
+              <Text style={styles.footerEnvSeparator}> · </Text>
               <Text
                 testID="footer-api-url"
                 style={styles.footerEnvUrl}
@@ -573,13 +795,13 @@ const makeStyles = (colors: AppColors) =>
       fontWeight: 'bold',
       color: colors.textPrimary,
     },
-    mockBadge: {
-      backgroundColor: colors.warning,
+    cachedBadge: {
+      backgroundColor: colors.info,
       paddingHorizontal: 12,
       paddingVertical: 6,
       borderRadius: 20,
     },
-    mockBadgeText: {
+    cachedBadgeText: {
       color: '#fff',
       fontWeight: 'bold',
       fontSize: 12,
@@ -627,6 +849,15 @@ const makeStyles = (colors: AppColors) =>
       elevation: 3,
       borderLeftWidth: 4,
     },
+    unavailableCard: {
+      borderLeftColor: colors.error,
+    },
+    unavailableMessage: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      lineHeight: 20,
+      marginTop: 4,
+    },
     cardHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',
@@ -664,16 +895,16 @@ const makeStyles = (colors: AppColors) =>
       color: colors.textPrimary,
       fontWeight: '500',
     },
-    insideMockIndicator: {
+    insideCachedIndicator: {
       marginTop: 12,
       padding: 8,
-      backgroundColor: colors.warningBg,
+      backgroundColor: colors.infoBg,
       borderRadius: 6,
       borderWidth: 1,
-      borderColor: colors.warningBorder,
+      borderColor: colors.info,
     },
-    insideMockText: {
-      color: colors.warning,
+    insideCachedText: {
+      color: colors.info,
       fontSize: 12,
       fontWeight: '500',
       textAlign: 'center',
@@ -736,7 +967,6 @@ const makeStyles = (colors: AppColors) =>
     retryButton: {
       backgroundColor: colors.brand.primary,
       padding: 16,
-      // Minimum 44 pt height (WCAG 2.5.5)
       minHeight: 44,
       borderRadius: 12,
       alignItems: 'center',

--- a/app/mobile/src/services/aidCache.ts
+++ b/app/mobile/src/services/aidCache.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AidPackage } from './api';
+import type { AidDetails } from './aidApi';
 import { config } from '../config';
 import {
   AID_CACHE_KEY,
@@ -10,6 +11,9 @@ import {
   persistBoundedCache,
 } from './localCache';
 import type { CacheWriteResult } from './localCache';
+
+const CACHE_DETAILS_PREFIX = '@soter/aid_details_';
+const CACHE_DETAILS_TIMESTAMP_PREFIX = '@soter/aid_details_timestamp_';
 
 const aidCacheOptions = {
   cacheKey: AID_CACHE_KEY,
@@ -45,3 +49,33 @@ export const getCacheTimestamp = async (): Promise<string | null> => {
 export const clearAidCache = async () => clearBoundedCache<AidPackage>(aidCacheOptions);
 
 export const getAidCacheSummary = async () => getCacheSummary<AidPackage>(aidCacheOptions);
+
+/** Persist aid package details to AsyncStorage */
+export const cacheAidDetails = async (aidId: string, data: AidDetails): Promise<void> => {
+  await AsyncStorage.setItem(`${CACHE_DETAILS_PREFIX}${aidId}`, JSON.stringify(data));
+  await AsyncStorage.setItem(`${CACHE_DETAILS_TIMESTAMP_PREFIX}${aidId}`, Date.now().toString());
+};
+
+/** Load cached aid package details from AsyncStorage */
+export const loadCachedAidDetails = async (aidId: string): Promise<AidDetails | null> => {
+  const raw = await AsyncStorage.getItem(`${CACHE_DETAILS_PREFIX}${aidId}`);
+  if (!raw) return null;
+  return JSON.parse(raw) as AidDetails;
+};
+
+/** Returns the ISO timestamp of the last successful cache write for an aid detail, or null */
+export const getAidDetailsCacheTimestamp = async (aidId: string): Promise<string | null> => {
+  const ts = await AsyncStorage.getItem(`${CACHE_DETAILS_TIMESTAMP_PREFIX}${aidId}`);
+  if (!ts) return null;
+  return new Date(parseInt(ts, 10)).toISOString();
+};
+
+/** Clear the cached aid details for a specific aidId or all */
+export const clearAidDetailsCache = async (aidId?: string): Promise<void> => {
+  if (aidId) {
+    await AsyncStorage.multiRemove([
+      `${CACHE_DETAILS_PREFIX}${aidId}`,
+      `${CACHE_DETAILS_TIMESTAMP_PREFIX}${aidId}`,
+    ]);
+  }
+};

--- a/app/mobile/src/services/healthCache.ts
+++ b/app/mobile/src/services/healthCache.ts
@@ -1,0 +1,30 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { HealthStatus } from './api';
+
+const CACHE_KEY = '@soter/health_status';
+const CACHE_TIMESTAMP_KEY = '@soter/health_status_timestamp';
+
+/** Persist health status to AsyncStorage */
+export const cacheHealthStatus = async (data: HealthStatus): Promise<void> => {
+  await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  await AsyncStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
+};
+
+/** Load cached health status from AsyncStorage */
+export const loadCachedHealthStatus = async (): Promise<HealthStatus | null> => {
+  const raw = await AsyncStorage.getItem(CACHE_KEY);
+  if (!raw) return null;
+  return JSON.parse(raw) as HealthStatus;
+};
+
+/** Returns the ISO timestamp of the last successful health cache write, or null */
+export const getHealthCacheTimestamp = async (): Promise<string | null> => {
+  const ts = await AsyncStorage.getItem(CACHE_TIMESTAMP_KEY);
+  if (!ts) return null;
+  return new Date(parseInt(ts, 10)).toISOString();
+};
+
+/** Clear the cached health status */
+export const clearHealthCache = async (): Promise<void> => {
+  await AsyncStorage.multiRemove([CACHE_KEY, CACHE_TIMESTAMP_KEY]);
+};

--- a/app/mobile/src/services/mockData.ts
+++ b/app/mobile/src/services/mockData.ts
@@ -1,6 +1,14 @@
 import { HealthStatus } from './api';
 
+/**
+ * Mock health data generator.
+ * Accessible only from tests and development builds.
+ */
 export const getMockHealthData = (): HealthStatus => {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('mockData.ts cannot be used in production builds');
+  }
+
   return {
     status: 'ok',
     service: 'backend',


### PR DESCRIPTION
Closes #923 

## Description
Resolves #923 by removing fabricated mock data fallbacks from production field screens (`HealthScreen.tsx` and `AidDetailsScreen.tsx`) and replacing them with honest offline/unavailable states and persistent real-data caching with age labels.

### Key Changes
- **Retire Mock Fallbacks**:
  - `HealthScreen.tsx`: Removed `getMockHealthData` import, mock badges (`🔧 MOCK`), and fake status indicators.
  - `AidDetailsScreen.tsx`: Removed silent fallback to `getMockAidDetails`.
- **Offline Caching & Freshness**:
  - `healthCache.ts`: Added caching for `HealthStatus` into AsyncStorage (`cacheHealthStatus`, `loadCachedHealthStatus`, `getHealthCacheTimestamp`, `clearHealthCache`).
  - `aidCache.ts`: Added caching for individual `AidDetails` (`cacheAidDetails`, `loadCachedAidDetails`, `getAidDetailsCacheTimestamp`, `clearAidDetailsCache`).
  - Cached real data is displayed when the backend is unreachable and is clearly labeled with its age via `DataFreshnessIndicator` / cached indicators.
- **Explicit Unavailable State**:
  - When backend is unreachable and no offline cache exists, both screens render an explicit unavailable state with an actionable "🔄 Retry Connection" button and diagnostic info.
- **Production Guard on Mock Data**:
  - `mockData.ts`: Added a runtime guard `if (process.env.NODE_ENV === 'production') throw new Error(...)` so mock data cannot be accessed in production builds.
- **Test Coverage**:
  - Added unit test suites for `AidDetailsScreen.test.tsx`, `mockData.test.ts`, `healthCache.test.ts`, and `aidCache.test.ts`.
  - Updated `HealthScreen.test.tsx` and `navigation.test.tsx` to verify live data, cached data, unreachable backend with no cache, and retry connection behaviors.

### Verification
- Ran test suites for `HealthScreen`, `AidDetailsScreen`, `mockData`, `healthCache`, `aidCache`, `localCache`, `SettingsScreen`, and `navigation` (`42/42 tests passed`).
