### PR TITLE
feat(ci): gate gas and resource regressions in CI (#970)

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -43,3 +43,15 @@ jobs:
 
       - name: Run tests
         run: cargo test --target x86_64-unknown-linux-gnu
+
+      - name: Gate gas / resource regressions
+        run: |
+          cargo test --target x86_64-unknown-linux-gnu --test gas_profiling -- --nocapture
+          python3 scripts/check_gas_budgets.py
+
+      - name: Upload gas metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gas-metrics
+          path: target/gas_metrics

--- a/app/onchain/contracts/aid_escrow/GAS_PROFILING_REPORT.md
+++ b/app/onchain/contracts/aid_escrow/GAS_PROFILING_REPORT.md
@@ -101,6 +101,55 @@ Potential future focus:
 - consider more direct aggregate accounting for heavily-used read paths
 - evaluate recipient-specific indexing if dashboard queries become expensive
 
+## CI Regression Gate (Budgets)
+
+Profiling alone does not stop a pull request from making a hot path materially
+more expensive. A committed budget file now acts as the gate:
+
+- `gas_budgets.json` — the source of truth for allowed costs per entry point.
+  Each entry lists `cpu_instructions` and `memory_bytes` ceilings, plus a
+  `tolerance` (default ±15%) that absorbs normal measurement noise.
+- `tests/gas_profiling.rs` — every profiling test now records its measured
+  cost to `target/gas_metrics/<operation>.json` (machine-readable).
+- `scripts/check_gas_budgets.py` — the CI gate. It reads the budgets and the
+  recorded metrics, compares them, and **fails the build** when any measured
+  cost exceeds its budget beyond tolerance. The failure message names the
+  entry point and the CPU/memory delta vs budget so the regression is
+  actionable.
+
+### How a regression is caught
+
+1. A PR changes contract logic, making `claim` ~30% more expensive.
+2. The gate step runs `cargo test --test gas_profiling` (producing the metrics)
+   then `python3 scripts/check_gas_budgets.py`.
+3. The script prints `[REGRESSION] claim` with the CPU/Memory delta and exits
+   non-zero, failing the `Contract CI` job.
+
+### Tolerating noise
+
+Budgets are deterministic (Soroban meters guest VM instructions, not wall
+clock), so the same code yields the same numbers across machines. The
+`tolerance` band still permits minor runtime variance without a false failure.
+
+### Updating a budget deliberately
+
+Budgets are only changed in a reviewed commit. To refresh a baseline after an
+intentional, approved cost change:
+
+```bash
+cd app/onchain
+SOTER_UPDATE_GAS_BUDGETS=1 cargo test --test gas_profiling
+# review the diff in contracts/aid_escrow/gas_budgets.json, then commit it
+```
+
+### Re-running the gate locally
+
+```bash
+cd app/onchain
+cargo test --test gas_profiling -- --nocapture
+python3 scripts/check_gas_budgets.py
+```
+
 ## Validation Summary
 
 - Baseline profiling now explicitly covers **create / claim / refund** as requested.
@@ -109,5 +158,8 @@ Potential future focus:
 
 ## Files Updated
 
-- `app/onchain/contracts/aid_escrow/tests/gas_profiling.rs`
+- `app/onchain/contracts/aid_escrow/tests/gas_profiling.rs` (records metrics)
+- `app/onchain/contracts/aid_escrow/gas_budgets.json` (committed budgets + tolerance)
+- `app/onchain/scripts/check_gas_budgets.py` (CI regression gate)
+- `.github/workflows/contract-ci.yml` (gate step + metrics artifact upload)
 - `app/onchain/contracts/aid_escrow/GAS_PROFILING_REPORT.md`

--- a/app/onchain/contracts/aid_escrow/gas_budgets.json
+++ b/app/onchain/contracts/aid_escrow/gas_budgets.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Committed gas/resource budgets for aid_escrow entry points. Each budget is the maximum allowed cost (CPU instructions and memory bytes) for a single invocation of that entry point. CI (scripts/check_gas_budgets.py) fails when a measured cost exceeds a budget beyond `tolerance`. The cost model is deterministic, so these baselines reproduce across machines; the tolerance absorbs normal measurement noise. Read entry points (get_package, get_aggregates) meter at ~0 in the test VM, so they carry a small slack budget rather than 0 to avoid false failures on noise while still catching large regressions. To update a budget deliberately, run the gas profiling tests with SOTER_UPDATE_GAS_BUDGETS=1 (locally) and commit the resulting file in a reviewed PR.",
+  "tolerance": {
+    "cpu_instructions_pct": 15,
+    "memory_bytes_pct": 15
+  },
+  "budgets": {
+    "create_package": { "cpu_instructions": 95252, "memory_bytes": 18915 },
+    "claim": { "cpu_instructions": 122082, "memory_bytes": 19760 },
+    "refund": { "cpu_instructions": 83260, "memory_bytes": 9995 },
+    "claim_with_proof": { "cpu_instructions": 214434, "memory_bytes": 29171 },
+    "fund": { "cpu_instructions": 114631, "memory_bytes": 16791 },
+    "get_package": { "cpu_instructions": 256, "memory_bytes": 1024 },
+    "get_aggregates": { "cpu_instructions": 256, "memory_bytes": 1024 },
+    "batch_create_packages_10": { "cpu_instructions": 658368, "memory_bytes": 133314 },
+    "batch_create_packages_25": { "cpu_instructions": 2084932, "memory_bytes": 458679 },
+    "batch_create_packages_50": { "cpu_instructions": 5774523, "memory_bytes": 1376954 },
+    "batch_create_packages_100": { "cpu_instructions": 17965494, "memory_bytes": 4623504 },
+    "batch_create_packages_200": { "cpu_instructions": 61378004, "memory_bytes": 16756604 }
+  }
+}

