### PR TITLE
fix: Stabilize and Export Contract Error Codes

### DIFF
--- a/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.spec.ts
@@ -61,4 +61,63 @@ describe('SorobanErrorMapper', () => {
       },
     });
   });
+
+  it('maps no pending transfer errors from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 19 })).toMatchObject({
+      statusCode: 400,
+      message: 'No pending admin transfer in progress',
+      details: {
+        error_code: 19,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps invalid pending admin errors from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 20 })).toMatchObject({
+      statusCode: 403,
+      message: 'Invalid pending admin address',
+      details: {
+        error_code: 20,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps batch too large errors from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 21 })).toMatchObject({
+      statusCode: 400,
+      message: 'Batch operation exceeds the maximum allowed size',
+      details: {
+        error_code: 21,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps claim cooldown errors from numeric contract codes', () => {
+    expect(mapper.mapError({ errorCode: 22 })).toMatchObject({
+      statusCode: 400,
+      message: 'Claim cooldown is still active',
+      details: {
+        error_code: 22,
+        error_type: 'contract_error',
+      },
+    });
+  });
+
+  it('maps claim cooldown errors from contract error messages', () => {
+    expect(
+      mapper.mapError(
+        new Error('HostError: Error(Contract, #22) ClaimCooldownActive'),
+      ),
+    ).toMatchObject({
+      statusCode: 400,
+      message: 'Claim cooldown is still active',
+      details: {
+        error_name: 'ClaimCooldownActive',
+        error_type: 'contract_error',
+      },
+    });
+  });
 });

--- a/app/backend/src/onchain/utils/soroban-error.mapper.ts
+++ b/app/backend/src/onchain/utils/soroban-error.mapper.ts
@@ -105,6 +105,26 @@ export class SorobanErrorMapper {
       message: 'Token transfer failed',
       errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED,
     },
