### PR TITLE
feat(providers): make fallback order explicit, configurable, and vali…

### DIFF
--- a/app/ai-service/config.py
+++ b/app/ai-service/config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 import secrets
-from typing import Dict, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import Field, HttpUrl, model_validator
 from pydantic_core import PydanticUndefined
@@ -107,6 +107,16 @@ class Settings(BaseSettings):
     # Circuit Breaker settings
     circuit_breaker_failure_threshold: int = 3
     circuit_breaker_recovery_timeout_seconds: float = 30.0
+
+    # Provider fallback ordering.
+    # Explicit, operator-controlled ordering used when a request must fall back
+    # across providers (e.g. under ``provider_preference="auto"``). Comma-
+    # separated provider names; each must be a known provider and the list is
+    # intersected with the providers that are actually available at runtime.
+    # Order is preserved, so operators can express e.g. cheapest-first or
+    # lowest-latency-first without editing source.
+    llm_provider_fallback_order: str = "openai,groq,test"
+    ocr_provider_fallback_order: str = "test,tesseract"
 
     # Load shedding settings
     load_shed_memory_threshold_percent: float = 90.0
@@ -311,6 +321,21 @@ class Settings(BaseSettings):
                     _add(key, "origin entries must start with http:// or https://")
                     break
 
+        # --- Provider fallback ordering ----------------------------------
+        # Imported lazily to avoid a circular import (config -> providers ->
+        # config). The known-provider sets live next to the registry so they
+        # remain the single source of truth.
+        from services.providers import validate_fallback_order
+
+        for key, order in (
+            ("LLM_PROVIDER_FALLBACK_ORDER", self.get_llm_fallback_order()),
+            ("OCR_PROVIDER_FALLBACK_ORDER", self.get_ocr_fallback_order()),
+        ):
+            try:
+                validate_fallback_order(key, order)
+            except ValueError as exc:
+                _add(key, str(exc))
+
         # --- Production requirements (defense in depth) ------------------
         # apply_environment_defaults already rejects this at construction
         # time; re-checking here keeps validate_configuration() authoritative.
@@ -367,6 +392,18 @@ class Settings(BaseSettings):
         if self.groq_api_key:
             return "groq"
         return None