--- a/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
+++ b/app/onchain/contracts/aid_escrow/tests/gas_profiling.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
+use std::path::Path;
+
 use aid_escrow::{AidEscrow, AidEscrowClient, Config};
+use serde_json::json;
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     token::StellarAssetClient,
@@ -111,6 +114,76 @@ fn print_budget_metrics(operation: &str, metrics: &BudgetMetrics) {
     println!();
 }
 
+// ---------------------------------------------------------------------------
+// Budget gate artifacts + deliberate budget updates
+// ---------------------------------------------------------------------------
+
+/// Artifacts are written into the workspace `target` dir so they are gitignored
+/// and discoverable by the CI budget-gate script (`scripts/check_gas_budgets.py`).
+fn metrics_dir() -> std::path::PathBuf {
+    // CARGO_MANIFEST_DIR is the package dir (app/onchain/contracts/aid_escrow);
+    // walk up two levels to the workspace (app/onchain) and into its target.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("target/gas_metrics")
+}
+
+/// Persist a measured cost for one entry point so the CI budget-gate can
+/// compare it against the committed budgets in `gas_budgets.json`.
+fn record_metrics(operation: &str, size: u32, metrics: &BudgetMetrics) {
+    let dir = metrics_dir();
+    let _ = std::fs::create_dir_all(&dir);
+    let file_name = format!("{}.json", operation);
+    let record = json!({
+        "operation": operation,
+        "size": size,
+        "cpu_instructions": metrics.cpu_instructions,
+        "memory_bytes": metrics.memory_bytes,
+    });
+    if let Ok(contents) = serde_json::to_string_pretty(&record) {
+        let _ = std::fs::write(dir.join(file_name), contents);
+    }
+    maybe_update_budgets(operation, size, metrics);
+}
+
+/// When `SOTER_UPDATE_GAS_BUDGETS=1` is set, rewrite `gas_budgets.json` with
+/// the just-measured values. This is the deliberate, reviewable way to bump a
+/// budget after an intentional cost change (commit the result in a reviewed PR).
+fn maybe_update_budgets(operation: &str, size: u32, metrics: &BudgetMetrics) {
+    if std::env::var("SOTER_UPDATE_GAS_BUDGETS").is_err() {
+        return;
+    }
+    let budgets_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("gas_budgets.json");
+    let mut budgets: serde_json::Value = if budgets_path.exists() {
+        serde_json::from_str(&std::fs::read_to_string(&budgets_path).unwrap_or_default())
+            .unwrap_or_else(|_| json!({ "tolerance": default_tolerance(), "budgets": {} }))
+    } else {
+        json!({ "tolerance": default_tolerance(), "budgets": {} })
+    };
+    let (cpu, mem) = if size > 1 {
+        (
+            metrics.cpu_instructions / size as u64,
+            metrics.memory_bytes / size as u64,
+        )
+    } else {
+        (metrics.cpu_instructions, metrics.memory_bytes)
+    };
+    budgets["budgets"][operation] = json!({
+        "cpu_instructions": cpu,
+        "memory_bytes": mem,
+    });
+    if let Ok(contents) = serde_json::to_string_pretty(&budgets) {
+        let _ = std::fs::write(&budgets_path, contents);
+    }
+}
+
+fn default_tolerance() -> serde_json::Value {
+    json!({ "cpu_instructions_pct": 15, "memory_bytes_pct": 15 })
+}
+
 fn new_metadata(env: &Env) -> Map<Symbol, soroban_sdk::String> {
     Map::new(env)
 }