+    19: {
+      code: 400,
+      message: 'No pending admin transfer in progress',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
+    },
+    20: {
+      code: 403,
+      message: 'Invalid pending admin address',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED,
+    },
+    21: {
+      code: 400,
+      message: 'Batch operation exceeds the maximum allowed size',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
+    },
+    22: {
+      code: 400,
+      message: 'Claim cooldown is still active',
+      errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE,
+    },
   };
 
   /**
@@ -180,7 +200,11 @@ export class SorobanErrorMapper {
         message.includes('InvalidAmount') ||
         message.includes('InvalidProof') ||
         message.includes('InvalidToken') ||
-        message.includes('TokenTransferFailed'))
+        message.includes('TokenTransferFailed') ||
+        message.includes('NoPendingTransfer') ||
+        message.includes('InvalidPendingAdmin') ||
+        message.includes('BatchTooLarge') ||
+        message.includes('ClaimCooldownActive'))
     ) {
       return this.mapContractErrorMessage(message);
     }
@@ -390,6 +414,26 @@ export class SorobanErrorMapper {
         code: 502,
         message: 'Token transfer failed',
         errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_TOKEN_TRANSFER_FAILED,
+      },
+      NoPendingTransfer: {
+        code: 400,
+        message: 'No pending admin transfer in progress',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
+      },
+      InvalidPendingAdmin: {
+        code: 403,
+        message: 'Invalid pending admin address',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_NOT_AUTHORIZED,
+      },
+      BatchTooLarge: {
+        code: 400,
+        message: 'Batch operation exceeds the maximum allowed size',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_CONTRACT_ERROR,
+      },
+      ClaimCooldownActive: {
+        code: 400,
+        message: 'Claim cooldown is still active',
+        errorCode: INTEGRATION_ERROR_CODES.ONCHAIN_INVALID_STATE,
       },
     };
 

--- a/app/onchain/contracts/aid_escrow/README.md
+++ b/app/onchain/contracts/aid_escrow/README.md
@@ -106,6 +106,32 @@ Cancelled --> Refunded       (admin refunds)
 | 12 | `MismatchedArrays` | `recipients` and `amounts` lengths differ in batch create. |
 | 13 | `InsufficientSurplus` | `withdraw_surplus` amount exceeds available surplus. |
 | 14 | `ContractPaused` | Operation blocked because contract is paused. |
+| 15 | `ClaimTooEarly` | Claim attempted before the claim window opens. |
+| 16 | `InvalidProof` | Claim proof is invalid or missing. |
+| 17 | `InvalidToken` | Token contract address is not allowed by config. |
+| 18 | `TokenTransferFailed` | Token transfer reverted (e.g. insufficient allowance). |
+| 19 | `NoPendingTransfer` | No pending admin transfer is in progress. |
+| 20 | `InvalidPendingAdmin` | Pending admin address does not match the caller. |
+| 21 | `BatchTooLarge` | Batch operation exceeds the maximum allowed size. |
+| 22 | `ClaimCooldownActive` | Recipient has not yet completed the claim cooldown. |
+
+### Compatibility Policy
+
+The numeric codes in the table above are **stable and part of the public
+contract ABI**. The backend adapter
+(`app/backend/src/onchain/utils/soroban-error.mapper.ts`) maps these codes to
+user-facing messages, so reordering or removing a variant would silently break
+that mapping.
+
+- **Adding a new error**: append the new variant with the **next unused code**
+  (currently `23`). Never reuse, renumber, or skip codes.
+- **Removing an error**: do **not** remove a variant. If it is no longer
+  emitted, keep the variant and its code so existing mappings remain valid.
+- **Renaming**: renaming a variant is allowed only if the numeric code is
+  preserved; update the backend mapper and this table in the same change.
+- **Guarding**: `tests/error_codes.rs` pins every variant to its canonical code
+  and verifies the codes are unique and contiguous. Any reorder or removal
+  fails CI.
 
 ## Data Structures
 

--- a/app/onchain/contracts/aid_escrow/tests/error_codes.rs
+++ b/app/onchain/contracts/aid_escrow/tests/error_codes.rs
@@ -1,0 +1,74 @@
+#![cfg(test)]
+
+//! Guards the stable numeric discriminants of the contract `Error` enum.
+//!
+//! The backend adapter (`app/backend/src/onchain/utils/soroban-error.mapper.ts`)
+//! maps contract failures to user-facing messages by these numeric codes.
+//! Reordering or removing a variant would silently break that mapping, so this
+//! test pins every variant to its canonical code. New variants MUST be appended
+//! with the next unused code (see the compatibility policy in README.md).
+
+use aid_escrow::Error;
+
+#[test]
+fn error_discriminants_are_stable() {
+    // Every variant must map to its canonical, stable numeric code.
+    assert_eq!(Error::NotInitialized as u32, 1);
+    assert_eq!(Error::AlreadyInitialized as u32, 2);
+    assert_eq!(Error::NotAuthorized as u32, 3);
+    assert_eq!(Error::InvalidAmount as u32, 4);
+    assert_eq!(Error::PackageNotFound as u32, 5);
+    assert_eq!(Error::PackageNotActive as u32, 6);
+    assert_eq!(Error::PackageExpired as u32, 7);
+    assert_eq!(Error::PackageNotExpired as u32, 8);
+    assert_eq!(Error::InsufficientFunds as u32, 9);
+    assert_eq!(Error::PackageIdExists as u32, 10);
+    assert_eq!(Error::InvalidState as u32, 11);
+    assert_eq!(Error::MismatchedArrays as u32, 12);
+    assert_eq!(Error::InsufficientSurplus as u32, 13);
+    assert_eq!(Error::ContractPaused as u32, 14);
+    assert_eq!(Error::ClaimTooEarly as u32, 15);
+    assert_eq!(Error::InvalidProof as u32, 16);
+    assert_eq!(Error::InvalidToken as u32, 17);
+    assert_eq!(Error::TokenTransferFailed as u32, 18);
+    assert_eq!(Error::NoPendingTransfer as u32, 19);
+    assert_eq!(Error::InvalidPendingAdmin as u32, 20);
+    assert_eq!(Error::BatchTooLarge as u32, 21);
+    assert_eq!(Error::ClaimCooldownActive as u32, 22);
+}
+
+#[test]
+fn error_discriminants_are_contiguous_and_unique() {
+    // Collect all discriminants and verify they are unique and contiguous
+    // starting at 1. This catches accidental duplicate or skipped codes.
+    let mut codes: Vec<u32> = vec![
+        Error::NotInitialized as u32,
+        Error::AlreadyInitialized as u32,
+        Error::NotAuthorized as u32,
+        Error::InvalidAmount as u32,
+        Error::PackageNotFound as u32,
+        Error::PackageNotActive as u32,
+        Error::PackageExpired as u32,
+        Error::PackageNotExpired as u32,
+        Error::InsufficientFunds as u32,
+        Error::PackageIdExists as u32,
+        Error::InvalidState as u32,
+        Error::MismatchedArrays as u32,
+        Error::InsufficientSurplus as u32,
+        Error::ContractPaused as u32,
+        Error::ClaimTooEarly as u32,
+        Error::InvalidProof as u32,
+        Error::InvalidToken as u32,
+        Error::TokenTransferFailed as u32,
+        Error::NoPendingTransfer as u32,
+        Error::InvalidPendingAdmin as u32,
+        Error::BatchTooLarge as u32,
+        Error::ClaimCooldownActive as u32,
+    ];
+    codes.sort_unstable();
+    codes.dedup();
+    assert_eq!(codes.len(), 22, "error codes must be unique");
+    for (i, code) in codes.iter().enumerate() {
+        assert_eq!(*code, (i + 1) as u32, "error codes must be contiguous from 1");
+    }
+}

--- a/app/onchain/contracts/aid_escrow/tests/error_codes.rs
+++ b/app/onchain/contracts/aid_escrow/tests/error_codes.rs
@@ -69,6 +69,10 @@ fn error_discriminants_are_contiguous_and_unique() {
     codes.dedup();
     assert_eq!(codes.len(), 22, "error codes must be unique");
     for (i, code) in codes.iter().enumerate() {
-        assert_eq!(*code, (i + 1) as u32, "error codes must be contiguous from 1");
+        assert_eq!(
+            *code,
+            (i + 1) as u32,
+            "error codes must be contiguous from 1"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Implemented changes for issue #967. The agent reached its turn budget after producing this draft; repository CI must validate the result.

## Changed files
- `app/backend/src/onchain/utils/soroban-error.mapper.spec.ts`
- `app/backend/src/onchain/utils/soroban-error.mapper.ts`
- `app/onchain/contracts/aid_escrow/README.md`
- `app/onchain/contracts/aid_escrow/tests/error_codes.rs`

## Test plan
Run all repository CI checks and review the changed behavior.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #967