+
+    @staticmethod
+    def _parse_fallback_order(raw: str) -> List[str]:
+        return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+    def get_llm_fallback_order(self) -> List[str]:
+        """Parsed, ordered LLM provider fallback list from configuration."""
+        return self._parse_fallback_order(self.llm_provider_fallback_order)
+
+    def get_ocr_fallback_order(self) -> List[str]:
+        """Parsed, ordered OCR provider fallback list from configuration."""
+        return self._parse_fallback_order(self.ocr_provider_fallback_order)
 
     def get_cors_allowed_origins(self) -> list[str]:
         """

--- a/app/ai-service/conftest.py
+++ b/app/ai-service/conftest.py
@@ -27,6 +27,7 @@ _PKG_STUBS = [
     "prometheus_client",
     "celery",
     "celery.result",
+    "celery.schedules",
     "redis",
     "spacy",
     "spacy.language",

--- a/app/ai-service/exceptions.py
+++ b/app/ai-service/exceptions.py
@@ -19,6 +19,19 @@ class AIServiceError(Exception):
         return f"[{self.code}] {self.message}"
 
 
+class ProviderExhaustedError(AIServiceError):
+    """Raised when every candidate provider has been tried and none succeeded.
+
+    Distinct from a generic :class:`AIServiceError` so callers (and operators
+    reading logs/traces) can tell a total fallback-exhaustion failure apart
+    from a single transient provider error. ``details`` carries the ordered
+    list of per-provider failures so the exhaustion is fully diagnosable.
+    """
+
+    def __init__(self, message: str, details: Optional[Any] = None):
+        super().__init__(message, code="AI_PROVIDERS_EXHAUSTED", details=details)
+
+
 class LoadShedError(Exception):
     """Raised when the service must reject work due to overload."""
 

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -7,6 +7,7 @@ import time
 import metrics
 
 from config import settings
+from exceptions import ProviderExhaustedError
 from services.humanitarian_prompt import HumanitarianPromptEngine
 from services.circuit_breaker import CircuitBreaker
 from services.providers import ProviderRegistry, ModelProvider, LLMResponse
@@ -110,8 +111,10 @@ class HumanitarianVerificationService:
                             "Humanitarian verification attempt failed: %s", err
                         )
 
-            raise RuntimeError(
-                "All humanitarian verification attempts failed: " + " | ".join(errors)
+            raise ProviderExhaustedError(
+                "All LLM providers were attempted and exhausted: "
+                + " | ".join(errors),
+                details={"attempted": errors},
             )
         finally:
             latency = time.time() - start_time

--- a/app/ai-service/services/humanitarian_verification.py
+++ b/app/ai-service/services/humanitarian_verification.py
@@ -112,8 +112,7 @@ class HumanitarianVerificationService:
                         )
 
             raise ProviderExhaustedError(
-                "All LLM providers were attempted and exhausted: "
-                + " | ".join(errors),
+                "All LLM providers were attempted and exhausted: " + " | ".join(errors),
                 details={"attempted": errors},
             )
         finally:

--- a/app/ai-service/services/ocr.py
+++ b/app/ai-service/services/ocr.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import time
 from dataclasses import dataclass, field
@@ -7,6 +8,10 @@ from PIL import Image
 
 import metrics
 from config import settings
+
+logger = logging.getLogger(__name__)
+from exceptions import ProviderExhaustedError
+from services.circuit_breaker import CircuitBreaker
 from services.preprocessing import ImagePreprocessor
 from services.providers import ProviderRegistry, OCRField, OCRResponse
 
@@ -22,6 +27,7 @@ class OCRResult:
     fields: dict[str, FieldMatch]
     raw_text: str
     processing_time_ms: int
+    provider: Optional[str] = None
 
 
 class FieldDetector:
@@ -81,6 +87,16 @@ class OCRService:
         self.preprocessor = ImagePreprocessor()
         self.field_detector = FieldDetector()
         self.registry = registry or ProviderRegistry()
+        self.breakers: Dict[str, CircuitBreaker] = {}
+
+    def _get_breaker(self, provider_name: str) -> CircuitBreaker:
+        if provider_name not in self.breakers:
+            self.breakers[provider_name] = CircuitBreaker(
+                name=provider_name,
+                failure_threshold=settings.circuit_breaker_failure_threshold,
+                recovery_timeout=settings.circuit_breaker_recovery_timeout_seconds,
+            )
+        return self.breakers[provider_name]
 
     def process_image(
         self, image: Image.Image, language_hint: Optional[str] = None
@@ -89,7 +105,17 @@ class OCRService:
         if not providers:
             return OCRResult(fields={}, raw_text="", processing_time_ms=0)
 
+        errors: List[str] = []
         for provider_name, provider in providers:
+            breaker = self._get_breaker(provider_name)
+            if not breaker.allow_request():
+                logger.warning(
+                    "Circuit breaker is OPEN for provider=%s. Skipping.", provider_name
+                )
+                errors.append(
+                    f"provider={provider_name}, error=Circuit breaker is OPEN"
+                )
+                continue
             try:
                 response: OCRResponse = provider.ocr_extract(
                     image, language_hint=language_hint
@@ -104,14 +130,23 @@ class OCRService:
                     response.processing_time_ms / 1000.0
                 )
 
+                breaker.record_success()
                 return OCRResult(
                     fields=fields,
                     raw_text=response.raw_text,
                     processing_time_ms=response.processing_time_ms,
+                    provider=provider_name,
                 )
             except NotImplementedError:
                 continue
-            except Exception:
+            except Exception as exc:
+                breaker.record_failure()
+                err = f"provider={provider_name}, error={exc}"
+                errors.append(err)
+                logger.warning("OCR attempt failed: %s", err)
                 continue
 
-        return OCRResult(fields={}, raw_text="", processing_time_ms=0)
+        raise ProviderExhaustedError(
+            "All OCR providers were attempted and exhausted: " + " | ".join(errors),
+            details={"attempted": errors},
+        )

--- a/app/ai-service/services/providers.py
+++ b/app/ai-service/services/providers.py
@@ -29,6 +29,35 @@ from exceptions import AIServiceError
 logger = logging.getLogger(__name__)
 
 
+# Provider names that can appear in a configured fallback order. Kept here so
+# the registry and the configuration validator share a single source of truth.
+KNOWN_LLM_PROVIDERS = frozenset({"openai", "groq", "test"})
+KNOWN_OCR_PROVIDERS = frozenset({"test", "tesseract"})
+
+
+def validate_fallback_order(setting_name: str, order: "List[str]") -> None:
+    """Validate a configured provider fallback order.
+
+    Args:
+        setting_name: The configuration key being validated (for messages).
+        order: The ordered list of provider names from configuration.
+
+    Raises:
+        ValueError: if ``order`` references an unknown provider, contains
+            duplicates, or is empty.
+    """
+    known = KNOWN_LLM_PROVIDERS | KNOWN_OCR_PROVIDERS
+    if not order:
+        raise ValueError("must list at least one provider")
+    seen: "set[str]" = set()
+    for name in order:
+        if name not in known:
+            raise ValueError(f"references unknown provider {name!r}")
+        if name in seen:
+            raise ValueError(f"lists provider {name!r} more than once")
+        seen.add(name)
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -439,23 +468,41 @@ class ProviderRegistry:
         return available
 
     def resolve_llm(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:
-        """Return (name, provider) pairs in attempt order for LLM chat."""
-        available = self.available_llm_providers()
-        pref = (preference or "auto").lower()
-        if pref == "test" and "test" in available:
-            return [("test", self.get("test"))]
-        if pref in available:
-            ordered = [pref] + [p for p in available if p != pref]
-        else:
-            ordered = available
-        return [(name, self.get(name)) for name in ordered]
+        """Return (name, provider) pairs in attempt order for LLM chat.
+
+        The base attempt order is the operator-configured
+        ``settings.llm_provider_fallback_order``, filtered to the providers that
+        are actually available, preserving configuration order. An explicit
+        ``preference`` (other than ``"auto"``) is moved to the front so callers
+        can pin a provider without editing configuration.
+        """
+        return self._resolve(
+            available=self.available_llm_providers(),
+            configured_order=settings.get_llm_fallback_order(),
+            preference=preference,
+        )
 
     def resolve_ocr(self, preference: str = "auto") -> List[Tuple[str, ModelProvider]]:
-        """Return (name, provider) pairs in attempt order for OCR."""
-        available = self.available_ocr_providers()
+        """Return (name, provider) pairs in attempt order for OCR.
+
+        See :meth:`resolve_llm` for the ordering semantics. OCR does not
+        currently honour an explicit ``preference`` beyond the configured order.
+        """
+        return self._resolve(
+            available=self.available_ocr_providers(),
+            configured_order=settings.get_ocr_fallback_order(),
+            preference=preference,
+        )
+
+    def _resolve(
+        self,
+        available: List[str],
+        configured_order: List[str],
+        preference: str = "auto",
+    ) -> List[Tuple[str, ModelProvider]]:
+        available_set = set(available)
+        ordered = [name for name in configured_order if name in available_set]
         pref = (preference or "auto").lower()
-        if pref in available:
-            ordered = [pref] + [p for p in available if p != pref]
-        else:
-            ordered = available
+        if pref != "auto" and pref in ordered:
+            ordered = [pref] + [name for name in ordered if name != pref]
         return [(name, self.get(name)) for name in ordered]

--- a/app/ai-service/tests/test_config.py
+++ b/app/ai-service/tests/test_config.py
@@ -210,6 +210,49 @@ def test_missing_provider_in_production_names_every_option(monkeypatch):
     assert "TEST_PROVIDER_MODE" in message
 
 
+def test_fallback_order_defaults_validate(monkeypatch):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+    settings.validate_configuration()
+    assert settings.get_llm_fallback_order() == ["openai", "groq", "test"]
+    assert settings.get_ocr_fallback_order() == ["test", "tesseract"]
+
+
+def test_invalid_llm_fallback_order_rejected(monkeypatch):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+    settings.llm_provider_fallback_order = "openai,bogus"
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    message = str(excinfo.value)
+    assert "LLM_PROVIDER_FALLBACK_ORDER" in message
+    assert "bogus" in message
+
+
+def test_duplicate_llm_fallback_order_rejected(monkeypatch):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+    settings.llm_provider_fallback_order = "openai,openai"
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    assert "LLM_PROVIDER_FALLBACK_ORDER" in str(excinfo.value)
+
+
+def test_empty_llm_fallback_order_rejected(monkeypatch):
+    _isolate_env(monkeypatch)
+    settings = Settings(_env_file=None)
+    settings.llm_provider_fallback_order = ""
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        settings.validate_configuration()
+
+    assert "LLM_PROVIDER_FALLBACK_ORDER" in str(excinfo.value)
+
+
 def test_boot_report_logs_defaults_at_debug_level(monkeypatch, caplog):
     _isolate_env(monkeypatch)
     settings = Settings(_env_file=None)

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -1,6 +1,8 @@
 import pytest
 
 from config import settings
+from exceptions import ProviderExhaustedError
+from services.circuit_breaker import CircuitBreaker
 from services.humanitarian_verification import HumanitarianVerificationService
 from services.providers import (
     ProviderRegistry,
@@ -206,6 +208,117 @@ class TestHumanitarianVerificationService:
         )
 
         assert first_result == second_result
+
+    def test_verify_claim_records_serving_provider(self, monkeypatch):
+        """The provider that actually served the request is recorded on result."""
+        ok = MagicMock(spec=ModelProvider)
+        ok.name = "openai"
+        ok.llm_chat.return_value = LLMResponse(
+            content='{"verdict":"credible","confidence":0.9}', provider="openai", model="m"
+        )
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", ok)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "m"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Aid reached households.",
+            supporting_evidence=[],
+            context_factors={},
+            provider_preference="auto",
+        )
+        assert result["provider"] == "openai"
+
+    def test_verify_claim_follows_configured_fallback_order(self, monkeypatch):
+        """First configured provider is attempted first and, if it succeeds,
+        is the one recorded as serving the request."""
+        groq = MagicMock(spec=ModelProvider)
+        groq.name = "groq"
+        groq.llm_chat.return_value = LLMResponse(
+            content='{"verdict":"credible","confidence":0.9}', provider="groq", model="m"
+        )
+        openai = MagicMock(spec=ModelProvider)
+        openai.name = "openai"
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        # groq listed before openai -> configured cheapest/latency-first order
+        mock_registry.resolve_llm.return_value = [("groq", groq), ("openai", openai)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "m"
+        )
+
+        result = self.service.verify_claim(
+            aid_claim="Aid reached households.",
+            supporting_evidence=[],
+            context_factors={},
+            provider_preference="auto",
+        )
+        assert result["provider"] == "groq"
+        openai.llm_chat.assert_not_called()
+
+    def test_verify_claim_skips_open_circuit_provider(self, monkeypatch):
+        """Providers with an OPEN circuit breaker are skipped, not retried."""
+        openai = MagicMock(spec=ModelProvider)
+        openai.name = "openai"
+        groq = MagicMock(spec=ModelProvider)
+        groq.name = "groq"
+        groq.llm_chat.return_value = LLMResponse(
+            content='{"verdict":"credible","confidence":0.9}', provider="groq", model="m"
+        )
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", openai), ("groq", groq)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "m"
+        )
+
+        # Trip openai's breaker into the OPEN state.
+        breaker = CircuitBreaker(name="openai", failure_threshold=1)
+        breaker.record_failure()
+        self.service.breakers["openai"] = breaker
+
+        result = self.service.verify_claim(
+            aid_claim="Aid reached households.",
+            supporting_evidence=[],
+            context_factors={},
+            provider_preference="auto",
+        )
+        assert result["provider"] == "groq"
+        openai.llm_chat.assert_not_called()
+
+    def test_verify_claim_exhaustion_raises_distinct_error(self, monkeypatch):
+        """Exhausting every candidate provider yields a documented error."""
+        failing = MagicMock(spec=ModelProvider)
+        failing.name = "openai"
+        failing.llm_chat.side_effect = RuntimeError("boom")
+        groq = MagicMock(spec=ModelProvider)
+        groq.name = "groq"
+        groq.llm_chat.side_effect = RuntimeError("bang")
+
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_llm.return_value = [("openai", failing), ("groq", groq)]
+        monkeypatch.setattr(self.service, "registry", mock_registry)
+        monkeypatch.setattr(
+            self.service, "_get_model_for_provider", lambda provider: "m"
+        )
+
+        with pytest.raises(ProviderExhaustedError) as excinfo:
+            self.service.verify_claim(
+                aid_claim="Aid reached households.",
+                supporting_evidence=[],
+                context_factors={},
+                provider_preference="auto",
+            )
+        assert excinfo.value.code == "AI_PROVIDERS_EXHAUSTED"
+        assert isinstance(excinfo.value.details, dict)
+        attempted = excinfo.value.details["attempted"]
+        assert len(attempted) >= 2
+        assert any("openai" in entry for entry in attempted)
+        assert any("groq" in entry for entry in attempted)
 
 
 class TestTestProvider:

--- a/app/ai-service/tests/test_humanitarian_verification.py
+++ b/app/ai-service/tests/test_humanitarian_verification.py
@@ -214,7 +214,9 @@ class TestHumanitarianVerificationService:
         ok = MagicMock(spec=ModelProvider)
         ok.name = "openai"
         ok.llm_chat.return_value = LLMResponse(
-            content='{"verdict":"credible","confidence":0.9}', provider="openai", model="m"
+            content='{"verdict":"credible","confidence":0.9}',
+            provider="openai",
+            model="m",
         )
         mock_registry = MagicMock(spec=ProviderRegistry)
         mock_registry.resolve_llm.return_value = [("openai", ok)]
@@ -237,7 +239,9 @@ class TestHumanitarianVerificationService:
         groq = MagicMock(spec=ModelProvider)
         groq.name = "groq"
         groq.llm_chat.return_value = LLMResponse(
-            content='{"verdict":"credible","confidence":0.9}', provider="groq", model="m"
+            content='{"verdict":"credible","confidence":0.9}',
+            provider="groq",
+            model="m",
         )
         openai = MagicMock(spec=ModelProvider)
         openai.name = "openai"
@@ -266,7 +270,9 @@ class TestHumanitarianVerificationService:
         groq = MagicMock(spec=ModelProvider)
         groq.name = "groq"
         groq.llm_chat.return_value = LLMResponse(
-            content='{"verdict":"credible","confidence":0.9}', provider="groq", model="m"
+            content='{"verdict":"credible","confidence":0.9}',
+            provider="groq",
+            model="m",
         )
 
         mock_registry = MagicMock(spec=ProviderRegistry)

--- a/app/ai-service/tests/test_ocr.py
+++ b/app/ai-service/tests/test_ocr.py
@@ -1,5 +1,6 @@
 import pytest
 from dataclasses import dataclass
+from config import settings
 from services.ocr import FieldDetector, OCRService, FieldMatch, OCRResult
 from services.providers import ProviderRegistry, OCRField, OCRResponse, ModelProvider
 from services.circuit_breaker import CircuitBreaker
@@ -162,8 +163,13 @@ class TestOCRService:
         assert captured_hints == ["fra"]
         assert result.raw_text == "Name: Jane"
 
-    def test_process_image_empty_image(self):
+    def test_process_image_empty_image(self, monkeypatch):
         from PIL import Image
+
+        # Use the fixture provider so the test does not depend on a real OCR
+        # engine being available; it still exercises the degenerate-image path
+        # through the full service without exhausting providers.
+        monkeypatch.setattr(settings, "test_provider_mode", True)
 
         img = Image.new("RGB", (0, 0), color="white")
         result = self.ocr.process_image(img)

--- a/app/ai-service/tests/test_ocr.py
+++ b/app/ai-service/tests/test_ocr.py
@@ -2,6 +2,8 @@ import pytest
 from dataclasses import dataclass
 from services.ocr import FieldDetector, OCRService, FieldMatch, OCRResult
 from services.providers import ProviderRegistry, OCRField, OCRResponse, ModelProvider
+from services.circuit_breaker import CircuitBreaker
+from exceptions import ProviderExhaustedError
 from unittest.mock import patch, MagicMock
 
 
@@ -79,12 +81,16 @@ class StubOCRProvider(ModelProvider):
 
     def __init__(self, response):
         self._response = response
+        self._call_count = 0
 
     @property
     def name(self):
         return "stub"
 
     def ocr_extract(self, image, *, language_hint=None):
+        self._call_count += 1
+        if isinstance(self._response, Exception):
+            raise self._response
         return self._response
 
 
@@ -162,6 +168,85 @@ class TestOCRService:
         img = Image.new("RGB", (0, 0), color="white")
         result = self.ocr.process_image(img)
         assert isinstance(result, OCRResult)
+
+    @patch("metrics.PIPELINE_STEP_LATENCY.labels")
+    def test_process_image_records_serving_provider(self, mock_labels, monkeypatch):
+        from PIL import Image
+
+        mock_observe = MagicMock()
+        mock_labels.return_value.observe = mock_observe
+
+        stub_response = OCRResponse(
+            fields={"name": OCRField(value="John", confidence=0.9)},
+            raw_text="Name: John",
+            processing_time_ms=10,
+            provider="tesseract",
+        )
+        stub_provider = StubOCRProvider(stub_response)
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_ocr.return_value = [("tesseract", stub_provider)]
+        monkeypatch.setattr(self.ocr, "registry", mock_registry)
+
+        img = Image.new("RGB", (200, 100), color="white")
+        result = self.ocr.process_image(img)
+        assert result.provider == "tesseract"
+
+    @patch("metrics.PIPELINE_STEP_LATENCY.labels")
+    def test_process_image_skips_open_circuit_provider(self, mock_labels, monkeypatch):
+        from PIL import Image
+
+        mock_observe = MagicMock()
+        mock_labels.return_value.observe = mock_observe
+
+        tesseract = StubOCRProvider(
+            OCRResponse(
+                fields={}, raw_text="", processing_time_ms=1, provider="tesseract"
+            )
+        )
+        fallback = StubOCRProvider(
+            OCRResponse(
+                fields={"name": OCRField(value="Jane", confidence=0.9)},
+                raw_text="Name: Jane",
+                processing_time_ms=1,
+                provider="test",
+            )
+        )
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_ocr.return_value = [
+            ("tesseract", tesseract),
+            ("test", fallback),
+        ]
+        monkeypatch.setattr(self.ocr, "registry", mock_registry)
+
+        breaker = CircuitBreaker(name="tesseract", failure_threshold=1)
+        breaker.record_failure()
+        self.ocr.breakers["tesseract"] = breaker
+
+        img = Image.new("RGB", (200, 100), color="white")
+        result = self.ocr.process_image(img)
+        assert result.provider == "test"
+        # tesseract was skipped because its circuit is OPEN
+        assert tesseract._call_count == 0
+
+    @patch("metrics.PIPELINE_STEP_LATENCY.labels")
+    def test_process_image_exhaustion_raises_distinct_error(
+        self, mock_labels, monkeypatch
+    ):
+        from PIL import Image
+
+        mock_observe = MagicMock()
+        mock_labels.return_value.observe = mock_observe
+
+        failing = StubOCRProvider(RuntimeError("ocr boom"))
+        mock_registry = MagicMock(spec=ProviderRegistry)
+        mock_registry.resolve_ocr.return_value = [("tesseract", failing)]
+        monkeypatch.setattr(self.ocr, "registry", mock_registry)
+
+        img = Image.new("RGB", (200, 100), color="white")
+        with pytest.raises(ProviderExhaustedError) as excinfo:
+            self.ocr.process_image(img)
+        assert excinfo.value.code == "AI_PROVIDERS_EXHAUSTED"
+        assert excinfo.value.details["attempted"]
 
 
 class TestOCRResult:

--- a/app/ai-service/tests/test_providers.py
+++ b/app/ai-service/tests/test_providers.py
@@ -182,7 +182,11 @@ class TestProviderRegistry:
             mock_settings.test_provider_mode = False
             mock_settings.openai_api_key = "key"
             mock_settings.groq_api_key = None
-            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq", "test"]
+            mock_settings.get_llm_fallback_order.return_value = [
+                "openai",
+                "groq",
+                "test",
+            ]
             result = self.registry.resolve_llm("auto")
             names = [n for n, _ in result]
             assert names == ["openai"]
@@ -212,7 +216,11 @@ class TestProviderRegistry:
             mock_settings.test_provider_mode = True
             mock_settings.openai_api_key = None
             mock_settings.groq_api_key = None
-            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq", "test"]
+            mock_settings.get_llm_fallback_order.return_value = [
+                "openai",
+                "groq",
+                "test",
+            ]
             result = self.registry.resolve_llm("test")
             names = [n for n, _ in result]
             assert names == ["test"]
@@ -238,7 +246,9 @@ class TestProviderRegistry:
 
 class TestFallbackOrderValidation:
     def test_valid_order_passes(self):
-        validate_fallback_order("LLM_PROVIDER_FALLBACK_ORDER", ["openai", "groq", "test"])
+        validate_fallback_order(
+            "LLM_PROVIDER_FALLBACK_ORDER", ["openai", "groq", "test"]
+        )
 
     def test_empty_order_rejected(self):
         with pytest.raises(ValueError, match="at least one provider"):

--- a/app/ai-service/tests/test_providers.py
+++ b/app/ai-service/tests/test_providers.py
@@ -13,6 +13,7 @@ from services.providers import (
     GroqProvider,
     FixtureProvider,
     TesseractOCRProvider,
+    validate_fallback_order,
 )
 
 # ---------------------------------------------------------------------------
@@ -161,16 +162,37 @@ class TestProviderRegistry:
             mock_settings.test_provider_mode = False
             mock_settings.openai_api_key = "key"
             mock_settings.groq_api_key = "key"
+            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq"]
             result = self.registry.resolve_llm("auto")
             names = [n for n, _ in result]
-            assert "openai" in names
-            assert "groq" in names
+            assert names == ["openai", "groq"]
+
+    def test_resolve_llm_follows_configured_order(self):
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = "key"
+            mock_settings.get_llm_fallback_order.return_value = ["groq", "openai"]
+            result = self.registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+            assert names == ["groq", "openai"]
+
+    def test_resolve_llm_skips_unavailable_providers_in_config(self):
+        with patch("services.providers.settings") as mock_settings:
+            mock_settings.test_provider_mode = False
+            mock_settings.openai_api_key = "key"
+            mock_settings.groq_api_key = None
+            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq", "test"]
+            result = self.registry.resolve_llm("auto")
+            names = [n for n, _ in result]
+            assert names == ["openai"]
 
     def test_resolve_llm_preference_openai_first(self):
         with patch("services.providers.settings") as mock_settings:
             mock_settings.test_provider_mode = False
             mock_settings.openai_api_key = "key"
             mock_settings.groq_api_key = "key"
+            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq"]
             result = self.registry.resolve_llm("openai")
             names = [n for n, _ in result]
             assert names[0] == "openai"
@@ -180,6 +202,7 @@ class TestProviderRegistry:
             mock_settings.test_provider_mode = False
             mock_settings.openai_api_key = "key"
             mock_settings.groq_api_key = "key"
+            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq"]
             result = self.registry.resolve_llm("groq")
             names = [n for n, _ in result]
             assert names[0] == "groq"
@@ -189,6 +212,7 @@ class TestProviderRegistry:
             mock_settings.test_provider_mode = True
             mock_settings.openai_api_key = None
             mock_settings.groq_api_key = None
+            mock_settings.get_llm_fallback_order.return_value = ["openai", "groq", "test"]
             result = self.registry.resolve_llm("test")
             names = [n for n, _ in result]
             assert names == ["test"]
@@ -196,6 +220,7 @@ class TestProviderRegistry:
     def test_resolve_ocr_test_mode(self):
         with patch("services.providers.settings") as mock_settings:
             mock_settings.test_provider_mode = True
+            mock_settings.get_ocr_fallback_order.return_value = ["test", "tesseract"]
             result = self.registry.resolve_ocr()
             names = [n for n, _ in result]
             assert names[0] == "test"
@@ -204,10 +229,28 @@ class TestProviderRegistry:
     def test_resolve_ocr_production(self):
         with patch("services.providers.settings") as mock_settings:
             mock_settings.test_provider_mode = False
+            mock_settings.get_ocr_fallback_order.return_value = ["test", "tesseract"]
             result = self.registry.resolve_ocr()
             names = [n for n, _ in result]
             assert "tesseract" in names
             assert "test" not in names
+
+
+class TestFallbackOrderValidation:
+    def test_valid_order_passes(self):
+        validate_fallback_order("LLM_PROVIDER_FALLBACK_ORDER", ["openai", "groq", "test"])
+
+    def test_empty_order_rejected(self):
+        with pytest.raises(ValueError, match="at least one provider"):
+            validate_fallback_order("LLM_PROVIDER_FALLBACK_ORDER", [])
+
+    def test_unknown_provider_rejected(self):
+        with pytest.raises(ValueError, match="unknown provider"):
+            validate_fallback_order("LLM_PROVIDER_FALLBACK_ORDER", ["openai", "bogus"])
+
+    def test_duplicate_provider_rejected(self):
+        with pytest.raises(ValueError, match="more than once"):
+            validate_fallback_order("LLM_PROVIDER_FALLBACK_ORDER", ["openai", "openai"])
 
 
 # ---------------------------------------------------------------------------

--- a/app/ai-service/tests/test_test_provider_stability.py
+++ b/app/ai-service/tests/test_test_provider_stability.py
@@ -211,9 +211,10 @@ class TestOCRTestProviderStability:
         mock_registry.resolve_ocr.return_value = [("failing", failing_provider)]
         monkeypatch.setattr(self.service, "registry", mock_registry)
 
-        result = self.service.process_image(img)
-        assert result.raw_text == ""
-        assert result.fields == {}
+        from exceptions import ProviderExhaustedError
+
+        with pytest.raises(ProviderExhaustedError):
+            self.service.process_image(img)
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #982 — `providers.py` auto-fallback order was implicit in source; operators could not express a preference (e.g. cheapest-first) without editing code.

- **Configurable fallback order:** new `LLM_PROVIDER_FALLBACK_ORDER` and `OCR_PROVIDER_FALLBACK_ORDER` settings (comma-separated, e.g. `groq,openai,test`).
- **Validated at startup:** `validate_configuration()` rejects unknown/duplicate/empty provider names with a `ConfigurationError` naming the offending entry.
- **Explicit ordering:** `ProviderRegistry.resolve_llm`/`resolve_ocr` now order candidates strictly by the configured list (intersected with available providers), replacing the implicit `auto` ordering.
- **Serving provider recorded:** `OCRResult.provider` (and existing LLM `result["provider"]`) records which provider actually served the request.
- **Open circuits skipped:** `OCRService` now skips providers with an OPEN circuit breaker (mirroring existing `HumanitarianVerificationService` behaviour) rather than retrying them.
- **Distinct exhaustion error:** a new `ProviderExhaustedError` (`AI_PROVIDERS_EXHAUSTED`) is raised when every candidate provider is exhausted, carrying per-provider failure details.

## Test plan

- Added/updated tests in `test_config.py`, `test_providers.py`, `test_humanitarian_verification.py`, `test_ocr.py`, and `test_provider_stability.py` covering ordering, circuit-breaker skipping, provider recording, and exhaustion.
- Full `tests/` run (excluding 3 pre-existing, environment-specific failures) passes: 557 passed, 4 skipped.