@@ -144,6 +217,7 @@ fn profile_single_create_package() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Single create_package", &metrics);
+    record_metrics("create_package", 1, &metrics);
 }
 
 #[test]
@@ -170,6 +244,7 @@ fn profile_single_claim() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Single claim", &metrics);
+    record_metrics("claim", 1, &metrics);
 }
 
 #[test]
@@ -198,6 +273,7 @@ fn profile_single_refund() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Single refund", &metrics);
+    record_metrics("refund", 1, &metrics);
 }
 
 #[test]
@@ -260,6 +336,12 @@ fn profile_batch_create(batch_size: u32) {
     println!("  Per-package CPU: {}", per_package_cpu);
     println!("  Per-package Memory: {}", per_package_memory);
     println!();
+
+    record_metrics(
+        &format!("batch_create_packages_{}", batch_size),
+        batch_size,
+        &metrics,
+    );
 }
 
 #[test]
@@ -311,6 +393,7 @@ fn profile_claim_with_proof() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Claim with Merkle proof", &metrics);
+    record_metrics("claim_with_proof", 1, &metrics);
 }
 
 #[test]
@@ -325,6 +408,7 @@ fn profile_fund_operation() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Fund operation (1 token)", &metrics);
+    record_metrics("fund", 1, &metrics);
 }
 
 #[test]
@@ -351,6 +435,7 @@ fn profile_get_package() {
     let metrics = diff_budget(&before, &after);
 
     print_budget_metrics("Get package", &metrics);
+    record_metrics("get_package", 1, &metrics);
 }
 
 #[test]
@@ -383,4 +468,5 @@ fn profile_get_aggregates() {
         &format!("Get aggregates ({} packages)", batch_size),
         &metrics,
     );
+    record_metrics("get_aggregates", 1, &metrics);
 }

