### PR TITLE
feat(observability): expose evidence queue SLA metrics (#954)

### DIFF
--- a/app/backend/README.md
+++ b/app/backend/README.md
@@ -243,6 +243,11 @@ curl http://localhost:3001/metrics
 - `jobs_processed_total` / `jobs_failed_total` - Background job success/failure rates
 - `onchain_operations_total` - On-chain operation counts by status
 
+**Evidence Queue SLA metrics (issue #954):**
+- `evidence_queue_depth{status}` - Current count of evidence queue items per `EvidenceStatus` (`pending`, `uploading`, `completed`, `failed`). Refreshed every 30 seconds.
+- `evidence_queue_oldest_pending_age_seconds` - Age in seconds of the oldest evidence queue item that is still in a non-terminal status (`pending` or `uploading`). Reports `0` when the active queue is empty. Refreshed every 30 seconds.
+- `evidence_queue_intake_to_decision_seconds{decision}` - Histogram recording the elapsed time from evidence intake (`createdAt`) to the moment the item reaches a terminal status. The `decision` label is either `completed` or `failed`. Observed inline when `EvidenceService.processUpload()` transitions an item to a terminal state. SLA-oriented buckets: 60 s, 5 min, 15 min, 30 min, 1 h, 2 h, 24 h.
+
 **Structured logging fields:**
 - `request_id` - Unique identifier for each request (from X-Request-ID header)
 - `user_id` - User identifier from JWT token

--- a/app/backend/src/evidence/evidence-queue-metrics.scheduler.spec.ts
+++ b/app/backend/src/evidence/evidence-queue-metrics.scheduler.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EvidenceStatus } from '@prisma/client';
+import { EvidenceQueueMetricsScheduler } from './evidence-queue-metrics.scheduler';
+import { MetricsService } from '../observability/metrics/metrics.service';
+
+/**
+ * Unit tests for EvidenceQueueMetricsScheduler (issue #954).
+ *
+ * PrismaService and MetricsService are both replaced with Jest mocks so the
+ * scheduler logic can be tested in isolation without a real database or
+ * Prometheus registry.
+ */
+describe('EvidenceQueueMetricsScheduler', () => {
+  let scheduler: EvidenceQueueMetricsScheduler;
+
+  const mockPrisma = {
+    evidenceQueueItem: {
+      groupBy: jest.fn(),
+      findFirst: jest.fn(),
+    },
+  };
+
+  const mockMetrics = {
+    setEvidenceQueueDepth: jest.fn(),
+    setEvidenceQueueOldestPendingAge: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EvidenceQueueMetricsScheduler,
+        { provide: 'PrismaService', useValue: mockPrisma },
+        { provide: MetricsService, useValue: mockMetrics },
+      ],
+    })
+      .overrideProvider('PrismaService')
+      .useValue(mockPrisma)
+      .compile();
+
+    scheduler = module.get<EvidenceQueueMetricsScheduler>(
+      EvidenceQueueMetricsScheduler,
+    );
+
+    // Replace the private prisma reference with the mock directly so the
+    // scheduler uses our stub regardless of DI token naming.
+    (scheduler as unknown as Record<string, unknown>)['prisma'] = mockPrisma;
+    (scheduler as unknown as Record<string, unknown>)['metrics'] = mockMetrics;
+  });
+
+  describe('refreshEvidenceQueueMetrics', () => {
+    it('sets queue depth for all statuses using DB counts', async () => {
+      mockPrisma.evidenceQueueItem.groupBy.mockResolvedValueOnce([
+        { status: EvidenceStatus.pending, _count: { id: 4 } },
+        { status: EvidenceStatus.uploading, _count: { id: 1 } },
+        { status: EvidenceStatus.completed, _count: { id: 20 } },
+        // failed is deliberately missing — should be zero-filled
+      ]);
+      mockPrisma.evidenceQueueItem.findFirst.mockResolvedValueOnce(null);
+
+      await scheduler.refreshEvidenceQueueMetrics();
+
+      expect(mockMetrics.setEvidenceQueueDepth).toHaveBeenCalledWith(
+        EvidenceStatus.pending,
+        4,
+      );
+      expect(mockMetrics.setEvidenceQueueDepth).toHaveBeenCalledWith(
+        EvidenceStatus.uploading,
+        1,
+      );
+      expect(mockMetrics.setEvidenceQueueDepth).toHaveBeenCalledWith(
+        EvidenceStatus.completed,
+        20,
+      );
+      // Zero-fill for missing status
+      expect(mockMetrics.setEvidenceQueueDepth).toHaveBeenCalledWith(
+        EvidenceStatus.failed,
+        0,
+      );
+    });
+
+    it('sets oldest pending age from the oldest non-terminal item', async () => {
+      const createdAt = new Date(Date.now() - 90_000); // 90 seconds ago
+      mockPrisma.evidenceQueueItem.groupBy.mockResolvedValueOnce([]);
+      mockPrisma.evidenceQueueItem.findFirst.mockResolvedValueOnce({
+        createdAt,
+      });
+
+      await scheduler.refreshEvidenceQueueMetrics();
+
+      const call = mockMetrics.setEvidenceQueueOldestPendingAge.mock.calls[0];
+      const reportedAge: number = call[0];
+
+      // Allow ±2 s tolerance for test timing jitter
+      expect(reportedAge).toBeGreaterThanOrEqual(88);
+      expect(reportedAge).toBeLessThanOrEqual(92);
+    });
+
+    it('sets oldest pending age to 0 when there are no non-terminal items', async () => {
+      mockPrisma.evidenceQueueItem.groupBy.mockResolvedValueOnce([]);
+      mockPrisma.evidenceQueueItem.findFirst.mockResolvedValueOnce(null);
+
+      await scheduler.refreshEvidenceQueueMetrics();
+
+      expect(mockMetrics.setEvidenceQueueOldestPendingAge).toHaveBeenCalledWith(
+        0,
+      );
+    });
+
+    it('does not throw when the DB call rejects — logs the error instead', async () => {
+      mockPrisma.evidenceQueueItem.groupBy.mockRejectedValueOnce(
+        new Error('DB timeout'),
+      );
+      mockPrisma.evidenceQueueItem.findFirst.mockResolvedValueOnce(null);
+
+      // Should not throw
+      await expect(
+        scheduler.refreshEvidenceQueueMetrics(),
+      ).resolves.toBeUndefined();
+
+      // Metrics should not have been set on failure
+      expect(mockMetrics.setEvidenceQueueDepth).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/backend/src/evidence/evidence-queue-metrics.scheduler.ts
+++ b/app/backend/src/evidence/evidence-queue-metrics.scheduler.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { EvidenceStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
+
+/**
+ * Periodically refreshes Evidence Queue SLA gauges (issue #954).
+ *
+ * Two gauges are polled on a 30-second schedule:
+ *   - evidence_queue_depth{status}         – count per EvidenceStatus
+ *   - evidence_queue_oldest_pending_age_seconds – age of the oldest non-terminal item
+ *
+ * The intake-to-decision histogram is NOT driven from here; it is observed
+ * inline inside EvidenceService.processUpload() at the moment an item
+ * transitions to a terminal status.
+ */
+@Injectable()
+export class EvidenceQueueMetricsScheduler {
+  private readonly logger = new Logger(EvidenceQueueMetricsScheduler.name);
+
+  /** Statuses that are still "in-flight" (non-terminal). */
+  private static readonly NON_TERMINAL_STATUSES: EvidenceStatus[] = [
+    EvidenceStatus.pending,
+    EvidenceStatus.uploading,
+  ];
+
+  /** All statuses whose depth we want to expose. */
+  private static readonly ALL_STATUSES: EvidenceStatus[] = [
+    EvidenceStatus.pending,
+    EvidenceStatus.uploading,
+    EvidenceStatus.completed,
+    EvidenceStatus.failed,
+  ];
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly metrics: MetricsService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async refreshEvidenceQueueMetrics(): Promise<void> {
+    try {
+      await Promise.all([
+        this.refreshQueueDepths(),
+        this.refreshOldestPendingAge(),
+      ]);
+    } catch (err) {
+      this.logger.error(
+        `Failed to refresh evidence queue metrics: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  private async refreshQueueDepths(): Promise<void> {
+    const counts = await this.prisma.evidenceQueueItem.groupBy({
+      by: ['status'],
+      _count: { id: true },
+    });
+
+    // Build a lookup so we can zero-fill missing statuses.
+    const byStatus = new Map<EvidenceStatus, number>(
+      counts.map(row => [row.status, row._count.id]),
+    );
+
+    for (const status of EvidenceQueueMetricsScheduler.ALL_STATUSES) {
+      this.metrics.setEvidenceQueueDepth(status, byStatus.get(status) ?? 0);
+    }
+  }
+
+  private async refreshOldestPendingAge(): Promise<void> {
+    const oldest = await this.prisma.evidenceQueueItem.findFirst({
+      where: {
+        status: { in: EvidenceQueueMetricsScheduler.NON_TERMINAL_STATUSES },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: { createdAt: true },
+    });
+
+    const ageSeconds = oldest
+      ? (Date.now() - oldest.createdAt.getTime()) / 1000
+      : 0;
+
+    this.metrics.setEvidenceQueueOldestPendingAge(ageSeconds);
+  }
+}

--- a/app/backend/src/evidence/evidence.module.ts
+++ b/app/backend/src/evidence/evidence.module.ts
@@ -11,9 +11,11 @@ import { EncryptionModule } from '../common/encryption/encryption.module';
 import { AuditModule } from '../audit/audit.module';
 import { CacheModule } from '../common/cache/cache.module';
 import { FingerprintService } from './fingerprint.service';
+import { MetricsModule } from '../observability/metrics/metrics.module';
+import { EvidenceQueueMetricsScheduler } from './evidence-queue-metrics.scheduler';
 
 @Module({
-  imports: [PrismaModule, EncryptionModule, AuditModule, CacheModule],
+  imports: [PrismaModule, EncryptionModule, AuditModule, CacheModule, MetricsModule],
   controllers: [EvidenceController, UploadSessionController],
   providers: [
     EvidenceService,
@@ -22,6 +24,7 @@ import { FingerprintService } from './fingerprint.service';
     ArtifactTokenGuard,
     UploadSessionService,
     UploadSessionStore,
+    EvidenceQueueMetricsScheduler,
   ],
   exports: [FingerprintService, ArtifactOwnershipTokenService],
 })

--- a/app/backend/src/evidence/evidence.service.ts
+++ b/app/backend/src/evidence/evidence.service.ts
@@ -8,6 +8,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { EncryptionService } from '../common/encryption/encryption.service';
 import { AuditService } from '../audit/audit.service';
 import { FingerprintService } from './fingerprint.service';
+import { MetricsService } from '../observability/metrics/metrics.service';
 import * as fs from 'fs/promises';
 import { existsSync, mkdirSync } from 'fs';
 import * as path from 'path';
@@ -24,6 +25,7 @@ export class EvidenceService {
     private readonly encryptionService: EncryptionService,
     private readonly auditService: AuditService,
     private readonly fingerprintService: FingerprintService,
+    private readonly metricsService: MetricsService,
   ) {
     // Ensure upload directory exists
     if (!existsSync(this.uploadDir)) {
@@ -187,6 +189,13 @@ export class EvidenceService {
         data: { status: EvidenceStatus.completed },
       });
 
+      // Record intake-to-decision duration (issue #954)
+      const durationSeconds = (Date.now() - item.createdAt.getTime()) / 1000;
+      this.metricsService.recordEvidenceIntakeToDecision(
+        'completed',
+        durationSeconds,
+      );
+
       this.logger.log(`Upload completed for ${item.id}`);
     } catch (err) {
       this.logger.error(
@@ -201,6 +210,13 @@ export class EvidenceService {
           lastError: (err as Error).message,
         },
       });
+
+      // Record intake-to-decision duration (issue #954)
+      const durationSeconds = (Date.now() - item.createdAt.getTime()) / 1000;
+      this.metricsService.recordEvidenceIntakeToDecision(
+        'failed',
+        durationSeconds,
+      );
     }
   }
 

--- a/app/backend/src/observability/metrics/evidence-queue-metrics.spec.ts
+++ b/app/backend/src/observability/metrics/evidence-queue-metrics.spec.ts
@@ -1,0 +1,193 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import { Gauge, Histogram } from 'prom-client';
+import { MetricsService } from './metrics.service';
+
+/**
+ * All metric names injected into MetricsService via @InjectMetric.
+ * Must stay in sync with the constructor parameter list.
+ */
+const ALL_METRIC_NAMES = [
+  'http_requests_total',
+  'http_request_duration_seconds',
+  'jobs_processed_total',
+  'jobs_failed_total',
+  'active_connections',
+  'db_query_duration_seconds',
+  'onchain_operations_total',
+  'onchain_operation_duration_seconds',
+  'contract_call_latency_seconds',
+  'tx_submission_failures_total',
+  'ingestion_lag_seconds',
+  'webhook_retries_total',
+  'webhook_delivery_duration_seconds',
+  'callback_failures_total',
+  'notification_delivery_attempts_total',
+  'notification_delivery_failures_by_category_total',
+  'error_rate_total',
+  'analytics_cache_hits_total',
+  'analytics_cache_misses_total',
+  'analytics_cache_invalidations_total',
+  'cache_hits_total',
+  'cache_misses_total',
+  'cache_invalidations_total',
+  'cache_keys_total',
+  'verification_jobs_enqueued_total',
+  'verification_queue_waiting_by_priority',
+  'claims_created_total',
+  'claims_verified_total',
+  'claims_approved_total',
+  'claims_disbursed_total',
+  'claims_cancelled_total',
+  'claims_in_funnel',
+  'claim_funnel_duration_seconds',
+  'api_key_rate_limit_rejections_total',
+  'evidence_queue_depth',
+  'evidence_queue_oldest_pending_age_seconds',
+  'evidence_queue_intake_to_decision_seconds',
+];
+
+const stubMetric = () => ({
+  inc: jest.fn(),
+  dec: jest.fn(),
+  set: jest.fn(),
+  observe: jest.fn(),
+});
+
+describe('MetricsService – evidence queue SLA metrics (issue #954)', () => {
+  let service: MetricsService;
+  let depthGauge: Gauge<string>;
+  let oldestAgeGauge: Gauge<string>;
+  let intakeHistogram: Histogram<string>;
+
+  beforeEach(async () => {
+    // Real prom-client instances isolated from the global registry.
+    depthGauge = new Gauge({
+      name: 'evidence_queue_depth',
+      help: 'test',
+      labelNames: ['status'],
+      registers: [],
+    });
+    oldestAgeGauge = new Gauge({
+      name: 'evidence_queue_oldest_pending_age_seconds',
+      help: 'test',
+      labelNames: [],
+      registers: [],
+    });
+    intakeHistogram = new Histogram({
+      name: 'evidence_queue_intake_to_decision_seconds',
+      help: 'test',
+      labelNames: ['decision'],
+      buckets: [60, 300, 900, 1800, 3600, 7200, 86400],
+      registers: [],
+    });
+
+    const providers = ALL_METRIC_NAMES.map(name => {
+      if (name === 'evidence_queue_depth')
+        return { provide: getToken(name), useValue: depthGauge };
+      if (name === 'evidence_queue_oldest_pending_age_seconds')
+        return { provide: getToken(name), useValue: oldestAgeGauge };
+      if (name === 'evidence_queue_intake_to_decision_seconds')
+        return { provide: getToken(name), useValue: intakeHistogram };
+      return { provide: getToken(name), useValue: stubMetric() };
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MetricsService, ...providers],
+    }).compile();
+
+    service = module.get<MetricsService>(MetricsService);
+  });
+
+  // ─── setEvidenceQueueDepth ────────────────────────────────────────────────
+
+  it('sets queue depth gauge for each status', async () => {
+    service.setEvidenceQueueDepth('pending', 5);
+    service.setEvidenceQueueDepth('uploading', 2);
+    service.setEvidenceQueueDepth('completed', 10);
+    service.setEvidenceQueueDepth('failed', 1);
+
+    const data = await depthGauge.get();
+    const byStatus = (status: string) =>
+      data.values.find(v => v.labels.status === status)?.value;
+
+    expect(byStatus('pending')).toBe(5);
+    expect(byStatus('uploading')).toBe(2);
+    expect(byStatus('completed')).toBe(10);
+    expect(byStatus('failed')).toBe(1);
+  });
+
+  it('updates queue depth gauge to the latest value', async () => {
+    service.setEvidenceQueueDepth('pending', 3);
+    service.setEvidenceQueueDepth('pending', 7);
+
+    const data = await depthGauge.get();
+    const value = data.values.find(v => v.labels.status === 'pending')?.value;
+    expect(value).toBe(7);
+  });
+
+  // ─── setEvidenceQueueOldestPendingAge ─────────────────────────────────────
+
+  it('sets the oldest-pending-age gauge', async () => {
+    service.setEvidenceQueueOldestPendingAge(120);
+
+    const data = await oldestAgeGauge.get();
+    expect(data.values[0]?.value).toBe(120);
+  });
+
+  it('sets oldest-pending-age to 0 when queue is empty', async () => {
+    service.setEvidenceQueueOldestPendingAge(0);
+
+    const data = await oldestAgeGauge.get();
+    expect(data.values[0]?.value).toBe(0);
+  });
+
+  // ─── recordEvidenceIntakeToDecision ───────────────────────────────────────
+
+  it('records completed decision in histogram', async () => {
+    service.recordEvidenceIntakeToDecision('completed', 300);
+
+    const data = await intakeHistogram.get();
+    const completedSamples = data.values.filter(
+      v => v.labels.decision === 'completed',
+    );
+    // At least one bucket should have been incremented
+    const hasObservation = completedSamples.some(v => v.value > 0);
+    expect(hasObservation).toBe(true);
+  });
+
+  it('records failed decision in histogram', async () => {
+    service.recordEvidenceIntakeToDecision('failed', 600);
+
+    const data = await intakeHistogram.get();
+    const failedSamples = data.values.filter(
+      v => v.labels.decision === 'failed',
+    );
+    const hasObservation = failedSamples.some(v => v.value > 0);
+    expect(hasObservation).toBe(true);
+  });
+
+  it('keeps completed and failed observations independent', async () => {
+    service.recordEvidenceIntakeToDecision('completed', 100);
+    service.recordEvidenceIntakeToDecision('completed', 200);
+    service.recordEvidenceIntakeToDecision('failed', 500);
+
+    const data = await intakeHistogram.get();
+
+    // _count for completed should be 2
+    const completedCount = data.values.find(
+      v =>
+        v.labels.decision === 'completed' &&
+        v.metricName === 'evidence_queue_intake_to_decision_seconds_count',
+    );
+    // _count for failed should be 1
+    const failedCount = data.values.find(
+      v =>
+        v.labels.decision === 'failed' &&
+        v.metricName === 'evidence_queue_intake_to_decision_seconds_count',
+    );
+
+    expect(completedCount?.value).toBe(2);
+    expect(failedCount?.value).toBe(1);
+  });
+});

--- a/app/backend/src/observability/metrics/metrics.providers.ts
+++ b/app/backend/src/observability/metrics/metrics.providers.ts
@@ -219,4 +219,22 @@ export const metricsProviders = [
     help: 'Total number of per-API-key rate limit rejections',
     labelNames: ['scope', 'api_key_id'],
   }),
+
+  // Evidence Queue SLA Metrics (issue #954)
+  makeGaugeProvider({
+    name: 'evidence_queue_depth',
+    help: 'Current number of evidence queue items per status',
+    labelNames: ['status'],
+  }),
+  makeGaugeProvider({
+    name: 'evidence_queue_oldest_pending_age_seconds',
+    help: 'Age in seconds of the oldest evidence queue item in a non-terminal status',
+    labelNames: [],
+  }),
+  makeHistogramProvider({
+    name: 'evidence_queue_intake_to_decision_seconds',
+    help: 'Time in seconds from evidence intake (createdAt) to terminal status (completed or failed)',
+    labelNames: ['decision'],
+    buckets: [60, 300, 900, 1800, 3600, 7200, 86400],
+  }),
 ];

--- a/app/backend/src/observability/metrics/metrics.service.spec.ts
+++ b/app/backend/src/observability/metrics/metrics.service.spec.ts
@@ -42,6 +42,9 @@ const ALL_METRIC_NAMES = [
   'claims_in_funnel',
   'claim_funnel_duration_seconds',
   'api_key_rate_limit_rejections_total',
+  'evidence_queue_depth',
+  'evidence_queue_oldest_pending_age_seconds',
+  'evidence_queue_intake_to_decision_seconds',
 ];
 
 const stubMetric = () => ({

--- a/app/backend/src/observability/metrics/metrics.service.ts
+++ b/app/backend/src/observability/metrics/metrics.service.ts
@@ -89,6 +89,14 @@ export class MetricsService {
     // API Key Rate Limit Metrics (issue #952)
     @InjectMetric('api_key_rate_limit_rejections_total')
     public apiKeyRateLimitRejectionsCounter: Counter<string>,
+
+    // Evidence Queue SLA Metrics (issue #954)
+    @InjectMetric('evidence_queue_depth')
+    public evidenceQueueDepthGauge: Gauge<string>,
+    @InjectMetric('evidence_queue_oldest_pending_age_seconds')
+    public evidenceQueueOldestPendingAgeGauge: Gauge<string>,
+    @InjectMetric('evidence_queue_intake_to_decision_seconds')
+    public evidenceQueueIntakeToDecisionHistogram: Histogram<string>,
   ) {}
 
   /**
@@ -550,5 +558,39 @@ export class MetricsService {
    */
   incrementApiKeyRateLimitRejection(scope: string, apiKeyId: string): void {
     this.apiKeyRateLimitRejectionsCounter.inc({ scope, api_key_id: apiKeyId });
+  }
+
+  // ─── Evidence Queue SLA Metrics (issue #954) ────────────────────────────────
+
+  /**
+   * Set the current depth of the evidence queue for a given status.
+   * Call periodically for all statuses to keep the gauge accurate.
+   */
+  setEvidenceQueueDepth(status: string, count: number): void {
+    this.evidenceQueueDepthGauge.set({ status }, count);
+  }
+
+  /**
+   * Set the age (in seconds) of the oldest evidence queue item that is
+   * still in a non-terminal status (pending or uploading).
+   * Pass 0 when there are no active items.
+   */
+  setEvidenceQueueOldestPendingAge(ageSeconds: number): void {
+    this.evidenceQueueOldestPendingAgeGauge.set(ageSeconds);
+  }
+
+  /**
+   * Record the elapsed time (in seconds) from evidence intake to a terminal
+   * decision (completed or failed).  Call once per item when it transitions
+   * to a terminal status.
+   */
+  recordEvidenceIntakeToDecision(
+    decision: 'completed' | 'failed',
+    durationSeconds: number,
+  ): void {
+    this.evidenceQueueIntakeToDecisionHistogram.observe(
+      { decision },
+      durationSeconds,
+    );
   }
 }


### PR DESCRIPTION
 closes #954 

PR Description:
  
  ## Summary
  
  Implements issue #954. Adds three Prometheus metrics that expose evidence queue SLA health, giving operators visibility into queue depth, backlog age,
  and intake-to-decision latency.
  
  ## New metrics
  
  | Metric | Type | Labels | Description |
  |--------|------|--------|-------------|
  | `evidence_queue_depth` | Gauge | `status` | Current count of `EvidenceQueueItem` rows per `EvidenceStatus` (`pending`, `uploading`, `completed`,
  `failed`). Refreshed every 30 s. |
  | `evidence_queue_oldest_pending_age_seconds` | Gauge | — | Age in seconds of the oldest item in a non-terminal status (`pending` or `uploading`).
  Reports `0` when the active queue is empty. Refreshed every 30 s. |
  | `evidence_queue_intake_to_decision_seconds` | Histogram | `decision` (`completed`\|`failed`) | Elapsed time from `createdAt` to terminal status.
  Observed inline when `EvidenceService.processUpload()` transitions an item. SLA buckets: 60 s, 5 min, 15 min, 30 min, 1 h, 2 h, 24 h. |
  
  Label cardinality is bounded — only static enum-based labels are used.
  
  ## Changes
  
  - `metrics.providers.ts` — registers the three new prom-client providers
  - `metrics.service.ts` — injects them and exposes `setEvidenceQueueDepth`, `setEvidenceQueueOldestPendingAge`, `recordEvidenceIntakeToDecision` helpers
  - `evidence-queue-metrics.scheduler.ts` — new `@Cron(EVERY_30_SECONDS)` service that groups-by status in DB and refreshes both gauges; errors are caught
  and logged without crashing the scheduler
  - `evidence.service.ts` — injects `MetricsService` and calls `recordEvidenceIntakeToDecision` on both `completed` and `failed` terminal transitions in
  `processUpload()`
  - `evidence.module.ts` — imports `MetricsModule`, registers `EvidenceQueueMetricsScheduler`
  - `README.md` — documents the three metrics under the "Evidence Queue SLA metrics" subsection of Monitoring and Observability
  
  ## Tests
  
  - `evidence-queue-metrics.spec.ts` — 7 unit tests covering all three `MetricsService` helpers using isolated prom-client instances (no global registry);
  **all pass**
  - `evidence-queue-metrics.scheduler.spec.ts` — scheduler polling logic tests; currently blocked by missing Prisma client generation (pre-existing
  environment issue affecting all Prisma-dependent tests in the repo — `prisma generate` must run before this test can execute)
  - `metrics.service.spec.ts` — updated `ALL_METRIC_NAMES` list to include the three new metrics so existing cache metric tests continue to pass
  
  ## Testing instructions
  
  ```bash
  cd app/backend
  pnpm install --ignore-workspace --ignore-scripts
  npx prisma generate
  node_modules/.bin/jest --testPathPatterns="evidence-queue-metrics|metrics.service.spec" --no-coverage
  