--- a/app/onchain/scripts/check_gas_budgets.py
+++ b/app/onchain/scripts/check_gas_budgets.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Gate gas / resource regressions against committed budgets.
+
+Reads `gas_budgets.json` (committed budgets + tolerance) and the per-operation
+metrics artifacts produced by the gas profiling tests, then fails the build
+when any measured cost exceeds its budget beyond the allowed tolerance.
+
+The failure output names the entry point and the delta vs budget so a
+regression is actionable.
+
+Usage:
+    python3 check_gas_budgets.py \
+        [--budgets path/to/gas_budgets.json] \
+        [--metrics-dir path/to/target/gas_metrics]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def default_budgets_path() -> Path:
+    here = Path(__file__).resolve().parent
+    return here.parent / "contracts" / "aid_escrow" / "gas_budgets.json"
+
+
+def default_metrics_dir() -> Path:
+    here = Path(__file__).resolve().parent
+    return here.parent / "target" / "gas_metrics"
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def fmt(n: int) -> str:
+    return f"{n:,}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--budgets", type=Path, default=default_budgets_path())
+    parser.add_argument("--metrics-dir", type=Path, default=default_metrics_dir())
+    args = parser.parse_args()
+
+    budgets_path: Path = args.budgets
+    metrics_dir: Path = args.metrics_dir
+
+    if not budgets_path.exists():
+        print(f"ERROR: budgets file not found: {budgets_path}", file=sys.stderr)
+        return 2
+    if not metrics_dir.exists():
+        print(f"ERROR: metrics dir not found: {metrics_dir}", file=sys.stderr)
+        print("       Did the gas profiling tests run?", file=sys.stderr)
+        return 2
+
+    budgets_doc = load_json(budgets_path)
+    tolerance = budgets_doc.get("tolerance", {})
+    cpu_pct = float(tolerance.get("cpu_instructions_pct", 0))
+    mem_pct = float(tolerance.get("memory_bytes_pct", 0))
+    budgets = budgets_doc.get("budgets", {})
+
+    metric_files = sorted(metrics_dir.glob("*.json"))
+    if not metric_files:
+        print(f"ERROR: no gas metric artifacts found in {metrics_dir}", file=sys.stderr)
+        return 2
+
+    regressions = []
+
+    print("=" * 78)
+    print("Gas / resource budget gate")
+    print(f"  budgets : {budgets_path}")
+    print(f"  metrics : {metrics_dir}")
+    print(f"  tolerance: cpu +{cpu_pct:g}%  memory +{mem_pct:g}%")
+    print("=" * 78)
+
+    for mf in metric_files:
+        metric = load_json(mf)
+        operation = metric["operation"]
+        size = int(metric.get("size", 1))
+        measured_cpu = int(metric["cpu_instructions"])
+        measured_mem = int(metric["memory_bytes"])
+
+        if operation not in budgets:
+            print(f"\n[CONFIG ERROR] {operation}: no committed budget")
+            print("    Add an entry under `budgets` in gas_budgets.json.")
+            regressions.append((operation, "missing budget", 0, 0, 0, 0))
+            continue
+
+        budget = budgets[operation]
+        base_cpu = int(budget["cpu_instructions"])
+        base_mem = int(budget["memory_bytes"])
+
+        norm_cpu = measured_cpu
+        norm_mem = measured_mem
+        scope = operation if size <= 1 else f"{operation} (batch size {size})"
+
+        allowed_cpu = base_cpu * (1 + cpu_pct / 100.0)
+        allowed_mem = base_mem * (1 + mem_pct / 100.0)
+
+        cpu_over = norm_cpu > allowed_cpu
+        mem_over = norm_mem > allowed_mem
+
+        delta_cpu = norm_cpu - base_cpu
+        delta_mem = norm_mem - base_mem
+
+        status = "OK"
+        if cpu_over or mem_over:
+            status = "REGRESSION"
+            regressions.append(
+                (operation, scope, norm_cpu, base_cpu, norm_mem, base_mem)
+            )
+
+        print(f"\n[{status}] {scope}")
+        if base_cpu:
+            print(
+                f"    CPU     : measured {fmt(norm_cpu)}  budget {fmt(base_cpu)}  "
+                f"allowed {fmt(int(allowed_cpu))}  delta {fmt(delta_cpu)} "
+                f"({delta_cpu / base_cpu * 100:+.1f}%)"
+            )
+        else:
+            print(f"    CPU     : measured {fmt(norm_cpu)}  budget {fmt(base_cpu)}")
+        if base_mem:
+            print(
+                f"    Memory  : measured {fmt(norm_mem)}  budget {fmt(base_mem)}  "
+                f"allowed {fmt(int(allowed_mem))}  delta {fmt(delta_mem)} "
+                f"({delta_mem / base_mem * 100:+.1f}%)"
+            )
+        else:
+            print(f"    Memory  : measured {fmt(norm_mem)}  budget {fmt(base_mem)}")
+
+    print("\n" + "=" * 78)
+    if regressions:
+        print(f"FAILED: {len(regressions)} gas/resource regression(s) detected:")
+        for op, scope, norm_cpu, base_cpu, norm_mem, base_mem in regressions:
+            if scope == "missing budget":
+                print(f"  - {op}: missing committed budget")
+                continue
+            delta_cpu = norm_cpu - base_cpu
+            delta_mem = norm_mem - base_mem
+            print(
+                f"  - {op}: CPU delta {fmt(delta_cpu)} "
+                f"({delta_cpu / base_cpu * 100 if base_cpu else 0:+.1f}%), "
+                f"Memory delta {fmt(delta_mem)} "
+                f"({delta_mem / base_mem * 100 if base_mem else 0:+.1f}%)"
+            )
+        print("=" * 78)
+        return 1
+
+    print("PASSED: all measured entry points are within committed budgets.")
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Overview

`GAS_PROFILING_REPORT.md` and `tests/gas_profiling.rs` already captured resource usage, but nothing failed a pull request that made a hot path materially more expensive — so cost regressions reached testnet unnoticed. This PR adds a **committed-budget CI gate** that fails the build when a contract entry point's measured CPU/memory cost exceeds its budget beyond an allowed tolerance, and names the function and the delta when it does.

## Related Issue

Closes #970

## Changes

### 🛡️ Budget gate

-   **\[ADD\]** `app/onchain/contracts/aid_escrow/gas_budgets.json`
    -   Committed per-entry-point CPU-instruction and memory-byte ceilings for `create_package`, `claim`, `refund`, `claim_with_proof`, `fund`, `get_package`, `get_aggregates`, and `batch_create_packages` (sizes 10/25/50/100/200).
    -   `tolerance` band (±15%) that absorbs normal measurement noise.
-   **\[ADD\]** `app/onchain/scripts/check_gas_budgets.py`
    -   Reads the budgets and the recorded metrics, compares them, and **fails (exit 1) when a measured cost exceeds its budget beyond tolerance**.
    -   Prints a per-entry-point table and, on regression, names the entry point and the CPU/Memory delta (e.g. `- claim: CPU delta 52,495 (+43.0%), Memory delta 8,497 (+43.0%)`).

### 🧪 Profiling tests

-   **\[MODIFY\]** `app/onchain/contracts/aid_escrow/tests/gas_profiling.rs`
    -   Every profiling test now records its measured cost to `target/gas_metrics/<operation>.json` (machine-readable artifact).
    -   Supports `SOTER_UPDATE_GAS_BUDGETS=1` to deliberately rewrite `gas_budgets.json` in a reviewed commit.

### ⚙️ CI

-   **\[MODIFY\]** `.github/workflows/contract-ci.yml`
    -   Adds a `Gate gas / resource regressions` step that runs the profiling tests then the gate script.
    -   Uploads `target/gas_metrics` as a build artifact for debugging.

### 📝 Docs

-   **\[MODIFY\]** `app/onchain/contracts/aid_escrow/GAS_PROFILING_REPORT.md`
    -   Documents the gate, noise tolerance, and the deliberate budget-update workflow.

## Verification Results

```
cargo test --test gas_profiling
✅ 12/12 tests passed

python3 scripts/check_gas_budgets.py   (baseline vs committed budgets)
✅ PASSED: all measured entry points are within committed budgets

Regression check (one budget shrunk deliberately):
✅ FAILS the build, names the entry point + CPU/Memory delta

Noise check:
✅ +10% over budget  -> still PASSED (within ±15% tolerance)
✅ +30% over budget  -> FAILED, names the entry point + delta

cargo clippy --test gas_profiling -- -D warnings
✅ clean (no warnings)
```

Baseline budgets captured (representative):

| Entry point | CPU instructions | Memory bytes |
|---|---|---|
| `create_package` | 95,252 | 18,915 |
| `claim` | 122,082 | 19,760 |
| `refund` | 83,260 | 9,995 |
| `claim_with_proof` | 214,434 | 29,171 |
| `fund` | 114,631 | 16,791 |
| `batch_create_packages_10` | 658,368 | 133,314 |
| `batch_create_packages_200` | 61,378,004 | 16,756,604 |

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Committed budgets exist for the main entry points | ✅ `gas_budgets.json` |
| CI fails when measured usage exceeds a budget beyond an allowed tolerance | ✅ `check_gas_budgets.py` + Contract CI step |
| The failure message names the function and the delta | ✅ e.g. `- claim: CPU delta … (+43.0%), Memory delta … (+43.0%)` |
| Budgets can be updated deliberately in a reviewed commit | ✅ `SOTER_UPDATE_GAS_BUDGETS=1` rewrites the committed file |
| The workflow tolerates normal measurement noise | ✅ `tolerance` ±15%; +10% still passes |
